### PR TITLE
Add rootUri to InitializeParams

### DIFF
--- a/lib/auto-languageclient.js
+++ b/lib/auto-languageclient.js
@@ -77,6 +77,7 @@ export default class AutoLanguageClient {
       processId: process.pid,
       capabilities: { },
       rootPath: projectPath,
+      rootUri: `file://${projectPath}`,
     };
   }
 

--- a/lib/languageclient.js
+++ b/lib/languageclient.js
@@ -308,6 +308,9 @@ export type InitializeParams = {
   processId?: ?number,
   //  The rootPath of the workspace. Is null if no folder is open.
   rootPath?: ?string,
+  // The rootUri of the workspace. Is null if no folder is open. If both
+  // `rootPath` and `rootUri` are set `rootUri` wins.
+  rootUri?: ?string,
   //  User provided initialization options.
   initializationOptions?: any,
   //  The capabilities provided by the client (editor)


### PR DESCRIPTION
In version 3 of the Language Server Protocol `rootUri` has been added to the `initializeParams`, and `rootPath` has been deprecated.

> add a rootUri property to the initializeParams in favour of the rootPath property.

=> [Microsoft/language-server-protocol](https://github.com/Microsoft/language-server-protocol/blob/master/protocol.md)
