### PR TITLE
Highlight the word-at-buffer-position for hyperclick/definitions

### DIFF
--- a/flow-libs/atom.js.flow
+++ b/flow-libs/atom.js.flow
@@ -900,6 +900,7 @@ declare class atom$TextEditor extends atom$Model {
   tokenForBufferPosition(position: atom$Point | [?number, ?number]): atom$Token,
   onDidConflict(callback: () => void): IDisposable,
   serialize: () => mixed,
+  getNonWordCharacters: (scopes: atom$ScopeDescriptor) => string,
 }
 
 /**

--- a/lib/adapters/nuclide-definition-adapter.js
+++ b/lib/adapters/nuclide-definition-adapter.js
@@ -3,29 +3,43 @@
 import {LanguageClientConnection, type DocumentHighlight,
   type Location, type ServerCapabilities} from '../languageclient';
 import Convert from '../convert';
+import Utils from '../utils';
 import {Range} from 'atom';
 
 export default class NuclideDefinitionAdapter {
   _languageName: string;
 
   static canAdapt(serverCapabilities: ServerCapabilities): boolean {
-    return serverCapabilities.documentHighlightProvider === true && serverCapabilities.definitionProvider === true;
+    return serverCapabilities.definitionProvider === true;
   }
 
   constructor(languageName: string) {
     this._languageName = languageName;
   }
 
-  async getDefinition(connection: LanguageClientConnection, editor: TextEditor, point: atom$Point): Promise<?nuclide$DefinitionQueryResult> {
+  async getDefinition(
+    connection: LanguageClientConnection,
+    serverCapabilities: ServerCapabilities,
+    editor: TextEditor,
+    point: atom$Point,
+  ): Promise<?nuclide$DefinitionQueryResult> {
     const documentPositionParams = Convert.editorToTextDocumentPositionParams(editor, point);
 
-    const highlights = await connection.documentHighlight(documentPositionParams);
-    if (highlights == null || highlights.length === 0) { return null; }
+    let highlights;
+    // Underline all highlights if they're available.
+    // Otherwise, just fall back to highlighting the word at the given position.
+    // (Note that VSCode only ever highlights the word).
+    if (serverCapabilities.documentHighlightProvider) {
+      highlights = await connection.documentHighlight(documentPositionParams);
+    }
+    const ranges = (highlights == null || highlights.length === 0)
+      ? [Utils.getWordAtPosition(editor, point)]
+      : highlights.map(h => Range.fromObject(Convert.lsRangeToAtomRange(h.range)));
 
     const definitions = NuclideDefinitionAdapter.normalizeLocations(await connection.gotoDefinition(documentPositionParams));
     if (definitions == null || definitions.length === 0) { return null; }
 
-    return NuclideDefinitionAdapter.highlightsAndDefinitionsToQueryResult(highlights, definitions, this._languageName);
+    return NuclideDefinitionAdapter.definitionsToQueryResult(ranges, definitions, this._languageName);
   }
 
   static normalizeLocations(locationResult: Location | Array<Location>): ?Array<Location> {
@@ -33,9 +47,13 @@ export default class NuclideDefinitionAdapter {
     return (Array.isArray(locationResult) ? locationResult : [locationResult]).filter(d => d.range.start != null);
   }
 
-  static highlightsAndDefinitionsToQueryResult(highlights: Array<DocumentHighlight>, definitions: Array<Location>, languageName: string): nuclide$DefinitionQueryResult {
+  static definitionsToQueryResult(
+    ranges: Array<atom$Range>,
+    definitions: Array<Location>,
+    languageName: string,
+  ): nuclide$DefinitionQueryResult {
     return {
-      queryRange: highlights.map(h => Range.fromObject(Convert.lsRangeToAtomRange(h.range))),
+      queryRange: ranges,
       definitions: definitions.map(d => ({
         path: Convert.uriToPath(d.uri),
         position: Convert.positionToPoint(d.range.start),

--- a/lib/adapters/nuclide-hyperclick-adapter.js
+++ b/lib/adapters/nuclide-hyperclick-adapter.js
@@ -1,21 +1,33 @@
 // @flow
 
+import {Range} from 'atom';
 import {LanguageClientConnection, type ServerCapabilities} from '../languageclient';
 import Convert from '../convert';
+import Utils from '../utils';
 
 export default class NuclideHyperclickAdapter {
   static canAdapt(serverCapabilities: ServerCapabilities): boolean {
-    return serverCapabilities.documentHighlightProvider === true && serverCapabilities.definitionProvider === true;
+    return serverCapabilities.definitionProvider === true;
   }
 
-  async getSuggestion(connection: LanguageClientConnection, editor: atom$TextEditor, point: atom$Point): Promise<?nuclide$HyperclickSuggestion> {
+  async getSuggestion(
+    connection: LanguageClientConnection,
+    serverCapabilities: ServerCapabilities,
+    editor: atom$TextEditor,
+    point: atom$Point,
+  ): Promise<?nuclide$HyperclickSuggestion> {
     const documentPositionParams = {
       textDocument: Convert.editorToTextDocumentIdentifier(editor),
       position: Convert.pointToPosition(point),
     };
 
-    const highlights = await connection.documentHighlight(documentPositionParams);
-    if (highlights == null || highlights.length === 0) { return null; }
+    let highlights;
+    if (serverCapabilities.documentHighlightProvider) {
+      highlights = await connection.documentHighlight(documentPositionParams);
+    }
+    const ranges = (highlights == null || highlights.length === 0)
+      ? [Utils.getWordAtPosition(editor, point)]
+      : highlights.map(h => Range.fromObject(Convert.lsRangeToAtomRange(h.range)));
 
     const definition = await connection.gotoDefinition(documentPositionParams);
     if (definition == null || definition.length === 0) { return null; }
@@ -23,7 +35,7 @@ export default class NuclideHyperclickAdapter {
     const definitions = Array.isArray(definition) ? definition : [definition];
 
     return {
-      range: highlights.map(h => Convert.lsRangeToAtomRange(h.range)),
+      range: ranges,
       callback: () => {
         NuclideHyperclickAdapter.goToLocationInFile(Convert.uriToPath(definitions[0].uri), Convert.positionToPoint(definitions[0].range.start));
       },

--- a/lib/auto-languageclient.js
+++ b/lib/auto-languageclient.js
@@ -187,7 +187,7 @@ export default class AutoLanguageClient {
     if (server == null || !NuclideDefinitionAdapter.canAdapt(server.capabilities)) { return null; }
 
     this.definitions = this.definitions || new NuclideDefinitionAdapter(this.getLanguageName());
-    return this.definitions.getDefinition(server.connection, editor, point);
+    return this.definitions.getDefinition(server.connection, server.capabilities, editor, point);
   }
 
   getDefinitionById(filename: NuclideUri, id: string): Promise<?nuclide$Definition> {
@@ -259,6 +259,6 @@ export default class AutoLanguageClient {
     if (server == null || !NuclideHyperclickAdapter.canAdapt(server.capabilities)) { return null; }
 
     this.hyperclick = this.hyperclick || new NuclideHyperclickAdapter();
-    return this.hyperclick.getSuggestion(server.connection, editor, point);
+    return this.hyperclick.getSuggestion(server.connection, server.capabilities, editor, point);
   }
 }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,0 +1,58 @@
+// @flow
+
+import {Range} from 'atom';
+
+export default class Utils {
+  /**
+   * Obtain the range of the word at the given editor position.
+   * Uses the non-word characters from the position's grammar scope.
+   */
+  static getWordAtPosition(editor: TextEditor, position: atom$Point): Range {
+    const scopeDescriptor = editor.scopeDescriptorForBufferPosition(position);
+    const nonWordCharacters = Utils.escapeRegExp(
+      editor.getNonWordCharacters(scopeDescriptor),
+    );
+    const range = Utils._getRegexpRangeAtPosition(
+      editor.getBuffer(),
+      position,
+      new RegExp(`^[\t ]*$|[^\\s${nonWordCharacters}]+`, 'g'),
+    );
+    if (range == null) {
+      return new Range(position, position);
+    }
+    return range;
+  }
+
+  static escapeRegExp(string: string): string {
+    // From atom/underscore-plus.
+    return string.replace(/[-/\\^$*+?.()|[\]{}]/g, '\\$&');
+  }
+
+  static _getRegexpRangeAtPosition(
+    buffer: atom$TextBuffer,
+    position: atom$Point,
+    wordRegex: RegExp,
+  ): ?Range {
+    const {row, column} = position;
+    const rowRange = buffer.rangeForRow(row);
+    let matchData;
+    // Extract the expression from the row text.
+    buffer.scanInRange(wordRegex, rowRange, data => {
+      const {range} = data;
+      if (
+        position.isGreaterThanOrEqual(range.start) &&
+        // Range endpoints are exclusive.
+        position.isLessThan(range.end)
+      ) {
+        matchData = data;
+        data.stop();
+        return;
+      }
+      // Stop the scan if the scanner has passed our position.
+      if (range.end.column > column) {
+        data.stop();
+      }
+    });
+    return matchData == null ? null : matchData.range;
+  }
+}

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -1,0 +1,36 @@
+// @flow
+
+import Utils from '../lib/utils';
+import {createFakeEditor} from './helpers';
+
+import {Point} from 'atom';
+import {expect} from 'chai';
+
+describe('Utils', () => {
+  describe('getWordAtPosition', () => {
+    let editor;
+    beforeEach(() => {
+      editor = createFakeEditor('test.txt');
+      editor.setText('blah test1234 test-two');
+    });
+
+    it('gets the word at position from a text editor', () => {
+      // "blah"
+      let range = Utils.getWordAtPosition(editor, new Point(0, 0));
+      expect(range.serialize()).eql([[0, 0], [0, 4]]);
+
+      // "test1234"
+      range = Utils.getWordAtPosition(editor, new Point(0, 7));
+      expect(range.serialize()).eql([[0, 5], [0, 13]]);
+
+      // "test"
+      range = Utils.getWordAtPosition(editor, new Point(0, 14));
+      expect(range.serialize()).eql([[0, 14], [0, 18]]);
+    });
+
+    it('returns empty ranges for non-words', () => {
+      const range = Utils.getWordAtPosition(editor, new Point(0, 4));
+      expect(range.serialize()).eql([[0, 4], [0, 4]]);
+    });
+  });
+});


### PR DESCRIPTION
Both Nuclide and VSCode use the word-at-buffer-position when cmd-clicking rather than using the `documentHighlight` LSP messages. This makes the Atom language client fall back to using the word when the `documentHighlight` capability isn't available.

The "_getRegexpRangeAtPosition" code is roughly borrowed from https://github.com/facebook/nuclide/blob/master/pkg/commons-node/range.js#L21.

See: https://github.com/Microsoft/vscode/blob/ff9f7b3baa6052863b55e8b6ef7c7c94d07beddf/src/vs/editor/contrib/goToDeclaration/browser/goToDeclaration.ts#L437

Closes #28. Contributed under CC0.