### PR TITLE
Fixes around editor grammar override feature. Tracking grammar changes for LS start/stop and file syncing

### DIFF
--- a/lib/adapters/document-sync-adapter.js
+++ b/lib/adapters/document-sync-adapter.js
@@ -73,16 +73,44 @@ export default class DocumentSyncAdapter {
   //
   // * `editor` A {TextEditor} to consider for observation.
   observeTextEditor(editor: atom$TextEditor): void {
+    const listener = editor.observeGrammar(grammar => this._handleGrammarChange(editor));
+    this._disposable.add(editor.onDidDestroy(() => {
+      this._disposable.remove(listener);
+      listener.dispose();
+    }));
+    this._disposable.add(listener);
     if (!this._editors.has(editor) && this._editorSelector(editor)) {
-      const sync = new TextEditorSyncAdapter(editor, this._connection, this._documentSyncKind);
-      this._editors.set(editor, sync);
-      this._disposable.add(sync);
-      this._disposable.add(editor.onDidDestroy(() => {
+      this._handleNewEditor(editor);
+    }
+  }
+
+  _handleGrammarChange(editor: atom$TextEditor): void {
+    if (this._editors.has(editor) && !this._editorSelector(editor)) {
+      const sync = this._editors.get(editor);
+      this._editors.delete(editor);
+      this._disposable.remove(sync);
+      sync.dispose();
+    } else if (!this._editors.has(editor) && this._editorSelector(editor)) {
+      this._handleNewEditor(editor);
+    }
+  }
+
+  _handleNewEditor(editor: atom$TextEditor): void {
+    let sync = new TextEditorSyncAdapter(editor, this._connection, this._documentSyncKind);
+    this._editors.set(editor, sync);
+    this._disposable.add(sync);
+    this._disposable.add(editor.onDidDestroy(() => {
+      let sync = this._editors.get(editor);
+      if (sync) {
         this._editors.delete(editor);
         this._disposable.remove(sync);
         sync.dispose();
-      }));
-    }
+      }
+    }));
+  }
+
+  getEditorSyncAdapter(editor: atom$TextEditor): TextEditorSyncAdapter {
+    return this._editors.get(editor);
   }
 }
 

--- a/lib/auto-languageclient.js
+++ b/lib/auto-languageclient.js
@@ -162,9 +162,9 @@ export default class AutoLanguageClient {
     NotificationsAdapter.attach(server.connection, this.name);
 
     if (DocumentSyncAdapter.canAdapt(server.capabilities)) {
-      server.disposable.add(
-        new DocumentSyncAdapter(server.connection, server.capabilities.textDocumentSync,
-          editor => this.shouldSyncForEditor(editor, server.projectPath)));
+      server.docSyncAdapter = new DocumentSyncAdapter(server.connection, server.capabilities.textDocumentSync,
+              editor => this.shouldSyncForEditor(editor, server.projectPath));
+      server.disposable.add(server.docSyncAdapter);
     }
 
     server.linterPushV2 = new LinterPushV2Adapter(server.connection);

--- a/lib/server-manager.js
+++ b/lib/server-manager.js
@@ -14,6 +14,7 @@ export type ActiveServer = {
   connection: ls.LanguageClientConnection;
   capabilities: ls.ServerCapabilities;
   linterPushV2?: LinterPushV2Adapter;
+  docSyncAdapter: DocumentSyncAdapter;
 }
 
 // Manages the language server lifecycles and their associated objects necessary
@@ -33,10 +34,9 @@ export class ServerManager {
     this._logger = logger;
     this._startForEditor = startForEditor;
     this.updateNormalizedProjectPaths();
-    this._disposable = new CompositeDisposable(
-      atom.project.onDidChangePaths(this.projectPathsChanged.bind(this)),
-      atom.textEditors.observe(this.observeTextEditors.bind(this)),
-    );
+    this._disposable = new CompositeDisposable();
+    this._disposable.add(atom.project.onDidChangePaths(this.projectPathsChanged.bind(this)));
+    this._disposable.add(atom.textEditors.observe(this.observeTextEditors.bind(this)));
   }
 
   dispose(): void {
@@ -45,14 +45,47 @@ export class ServerManager {
   }
 
   async observeTextEditors(editor: atom$TextEditor): Promise<void> {
+    // Track grammar changes for opened editors
+    const listener = editor.observeGrammar(grammar => this._handleGrammarChange(editor));
+    this._disposable.add(editor.onDidDestroy(() => listener.dispose()));
+    // Try to see if editor can have LS connected to it
+    this._handleTextEditor(editor);
+  }
+
+  async _handleTextEditor(editor: atom$TextEditor): Promise<void> {
     if (!this._editorToServer.has(editor)) {
+      // editor hasn't been processed yet, so process it by allocating LS for it if necessary
       const server = await this.getServer(editor, {shouldStart: true});
       if (server != null) {
+        // There LS for the editor (either started now and already running)
         this._editorToServer.set(editor, server);
         this._disposable.add(editor.onDidDestroy(() => {
           this._editorToServer.delete(editor);
           this.stopUnusedServers();
         }));
+      }
+    }
+  }
+
+  _handleGrammarChange(editor: atom$TextEditor) {
+    if (this._startForEditor(editor)) {
+      // If editor is interesting for LS process the editor further to attempt to start LS if needed
+      this._handleTextEditor(editor);
+    } else {
+      // Editor is not supported by the LS
+      const server = this._editorToServer.get(editor);
+        // If LS is running for the unsupported editor then disconnect the editor from LS and shut down LS if necessary
+      if (server) {
+        // LS is up for unsupported server
+        const syncAdapter = server.docSyncAdapter.getEditorSyncAdapter(editor);
+        if (syncAdapter) {
+          // Immitate editor close to disconnect LS from the editor
+          syncAdapter.didDestroy();
+        }
+        // Remove editor from the cache
+        this._editorToServer.delete(editor);
+        // Shut down LS if it's used by any other editor
+        this.stopUnusedServers();
       }
     }
   }


### PR DESCRIPTION
Attempt to fix https://github.com/atom/atom-languageclient/issues/76

One issue left is to wipe out errors/warnings (markers) when switching from LS backed grammar to non LS grammar. Not sure how to get it fixed, need a hint