### PR TITLE
Add optional ipc transport

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ module.exports = new OmnisharpLanguageServer()
 
 You can get this code packaged up with the necessary package.json etc. from the [languageserver-csharp](https://github.com/atom/languageserver-csharp) provides C# support via [Omnisharp (node-omnisharp)](https://github.com/OmniSharp/omnisharp-node-client) repo.
 
-If the Language Server is using IPC type transport, you need to implement `useIpc()` and return `true`.
+If the Language Server is using IPC connection type, you need to implement `getConnectionType()` and return `'ipc'`.
 
 ```javascript
 class ExampleLanguageServer extends AutoLanguageClient {
@@ -103,7 +103,7 @@ class ExampleLanguageServer extends AutoLanguageClient {
   getLanguageName () { return 'JavaScript' }
   getServerName () { return 'JavaScript Language Server' }
   
-  useIpc() { return true }
+  getConnectionType() { return 'ipc' }
 
   startServerProcess () {
     const startServer = require.resolve('@example/js-language-server')

--- a/README.md
+++ b/README.md
@@ -95,6 +95,25 @@ module.exports = new OmnisharpLanguageServer()
 
 You can get this code packaged up with the necessary package.json etc. from the [languageserver-csharp](https://github.com/atom/languageserver-csharp) provides C# support via [Omnisharp (node-omnisharp)](https://github.com/OmniSharp/omnisharp-node-client) repo.
 
+If the Language Server is using IPC type transport, you need to implement `useIpc()` and return `true`.
+
+```javascript
+class ExampleLanguageServer extends AutoLanguageClient {
+  getGrammarScopes () { return [ 'source.js' ] }
+  getLanguageName () { return 'JavaScript' }
+  getServerName () { return 'JavaScript Language Server' }
+  
+  useIpc() { return true }
+
+  startServerProcess () {
+    const startServer = require.resolve('@example/js-language-server')
+    return cp.spawn('node', [startServer, '--node-ipc'], {
+      stdio: [null, null, null, 'ipc']
+    })
+  }
+}
+```
+
 Some more elaborate scenarios can be found in the Java LSP package which includes:
 
 * Downloading and unpacking non-npm dependencies (in this case a .tar.gz containing JAR files)

--- a/lib/auto-languageclient.js
+++ b/lib/auto-languageclient.js
@@ -88,6 +88,11 @@ export default class AutoLanguageClient {
   postInitialization(InitializationResult: ls.InitializeResult): void {
   }
 
+  // Determine whether to use ipc or stdio transport
+  useIpc() {
+    return false;
+  }
+
   // Default implementation of the rest of the AutoLanguageClient
   // ---------------------------------------------------------------------------
 
@@ -137,9 +142,17 @@ export default class AutoLanguageClient {
   }
 
   createRpcConnection(process: child_process$ChildProcess): rpc.Connection {
-    const hasSocket = this.socket != null;
-    const reader = hasSocket ? new rpc.SocketMessageReader(this.socket) : new rpc.StreamMessageReader(process.stdout);
-    const writer = hasSocket ? new rpc.SocketMessageWriter(this.socket) : new rpc.StreamMessageWriter(process.stdin);
+    let reader, writer;
+    if (this.useIpc()) {
+      reader = new rpc.IPCMessageReader(process);
+      writer = new rpc.IPCMessageWriter(process);
+    } else if (this.socket !== null) {
+      reader = new rpc.SocketMessageReader(this.socket);
+      writer = new rpc.SocketMessageWriter(this.socket);
+    } else {
+      reader = new rpc.StreamMessageReader(process.stdout);
+      writer = new rpc.StreamMessageWriter(process.stdin);
+    }
     return rpc.createMessageConnection(reader, writer, {error: m => { this.logger.error(m); }});
   }
 

--- a/lib/auto-languageclient.js
+++ b/lib/auto-languageclient.js
@@ -18,6 +18,8 @@ import NuclideFindReferencesAdapter from './adapters/nuclide-find-references-ada
 import NuclideHyperclickAdapter from './adapters/nuclide-hyperclick-adapter';
 import NuclideOutlineViewAdapter from './adapters/nuclide-outline-view-adapter';
 
+type ConnectionType = 'stdio' | 'socket' | 'ipc';
+
 export default class AutoLanguageClient {
   _disposable = new CompositeDisposable();
   _serverManager: ServerManager;
@@ -88,9 +90,10 @@ export default class AutoLanguageClient {
   postInitialization(InitializationResult: ls.InitializeResult): void {
   }
 
-  // Determine whether to use ipc or stdio transport
-  useIpc() {
-    return false;
+  // Determine whether to use ipc, stdio or socket to connect to the server
+  getConnectionType(): ConnectionType {
+    const hasSocket = this.socket != null;
+    return hasSocket ? 'socket' : 'stdio';
   }
 
   // Default implementation of the rest of the AutoLanguageClient
@@ -143,13 +146,15 @@ export default class AutoLanguageClient {
 
   createRpcConnection(process: child_process$ChildProcess): rpc.Connection {
     let reader, writer;
-    if (this.useIpc()) {
+    const connectionType = this.getConnectionType();
+
+    if (connectionType === 'ipc') {
       reader = new rpc.IPCMessageReader(process);
       writer = new rpc.IPCMessageWriter(process);
-    } else if (this.socket !== null) {
+    } else if (connectionType === 'socket') {
       reader = new rpc.SocketMessageReader(this.socket);
       writer = new rpc.SocketMessageWriter(this.socket);
-    } else {
+    } else if (connectionType === 'stdio') {
       reader = new rpc.StreamMessageReader(process.stdout);
       writer = new rpc.StreamMessageWriter(process.stdin);
     }


### PR DESCRIPTION
The [VSCode Language Server - Client](https://github.com/Microsoft/vscode-languageserver-node/tree/master/client) has the option to use [ipc](https://github.com/Microsoft/vscode-languageserver-node/blob/master/client/src/main.ts#L230) besides stdio message transports.

I am currently working on a Atom adaption of the [Ember Language Server](https://github.com/emberwatch/ember-language-server) which is using this.