### PR TITLE
Integrate document/hover with the Nuclide Datatip UI

### DIFF
--- a/flow-libs/nuclide-providers.js.flow
+++ b/flow-libs/nuclide-providers.js.flow
@@ -120,3 +120,40 @@ export type nuclide$FindReferencesError = {
 };
 
 export type nuclide$FindReferencesReturn = nuclide$FindReferencesData | nuclide$FindReferencesError;
+
+export type nuclide$MarkedString =
+  | {
+      type: 'markdown',
+      value: string,
+    }
+  | {
+      type: 'snippet',
+      grammar: atom$Grammar,
+      value: string,
+    };
+
+// This omits the React variant.
+export type nuclide$Datatip = {|
+  markedStrings: Array<nuclide$MarkedString>,
+  range: atom$Range,
+  pinnable?: boolean,
+|};
+
+export type nuclide$DatatipProvider = {
+  datatip(
+    editor: atom$TextEditor,
+    bufferPosition: atom$Point,
+    // The mouse event that triggered the datatip.
+    // This is null for manually toggled datatips.
+    mouseEvent: ?MouseEvent,
+  ): Promise<?Datatip>,
+  inclusionPriority: number,
+  validForScope(scopeName: string): boolean,
+  // A unique name for the provider to be used for analytics.
+  // It is recommended that it be the name of the provider's package.
+  providerName: string,
+};
+
+export type nuclide$DatatipService = {
+  addProvider(provider: nuclide$DatatipProvider): IDisposable,
+};

--- a/lib/adapters/nuclide-datatip-adapter.js
+++ b/lib/adapters/nuclide-datatip-adapter.js
@@ -1,0 +1,65 @@
+// @flow
+
+import {
+  LanguageClientConnection,
+  type MarkedString,
+  type ServerCapabilities,
+} from '../languageclient';
+import Convert from '../convert';
+import Utils from '../utils';
+
+export default class NuclideDatatipAdapter {
+  static canAdapt(serverCapabilities: ServerCapabilities): boolean {
+    return serverCapabilities.hoverProvider === true;
+  }
+
+  async getDatatip(
+    connection: LanguageClientConnection,
+    editor: atom$TextEditor,
+    point: atom$Point,
+  ): Promise<?nuclide$Datatip> {
+    const documentPositionParams = Convert.editorToTextDocumentPositionParams(
+      editor,
+      point,
+    );
+
+    const hover = await connection.hover(documentPositionParams);
+    if (
+      hover == null ||
+      hover.contents == null ||
+      // This intentionally covers both empty strings and empty arrays.
+      hover.contents.length === 0
+    ) {
+      return null;
+    }
+
+    const range = hover.range == null
+      ? Utils.getWordAtPosition(editor, point)
+      : Convert.lsRangeToAtomRange(hover.range);
+
+    const markedStrings = (Array.isArray(hover.contents)
+      ? hover.contents
+      : [hover.contents]).map(str =>
+      NuclideDatatipAdapter.convertMarkedString(editor, str),
+    );
+
+    return {range, markedStrings};
+  }
+
+  static convertMarkedString(
+    editor: atom$TextEditor,
+    markedString: MarkedString,
+  ): nuclide$MarkedString {
+    if (typeof markedString === 'object') {
+      return {
+        type: 'snippet',
+        // TODO: find a better mapping from language -> grammar
+        grammar: atom.grammars.grammarForScopeName(
+          `source.${markedString.language}`,
+        ) || editor.getGrammar(),
+        value: markedString.value,
+      };
+    }
+    return {type: 'markdown', value: markedString};
+  }
+}

--- a/lib/auto-languageclient.js
+++ b/lib/auto-languageclient.js
@@ -12,6 +12,7 @@ import DocumentSyncAdapter from './adapters/document-sync-adapter';
 import FormatCodeAdapter from './adapters/format-code-adapter';
 import LinterAdapter from './adapters/linter-adapter';
 import NotificationsAdapter from './adapters/notifications-adapter';
+import NuclideDatatipAdapter from './adapters/nuclide-datatip-adapter';
 import NuclideDefinitionAdapter from './adapters/nuclide-definition-adapter';
 import NuclideFindReferencesAdapter from './adapters/nuclide-find-references-adapter';
 import NuclideHyperclickAdapter from './adapters/nuclide-hyperclick-adapter';
@@ -27,6 +28,7 @@ export default class AutoLanguageClient {
 
   // Shared adapters that can take the RPC connection as required
   autoComplete: ?AutocompleteAdapter;
+  datatip: ?NuclideDatatipAdapter;
   definitions: ?NuclideDefinitionAdapter;
   findReferences: ?NuclideFindReferencesAdapter;
   hyperclick: ?NuclideHyperclickAdapter;
@@ -260,5 +262,25 @@ export default class AutoLanguageClient {
 
     this.hyperclick = this.hyperclick || new NuclideHyperclickAdapter();
     return this.hyperclick.getSuggestion(server.connection, server.capabilities, editor, point);
+  }
+
+  // Nuclide Datatip via LS textDocument/hover----------------------------------
+  consumeDatatip(service: nuclide$DatatipService): void {
+    this._disposable.add(service.addProvider({
+      providerName: this.name,
+      inclusionPriority: 1,
+      validForScope: (scopeName: string) => {
+        return this.getGrammarScopes().includes(scopeName);
+      },
+      datatip: this.getDatatip.bind(this),
+    }));
+  }
+
+  async getDatatip(editor: atom$TextEditor, point: atom$Point): Promise<?nuclide$Datatip> {
+    const server = await this._serverManager.getServer(editor);
+    if (server == null || !NuclideDatatipAdapter.canAdapt(server.capabilities)) { return null; }
+
+    this.datatip = this.datatip || new NuclideDatatipAdapter();
+    return this.datatip.getDatatip(server.connection, editor, point);
   }
 }

--- a/test/adapters/nuclide-datatip-adapter.test.js
+++ b/test/adapters/nuclide-datatip-adapter.test.js
@@ -1,0 +1,58 @@
+// @flow
+
+import invariant from 'assert';
+import {Point} from 'atom';
+import {expect} from 'chai';
+import sinon from 'sinon';
+import * as ls from '../../lib/languageclient';
+import NuclideDatatipAdapter from '../../lib/adapters/nuclide-datatip-adapter';
+import {createSpyConnection, createFakeEditor} from '../helpers.js';
+
+describe('NuclideDatatipAdapter', () => {
+  let fakeEditor;
+  let connection;
+
+  beforeEach(() => {
+    connection = new ls.LanguageClientConnection(createSpyConnection());
+    fakeEditor = createFakeEditor();
+  });
+
+  describe('getDatatip', () => {
+    it('calls LSP document/hover at the given position', async () => {
+      sinon.stub(connection, 'hover').resolves({
+        range: {
+          start: {line: 0, character: 1},
+          end: {line: 0, character: 2},
+        },
+        contents: ['test', {language: 'testlang', value: 'test snippet'}],
+      });
+
+      const grammarSpy = sinon.spy(atom.grammars, 'grammarForScopeName');
+
+      const datatipAdapter = new NuclideDatatipAdapter();
+      const datatip = await datatipAdapter.getDatatip(
+        connection,
+        fakeEditor,
+        new Point(0, 0),
+      );
+      expect(datatip).to.be.ok;
+      invariant(datatip != null);
+
+      expect(datatip.range.start.row).equal(0);
+      expect(datatip.range.start.column).equal(1);
+      expect(datatip.range.end.row).equal(0);
+      expect(datatip.range.end.column).equal(2);
+
+      expect(datatip.markedStrings).to.have.lengthOf(2);
+      expect(datatip.markedStrings[0]).eql({type: 'markdown', value: 'test'});
+
+      const snippet = datatip.markedStrings[1];
+      expect(snippet.type).equal('snippet');
+      invariant(snippet.type === 'snippet');
+      expect(snippet.grammar.scopeName).equal('text.plain.null-grammar');
+      expect(snippet.value).equal('test snippet');
+
+      expect(grammarSpy.calledWith('source.testlang')).to.be.true;
+    });
+  });
+});


### PR DESCRIPTION
This displays `document/hover` results by integrating with the Nuclide Datatip UI.
Note that this is stacked with #30 since this also uses the `wordAtPosition` utility - please take a look at that one first! :)

Screenshot using `flow-language-server`: (double scrollbar is caused by my having a plugged-in mouse; it's a bug we should fix)

![screen shot 2017-05-03 at 1 20 31 pm](https://cloud.githubusercontent.com/assets/577378/25679885/c921f8b4-3003-11e7-8e9d-297f782a7f83.png)

Closes #8.

Released under CC0.