### PR TITLE
Set descriptionMarkdown property for Atom auto-complete suggestion

### DIFF
--- a/lib/adapters/autocomplete-adapter.js
+++ b/lib/adapters/autocomplete-adapter.js
@@ -80,6 +80,7 @@ export default class AutocompleteAdapter {
   //
   // Returns an AutoComplete+ suggestion.
   static basicCompletionItemToSuggestion(item: CompletionItem): atom$AutocompleteSuggestion {
+    //noinspection JSAnnotator
     return {
       text: item.insertText || item.label,
       displayText: item.label,
@@ -87,6 +88,7 @@ export default class AutocompleteAdapter {
       type: AutocompleteAdapter.completionKindToSuggestionType(item.kind),
       leftLabel: item.detail,
       description: item.documentation,
+      descriptionMarkdown: item.documentation
     };
   }
 

--- a/test/adapters/autocomplete-adapter.test.js
+++ b/test/adapters/autocomplete-adapter.test.js
@@ -100,6 +100,7 @@ describe('AutoCompleteAdapter', () => {
       expect(result.type).equals('keyword');
       expect(result.leftLabel).equals('keyword');
       expect(result.description).equals('a truly useful keyword');
+      expect(result.descriptionMarkdown).equals('a truly useful keyword');
     });
 
     it('converts LSP CompletionItem to AutoComplete Suggestion with textEdit', () => {
@@ -127,6 +128,7 @@ describe('AutoCompleteAdapter', () => {
       expect(result.type).equals('variable');
       expect(result.leftLabel).equals('number');
       expect(result.description).equals('a truly useful variable');
+      expect(result.descriptionMarkdown).equals('a truly useful variable');
       expect(result.replacementPrefix).equals('replacementPrefix');
       expect(result.text).equals('newText');
       expect(autocompleteRequest.editor.getTextInBufferRange.calledOnce).equals(true);
@@ -150,6 +152,7 @@ describe('AutoCompleteAdapter', () => {
       expect(result.type).equals('keyword');
       expect(result.leftLabel).equals('detail');
       expect(result.description).equals('a very exciting keyword');
+      expect(result.descriptionMarkdown).equals('a very exciting keyword');
     });
 
     it('converts LSP CompletionItem without insertText or filterText to AutoComplete Suggestion', () => {
@@ -165,6 +168,7 @@ describe('AutoCompleteAdapter', () => {
       expect(result.type).equals('keyword');
       expect(result.leftLabel).equals('detail');
       expect(result.description).equals('A very useful keyword');
+      expect(result.descriptionMarkdown).equals('A very useful keyword');
     });
   });
 


### PR DESCRIPTION
AutoComplete+ suggestion model has `descriptionMarkdown` property for Markdown format proposal documentation. (Think it's safe for plain text as well)
Although LS protocol doesn't specify that `documentation` is `MarkedString` VSCode language client accepts Markdown format documentation, so does Eclipse client. Looks like it's easy to add support for this in Atom too.