### PR TITLE
Minor tweaks to diagnostics/find-references adapters

### DIFF
--- a/flow-libs/linter.js.flow
+++ b/flow-libs/linter.js.flow
@@ -108,4 +108,6 @@ type linter$V2Message = {
   description?: string | (() => Promise<string> | string),
   // ^ Markdown long description of the error, accepts callback so you can do
   // http requests etc.
+  linterName?: string,
+  // ^ Optionally override the displayed linter name. (Defaults to provider)
 }

--- a/lib/adapters/linter-push-v2-adapter.js
+++ b/lib/adapters/linter-push-v2-adapter.js
@@ -36,7 +36,7 @@ export default class LinterPushV2Adapter {
         position: Convert.lsRangeToAtomRange(diagnostic.range),
       },
       excerpt: diagnostic.message,
-      description: diagnostic.source,
+      linterName: diagnostic.source,
       severity: LinterPushV2Adapter.diagnosticSeverityToSeverity(diagnostic.severity || -1),
     };
   }

--- a/lib/adapters/nuclide-find-references-adapter.js
+++ b/lib/adapters/nuclide-find-references-adapter.js
@@ -16,7 +16,7 @@ export default class NuclideFindReferencesAdapter {
     };
 
     const locations = await connection.findReferences(documentPositionParams);
-    if (locations == null || locations.length === 0) { return null; }
+    if (locations == null) { return null; }
 
     const references = locations.map(NuclideFindReferencesAdapter.locationToReference);
 
@@ -37,6 +37,9 @@ export default class NuclideFindReferencesAdapter {
   }
 
   static getReferencedSymbolName(editor: atom$TextEditor, point: atom$Point, references: Array<nuclide$Reference>): string {
+    if (references.length === 0) {
+      return '';
+    }
     const currentReference = references.find(r => r.range.containsPoint(point)) || references[0];
     return editor.getBuffer().getTextInRange(currentReference.range);
   }

--- a/lib/auto-languageclient.js
+++ b/lib/auto-languageclient.js
@@ -268,6 +268,9 @@ export default class AutoLanguageClient {
   consumeDatatip(service: nuclide$DatatipService): void {
     this._disposable.add(service.addProvider({
       providerName: this.name,
+      priority: 1,
+      grammarScopes: this.getGrammarScopes(),
+      // For the legacy nuclide-datatip API. Will be removed...
       inclusionPriority: 1,
       validForScope: (scopeName: string) => {
         return this.getGrammarScopes().includes(scopeName);

--- a/test/adapters/linter-push-v2-adapter.test.js
+++ b/test/adapters/linter-push-v2-adapter.test.js
@@ -46,7 +46,7 @@ describe('LinterPushV2Adapter', () => {
       };
       const result = LinterPushV2Adapter.diagnosticToV2Message(filePath, diagnostic);
       expect(result.excerpt).equals(diagnostic.message);
-      expect(result.description).equals(diagnostic.source);
+      expect(result.linterName).equals(diagnostic.source);
       expect(result.location.file).equals(filePath);
       expect(result.location.position).deep.equals(new Range(new Point(1, 2), new Point(3, 4)));
       expect(result.severity).equals('info');


### PR DESCRIPTION
In diagnostics: Use `linterName` for the source, rather than the description. This requires https://github.com/steelbrain/linter/pull/1493 but until then it'll be ignored in favor of the language server's name (which is fine).

In find-references: when there's no references, make sure an empty array is returned rather than `null`. The UI uses this to distinguish between "no references" and "can't find references".

Released under CC0.