### PR TITLE
Ensure disposables are cleaned up on server shutdown

### DIFF
--- a/lib/server-manager.js
+++ b/lib/server-manager.js
@@ -107,11 +107,14 @@ export class ServerManager {
 
   async stopServer(server: ActiveServer): Promise<void> {
     this._logger.debug(`Server stopping "${server.projectPath}"`);
+    // Immediately remove the server to prevent further usage.
+    // If we re-open the file after this point, we'll get a new server.
+    const serverIndex = this._activeServers.indexOf(server);
+    this._activeServers.splice(serverIndex, 1);
+    server.disposable.dispose();
     await server.connection.shutdown();
     server.process.kill();
     this._logger.debug(`Server stopped "${server.projectPath}"`);
-    const serverIndex = this._activeServers.indexOf(server);
-    this._activeServers.splice(serverIndex, 1);
   }
 
   determineProjectPath(textEditor: atom$TextEditor): ?string {


### PR DESCRIPTION
This also fix a potential race condition that can occur if a file is closed and then re-opened. Since shutdown is asynchronous, re-opening a file before shutdown is complete can potentially cause it to  use a connection that's in the middle of shutting down!

Released under CC0.