### PR TITLE
Add postinstall-build to enable git:// install

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,5 +1,3 @@
-lib/
 .npmignore
-.babelrc
 .travis.yml
 appveyor.yml

--- a/package.json
+++ b/package.json
@@ -8,11 +8,13 @@
   "scripts": {
     "clean": "rm -rf build",
     "compile": "babel lib --out-dir build/lib && babel test --out-dir build/test",
+    "postinstall": "postinstall-build --only-as-dependency build \"npm run compile\"",
     "prepublish": "npm run clean && npm run compile",
     "test": "npm run compile && atom --test build/test",
     "watch": "npm run compile -- -w"
   },
   "dependencies": {
+    "postinstall-build": "^3.0.0",
     "vscode-jsonrpc": "^3.2.0"
   },
   "atomTestRunner": "./test/runner",


### PR DESCRIPTION
Also this means that the original source can't be `.npmignore`d.
(This should be reverted once this is actually published).

Closes #16.

Taken from: https://github.com/npm/npm/issues/3055

Released under CC0.