### PR TITLE
Implement window/showMessageRequest handler

### DIFF
--- a/lib/adapters/notifications-adapter.js
+++ b/lib/adapters/notifications-adapter.js
@@ -5,7 +5,8 @@ import {
   MessageType,
   type MessageActionItem,
   type ServerCapabilities,
-  type ShowMessageParams
+  type ShowMessageParams,
+  type ShowMessageRequestParams
 } from '../languageclient';
 
 // Public: Adapts Atom's user notifications to those of the language server protocol.
@@ -14,9 +15,35 @@ export default class NotificationsAdapter {
   // when user notifications should be displayed.
   static attach(connection: LanguageClientConnection, name: string) {
     connection.onShowMessage(m => NotificationsAdapter.onShowMessage(m, name));
+    connection.onShowMessageRequest(m => NotificationsAdapter.onShowMessageRequest(m, name));
   }
 
-  // TODO: Wire up onShowMessageRequest
+  static onShowMessageRequest(params: ShowMessageRequestParams, name: string): Promise<?MessageActionItem> {
+    return new Promise((resolve, reject) => {
+      let notification: ?atom$Notification;
+      const options: atom$NotificationOptions = {dismissable: true, detail: name};
+      if (params.actions) {
+        options.buttons = params.actions.map(a => ({
+          text: a.title,
+          onDidClick: () => {
+            resolve(a);
+            if (notification != null) {
+              notification.dismiss()
+            }
+          },
+        }));
+      }
+
+      notification = addNotificationForMessage(params.type, params.message, {
+        dismissable: true,
+        detail: name
+      });
+
+      if (notification != null) {
+        notification.onDidDismiss(() => { resolve(null) });
+      }
+    });
+  }
 
   // Public: Show a notification message using the Atom notifications API.
   //
@@ -25,21 +52,10 @@ export default class NotificationsAdapter {
   // * `name`   The name of the language server so the user can identify the
   //            context of the message.
   static onShowMessage(params: ShowMessageParams, name: string): void {
-    const options = {dismissable: true, detail: name};
-    switch (params.type) {
-      case MessageType.Error:
-        atom.notifications.addError(params.message, options);
-        return;
-      case MessageType.Warning:
-        atom.notifications.addWarning(params.message, options);
-        return;
-      case MessageType.Log:
-        // console.log(params.message);
-        return;
-      case MessageType.Info:
-      default:
-        atom.notifications.addInfo(params.message, options);
-    }
+    addNotificationForMessage(params.type, params.message, {
+      dismissable: true,
+      detail: name
+    });
   }
 
   // Public: Convert a {MessageActionItem} from the language server into an
@@ -52,5 +68,20 @@ export default class NotificationsAdapter {
     return {
       text: actionItem.title,
     }
+  }
+}
+
+function addNotificationForMessage(messageType: number, message: string, options: atom$NotificationOptions): ?atom$Notification {
+  switch (messageType) {
+    case MessageType.Error:
+      return atom.notifications.addError(message, options);
+    case MessageType.Warning:
+      return atom.notifications.addWarning(message, options);
+    case MessageType.Log:
+      // console.log(params.message);
+      return;
+    case MessageType.Info:
+    default:
+      return atom.notifications.addInfo(message, options);
   }
 }

--- a/lib/languageclient.js
+++ b/lib/languageclient.js
@@ -72,14 +72,13 @@ export class LanguageClientConnection {
     this._onNotification({method: 'window/showMessage'}, callback);
   }
 
-  // Public: Register a callback for the 'window/showMessage' message.
+  // Public: Register a callback for the 'window/showMessageRequest' message.
   //
-  // * `callback` The function to be called when the 'window/showMessage' message is
-  //              received with 'ShowMessageParams' being passed as an object.
-  // TODO: This message needs to be able to wait for MessageActionItem - Promise?
-  // onShowMessageRequest(callback: ShowMessageRequestParams => MessageActionItem): void {
-  //   this._onRequest({method: 'window/ShowMessageRequest'}, callback);
-  // }
+  // * `callback` The function to be called when the 'window/showMessageRequest' message is
+  //              received with 'ShowMessageRequestParams' being passed as an object.
+  onShowMessageRequest(callback: ShowMessageRequestParams => Promise<?MessageActionItem>): void {
+    this._onRequest({method: 'window/showMessageRequest'}, callback);
+  }
 
   // Public: Register a callback for the 'window/logMessage' message.
   //
@@ -206,7 +205,7 @@ export class LanguageClientConnection {
     return this._sendRequest('textDocument/rename', params);
   }
 
-  _onRequest(type: {method: string}, callback: Object => Object): void {
+  _onRequest(type: {method: string}, callback: Object => Promise<any>): void {
     this._rpc.onRequest(type, value => {
       this._log.debug(`rpc.onRequest ${type.method}`, value);
       return callback(value);

--- a/lib/languageclient.js
+++ b/lib/languageclient.js
@@ -76,6 +76,8 @@ export class LanguageClientConnection {
   //
   // * `callback` The function to be called when the 'window/showMessageRequest' message is
   //              received with 'ShowMessageRequestParams' being passed as an object.
+  //              Returns a promise resolved with the selected message action item (presented as
+  //              button options to the atom notification)
   onShowMessageRequest(callback: ShowMessageRequestParams => Promise<?MessageActionItem>): void {
     this._onRequest({method: 'window/showMessageRequest'}, callback);
   }


### PR DESCRIPTION
Similar to window/showMessage, this triggers an analagous notification in Atom. However,
the server also passes action options (see lsp protocol) that are
represented as buttons in the notification. The server is then notified
of the selected option when the request resolves.

Released under CC0.