### PR TITLE
Export LinterPushV2Adapter and let override diagnosticToV2Message

### DIFF
--- a/lib/adapters/linter-push-v2-adapter.js
+++ b/lib/adapters/linter-push-v2-adapter.js
@@ -39,7 +39,7 @@ export default class LinterPushV2Adapter {
   //            be captured and forwarded on to any attached {V2IndieDelegate}s.
   captureDiagnostics(params: PublishDiagnosticsParams): void {
     const path = Convert.uriToPath(params.uri);
-    const messages = params.diagnostics.map(d => LinterPushV2Adapter.diagnosticToV2Message(path, d));
+    const messages = params.diagnostics.map(d => this.diagnosticToV2Message(path, d));
     this._diagnosticMap.set(path, messages);
     this._indies.forEach(i => i.setMessages(path, messages));
   }
@@ -51,7 +51,7 @@ export default class LinterPushV2Adapter {
   // * `diagnostics` A {Diagnostic} object received from the language server.
   //
   // Returns a {V2Message} equivalent to the {Diagnostic} object supplied by the language server.
-  static diagnosticToV2Message(path: string, diagnostic: Diagnostic): linter$V2Message {
+  diagnosticToV2Message(path: string, diagnostic: Diagnostic): linter$V2Message {
     return {
       location: {
         file: path,

--- a/lib/auto-languageclient.js
+++ b/lib/auto-languageclient.js
@@ -59,6 +59,10 @@ export default class AutoLanguageClient {
     throw Error('Must override startServerProcess to start language server process when extending AutoLanguageClient');
   }
 
+  newLinterPushV2Adapter(connection: ls.LanguageClientConnection): LinterPushV2Adapter {
+    return new LinterPushV2Adapter(connection);
+  }
+
   // You might want to override these for different behavior
   // ---------------------------------------------------------------------------
 
@@ -165,7 +169,7 @@ export default class AutoLanguageClient {
           editor => (editor.getURI() || '').startsWith(server.projectPath)));
     }
 
-    server.linterPushV2 = new LinterPushV2Adapter(server.connection);
+    server.linterPushV2 = this.newLinterPushV2Adapter(server.connection);
     if (this._linterDelegate != null) {
       server.linterPushV2.attach(this._linterDelegate);
     }

--- a/lib/main.js
+++ b/lib/main.js
@@ -1,9 +1,11 @@
 import AutoLanguageClient from './auto-languageclient';
 import Convert from './convert';
 import DownloadFile from './download-file';
+import LinterPushV2Adapter from './adapters/linter-push-v2-adapter';
 
 module.exports = {
   AutoLanguageClient,
   Convert,
   DownloadFile,
+  LinterPushV2Adapter
 };

--- a/test/adapters/custom-linter-push-v2-adapter.test.js
+++ b/test/adapters/custom-linter-push-v2-adapter.test.js
@@ -1,0 +1,51 @@
+// @flow
+
+import LinterPushV2Adapter from '../../lib/adapters/linter-push-v2-adapter';
+import * as ls from '../../lib/languageclient';
+import {expect} from 'chai';
+import {Point, Range} from 'atom';
+
+const messageUrl = "dummy";
+const messageSolutions = ["dummy"];
+
+class CustomLinterPushV2Adapter extends LinterPushV2Adapter {
+
+  constructor(connection) {
+    super(connection);
+  }
+
+  diagnosticToV2Message(path, diagnostic) {
+    var message = super.diagnosticToV2Message(path, diagnostic);
+    message.url = messageUrl;
+    message.solutions = messageSolutions;
+    return message;
+  }
+}
+
+describe('CustomLinterPushV2Adapter', () => {
+  describe('diagnosticToMessage', () => {
+    it('converts Diagnostic and path to a linter$Message', () => {
+      const filePath = '/a/b/c/d';
+      const diagnostic: ls.Diagnostic = {
+        message: 'This is a message',
+        range: {start: {line: 1, character: 2}, end: {line: 3, character: 4}},
+        source: 'source',
+        code: 'code',
+        severity: ls.DiagnosticSeverity.Information,
+        type: ls.DiagnosticSeverity.Information,
+      };
+
+      const connection = { onPublishDiagnostics: function(){} };
+      const adapter = new CustomLinterPushV2Adapter(connection);
+      const result = adapter.diagnosticToV2Message(filePath, diagnostic);
+
+      expect(result.excerpt).equals(diagnostic.message);
+      expect(result.linterName).equals(diagnostic.source);
+      expect(result.location.file).equals(filePath);
+      expect(result.location.position).deep.equals(new Range(new Point(1, 2), new Point(3, 4)));
+      expect(result.severity).equals('info');
+      expect(result.url).equals(messageUrl);
+      expect(result.solutions).deep.equals(messageSolutions);
+    });
+  });
+});

--- a/test/adapters/linter-push-v2-adapter.test.js
+++ b/test/adapters/linter-push-v2-adapter.test.js
@@ -44,7 +44,11 @@ describe('LinterPushV2Adapter', () => {
         severity: ls.DiagnosticSeverity.Information,
         type: ls.DiagnosticSeverity.Information,
       };
-      const result = LinterPushV2Adapter.diagnosticToV2Message(filePath, diagnostic);
+
+      const connection = { onPublishDiagnostics: function(){} };
+      const adapter = new LinterPushV2Adapter(connection);
+      const result = adapter.diagnosticToV2Message(filePath, diagnostic);
+
       expect(result.excerpt).equals(diagnostic.message);
       expect(result.linterName).equals(diagnostic.source);
       expect(result.location.file).equals(filePath);


### PR DESCRIPTION
Export `LinterPushV2Adapter` and make it possible to override `LinterPushV2Adapter.diagnosticToV2Message` in derived classes, in order to customize the messages sent to linter.