### PR TITLE
Add nuclide code format support

### DIFF
--- a/flow-libs/nuclide-providers.js.flow
+++ b/flow-libs/nuclide-providers.js.flow
@@ -189,3 +189,10 @@ export interface nuclide$CodeFormatProvider {
   selector: string,
   inclusionPriority: number,
 }
+
+export type nuclide$TextEdit = {
+  oldRange: atom$Range,
+  newText: string,
+  // If included, this will be used to verify that the edit still applies cleanly.
+  oldText?: string,
+};

--- a/flow-libs/nuclide-providers.js.flow
+++ b/flow-libs/nuclide-providers.js.flow
@@ -5,7 +5,7 @@ export type nuclide$OutlineProvider = {
   priority: number,
   grammarScopes: Array<string>,
   updateOnEdit?: boolean,
-  getOutline: (editor: TextEditor) => Promise<?Outline>,
+  getOutline: (editor: atom$TextEditor) => Promise<?Outline>,
 };
 
 export type nuclide$OutlineTree = {
@@ -157,3 +157,35 @@ export type nuclide$DatatipProvider = {
 export type nuclide$DatatipService = {
   addProvider(provider: nuclide$DatatipProvider): IDisposable,
 };
+
+export interface nuclide$CodeFormatProvider {
+  /**
+   * Providers should implement at least one of formatCode / formatEntireFile.
+   * If formatCode exists, it'll be used if the editor selection isn't empty, or
+   * if it's empty but formatEntireFile doesn't exist.
+   */
+
+  /**
+   * Formats the range specified, and returns a list of text edits to apply.
+   * Text edits must be non-overlapping and preferably in reverse-sorted order.
+   */
+  +formatCode?: (
+    editor: atom$TextEditor,
+    range: atom$Range,
+  ) => Promise<Array<TextEdit>>,
+
+  /**
+   * Formats the range specified, but returns the entire file (along with the new cursor position).
+   * Useful for less-flexible providers like clang-format.
+   */
+  +formatEntireFile?: (
+    editor: atom$TextEditor,
+    range: atom$Range,
+  ) => Promise<{
+    newCursor?: number,
+    formatted: string,
+  }>,
+
+  selector: string,
+  inclusionPriority: number,
+}

--- a/lib/adapters/nuclide-code-format-adapter.js
+++ b/lib/adapters/nuclide-code-format-adapter.js
@@ -9,7 +9,7 @@ export default class NuclideCodeFormatAdapter {
     return serverCapabilities.documentRangeFormattingProvider == true || serverCapabilities.documentFormattingProvider == true;
   }
 
-  format(connection: LanguageClientConnection, serverCapabilities: ServerCapabilities, editor: atom$TextEditor, range: atom$Range): Promise<Array<TextEdit>> {
+  format(connection: LanguageClientConnection, serverCapabilities: ServerCapabilities, editor: atom$TextEditor, range: atom$Range): Promise<Array<nuclide$TextEdit>> {
     if (serverCapabilities.documentRangeFormattingProvider) {
       return NuclideCodeFormatAdapter.formatRange(connection, editor, range);
     }
@@ -21,8 +21,9 @@ export default class NuclideCodeFormatAdapter {
     throw new Error('Can not format document, language server does not support it');
   }
 
-  static formatDocument(connection: LanguageClientConnection, editor: atom$TextEditor): Promise<Array<TextEdit>> {
-    return connection.documentFormatting(NuclideCodeFormatAdapter.createDocumentFormattingParams(editor));
+  static async formatDocument(connection: LanguageClientConnection, editor: atom$TextEditor): Promise<Array<nuclide$TextEdit>> {
+    const edits = await connection.documentFormatting(NuclideCodeFormatAdapter.createDocumentFormattingParams(editor));
+    return NuclideCodeFormatAdapter.convertLsTextEditsToNuclide(edits);
   }
 
   static createDocumentFormattingParams(editor: atom$TextEditor): DocumentFormattingParams {
@@ -32,8 +33,9 @@ export default class NuclideCodeFormatAdapter {
     };
   }
 
-  static formatRange(connection: LanguageClientConnection, editor: atom$TextEditor, range: atom$Range): Promise<Array<TextEdit>> {
-    return connection.documentRangeFormatting(NuclideCodeFormatAdapter.createDocumentRangeFormattingParams(editor));
+  static async formatRange(connection: LanguageClientConnection, editor: atom$TextEditor, range: atom$Range): Promise<Array<nuclide$TextEdit>> {
+    const edits = await connection.documentRangeFormatting(NuclideCodeFormatAdapter.createDocumentRangeFormattingParams(editor));
+    return NuclideCodeFormatAdapter.convertLsTextEditsToNuclide(edits);
   }
 
   static createDocumentRangeFormattingParams(editor: atom$TextEditor): DocumentRangeFormattingParams {
@@ -49,5 +51,16 @@ export default class NuclideCodeFormatAdapter {
       tabSize: editor.getTabLength(),
       insertSpaces: editor.getSoftTabs(),
     };
+  }
+
+  static convertLsTextEditsToNuclide(edits: Array<TextEdit>): Array<nuclide$TextEdit> {
+    return edits.map(NuclideCodeFormatAdapter.convertLsTextEditToNuclide).reverse();
+  }
+
+  static convertLsTextEditToNuclide(textEdit: TextEdit): nuclide$TextEdit {
+    return {
+      oldRange: Convert.lsRangeToAtomRange(textEdit.range),
+      newText: textEdit.newText
+    }
   }
 }

--- a/lib/adapters/nuclide-code-format-adapter.js
+++ b/lib/adapters/nuclide-code-format-adapter.js
@@ -34,14 +34,14 @@ export default class NuclideCodeFormatAdapter {
   }
 
   static async formatRange(connection: LanguageClientConnection, editor: atom$TextEditor, range: atom$Range): Promise<Array<nuclide$TextEdit>> {
-    const edits = await connection.documentRangeFormatting(NuclideCodeFormatAdapter.createDocumentRangeFormattingParams(editor));
+    const edits = await connection.documentRangeFormatting(NuclideCodeFormatAdapter.createDocumentRangeFormattingParams(editor, range));
     return NuclideCodeFormatAdapter.convertLsTextEditsToNuclide(edits);
   }
 
-  static createDocumentRangeFormattingParams(editor: atom$TextEditor): DocumentRangeFormattingParams {
+  static createDocumentRangeFormattingParams(editor: atom$TextEditor, range: atom$Range): DocumentRangeFormattingParams {
     return {
       textDocument: Convert.editorToTextDocumentIdentifier(editor),
-      range: Convert.atomRangeToLSRange(editor.getSelectedBufferRange()),
+      range: Convert.atomRangeToLSRange(range),
       options: NuclideCodeFormatAdapter.getFormatOptions(editor),
     };
   }

--- a/lib/adapters/nuclide-code-format-adapter.js
+++ b/lib/adapters/nuclide-code-format-adapter.js
@@ -1,0 +1,53 @@
+// @flow
+
+import {LanguageClientConnection, type DocumentFormattingParams, type DocumentRangeFormattingParams,
+  type FormattingOptions, type ServerCapabilities, type TextEdit} from '../languageclient';
+import Convert from '../convert';
+
+export default class NuclideCodeFormatAdapter {
+  static canAdapt(serverCapabilities: ServerCapabilities): boolean {
+    return serverCapabilities.documentRangeFormattingProvider == true || serverCapabilities.documentFormattingProvider == true;
+  }
+
+  format(connection: LanguageClientConnection, serverCapabilities: ServerCapabilities, editor: atom$TextEditor, range: atom$Range): Promise<Array<TextEdit>> {
+    if (serverCapabilities.documentRangeFormattingProvider) {
+      return NuclideCodeFormatAdapter.formatRange(connection, editor, range);
+    }
+
+    if (serverCapabilities.documentFormattingProvider) {
+      return NuclideCodeFormatAdapter.formatDocument(connection, editor);
+    }
+
+    throw new Error('Can not format document, language server does not support it');
+  }
+
+  static formatDocument(connection: LanguageClientConnection, editor: atom$TextEditor): Promise<Array<TextEdit>> {
+    return connection.documentFormatting(NuclideCodeFormatAdapter.createDocumentFormattingParams(editor));
+  }
+
+  static createDocumentFormattingParams(editor: atom$TextEditor): DocumentFormattingParams {
+    return {
+      textDocument: Convert.editorToTextDocumentIdentifier(editor),
+      options: NuclideCodeFormatAdapter.getFormatOptions(editor),
+    };
+  }
+
+  static formatRange(connection: LanguageClientConnection, editor: atom$TextEditor, range: atom$Range): Promise<Array<TextEdit>> {
+    return connection.documentRangeFormatting(NuclideCodeFormatAdapter.createDocumentRangeFormattingParams(editor));
+  }
+
+  static createDocumentRangeFormattingParams(editor: atom$TextEditor): DocumentRangeFormattingParams {
+    return {
+      textDocument: Convert.editorToTextDocumentIdentifier(editor),
+      range: Convert.atomRangeToLSRange(editor.getSelectedBufferRange()),
+      options: NuclideCodeFormatAdapter.getFormatOptions(editor),
+    };
+  }
+
+  static getFormatOptions(editor: atom$TextEditor): FormattingOptions {
+    return {
+      tabSize: editor.getTabLength(),
+      insertSpaces: editor.getSoftTabs(),
+    };
+  }
+}

--- a/lib/auto-languageclient.js
+++ b/lib/auto-languageclient.js
@@ -294,7 +294,7 @@ export default class AutoLanguageClient {
     }
   }
 
-  async getCodeFormat(editor: atom$TextEditor, range: atom$Range): Promise<Array<ls.TextEdit>> {
+  async getCodeFormat(editor: atom$TextEditor, range: atom$Range): Promise<Array<nuclide$TextEdit>> {
     const server = await this._serverManager.getServer(editor);
     if (server == null || !NuclideCodeFormatAdapter.canAdapt(server.capabilities)) { return []; }
 

--- a/lib/auto-languageclient.js
+++ b/lib/auto-languageclient.js
@@ -12,6 +12,7 @@ import DocumentSyncAdapter from './adapters/document-sync-adapter';
 import FormatCodeAdapter from './adapters/format-code-adapter';
 import LinterPushV2Adapter from './adapters/linter-push-v2-adapter';
 import NotificationsAdapter from './adapters/notifications-adapter';
+import NuclideCodeFormatAdapter from './adapters/nuclide-code-format-adapter';
 import NuclideDatatipAdapter from './adapters/nuclide-datatip-adapter';
 import NuclideDefinitionAdapter from './adapters/nuclide-definition-adapter';
 import NuclideFindReferencesAdapter from './adapters/nuclide-find-references-adapter';
@@ -29,6 +30,7 @@ export default class AutoLanguageClient {
 
   // Shared adapters that can take the RPC connection as required
   autoComplete: ?AutocompleteAdapter;
+  codeFormat: ?NuclideCodeFormatAdapter;
   datatip: ?NuclideDatatipAdapter;
   definitions: ?NuclideDefinitionAdapter;
   findReferences: ?NuclideFindReferencesAdapter;
@@ -60,11 +62,6 @@ export default class AutoLanguageClient {
 
   // You might want to override these for different behavior
   // ---------------------------------------------------------------------------
-
-  // Get the selectors you handle
-  getSelectors(): string {
-    return this.getGrammarScopes().map(g => '.' + g).join(', ');
-  }
 
   // Determine whether we should start a server for a given editor if we don't have one yet
   shouldStartForEditor(editor: atom$TextEditor): boolean {
@@ -168,7 +165,7 @@ export default class AutoLanguageClient {
   // Atom Autocomplete+ via LS completion---------------------------------------
   provideAutocomplete(): atom$AutocompleteProvider {
     return {
-      selector: this.getSelectors(),
+      selector: this.getGrammarScopes().map(g => '.' + g).join(', '),
       excludeLowerPriority: false,
       getSuggestions: this.getSuggestions.bind(this),
     };
@@ -286,5 +283,22 @@ export default class AutoLanguageClient {
 
     this.datatip = this.datatip || new NuclideDatatipAdapter();
     return this.datatip.getDatatip(server.connection, editor, point);
+  }
+
+  // Nuclide Code Format via LS formatDocument & formatDocumentRange------------
+  provideCodeFormat(): nuclide$CodeFormatProvider {
+    return {
+      selector: this.getGrammarScopes().join(', '),
+      inclusionPriority: 1,
+      formatCode: this.getCodeFormat.bind(this),
+    }
+  }
+
+  async getCodeFormat(editor: atom$TextEditor, range: atom$Range): Promise<Array<ls.TextEdit>> {
+    const server = await this._serverManager.getServer(editor);
+    if (server == null || !NuclideCodeFormatAdapter.canAdapt(server.capabilities)) { return []; }
+
+    this.codeFormat = this.codeFormat || new NuclideCodeFormatAdapter();
+    return this.codeFormat.format(server.connection, server.capabilities, editor, range);
   }
 }


### PR DESCRIPTION
Fixes #27 

@hansonw I'm surprised by the behavior of Nuclide's "Code Format" command without any range selected.  Based on https://github.com/facebook/nuclide/blob/master/pkg/nuclide-code-format/lib/CodeFormatManager.js#L114 I expected to see no selection become whole file but I am not getting that in my callback - range is just set to the cursor position where end and start are both the same - effectively no range.