### PR TITLE
Upgrade to Flow 0.52 and run Flow on Travis

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -7,3 +7,6 @@ flow-libs/
 flow-typed/
 
 [options]
+
+[version]
+0.52.0

--- a/flow-libs/atom.js.flow
+++ b/flow-libs/atom.js.flow
@@ -98,7 +98,7 @@ declare class atom$CompositeDisposable {
   constructor(...disposables: IDisposable[]): void,
   dispose(): void,
 
-  add(disposable: IDisposable): void,
+  add(...disposables: Array<IDisposable>): void,
   remove(disposable: IDisposable): void,
   clear(): void,
 }
@@ -1736,6 +1736,7 @@ type atom$AutocompleteSuggestion = {
   className?: ?string,
   iconHTML?: ?string,
   description?: ?string,
+  descriptionMarkdown?: ?string,
   descriptionMoreURL?: ?string,
 };
 

--- a/lib/adapters/document-sync-adapter.js
+++ b/lib/adapters/document-sync-adapter.js
@@ -52,12 +52,14 @@ export default class DocumentSyncAdapter {
   // * `documentSyncKind` The type of document syncing supported - Full or Incremental.
   // * `editorSelector` A predicate function that takes a {TextEditor} and returns a {boolean}
   //                    indicating whether this adapter should care about the contents of the editor.
-  constructor(connection: LanguageClientConnection, documentSyncKind: TextDocumentSyncOptions | number, editorSelector: atom$TextEditor => boolean) {
+  constructor(connection: LanguageClientConnection, documentSyncKind: ?(TextDocumentSyncOptions | number), editorSelector: atom$TextEditor => boolean) {
     this._connection = connection;
-    if (typeof documentSyncKind === 'object') {
+    if (typeof documentSyncKind === 'number') {
+      this._documentSyncKind = documentSyncKind;
+    } else if (documentSyncKind != null && documentSyncKind.change != null) {
       this._documentSyncKind = documentSyncKind.change;
     } else {
-      this._documentSyncKind = documentSyncKind;
+      this._documentSyncKind = TextDocumentSyncKind.Full;
     }
     this._editorSelector = editorSelector;
     this._disposable.add(atom.textEditors.observe(this.observeTextEditor.bind(this)));

--- a/lib/adapters/document-sync-adapter.js
+++ b/lib/adapters/document-sync-adapter.js
@@ -87,12 +87,12 @@ export default class DocumentSyncAdapter {
   }
 
   _handleGrammarChange(editor: atom$TextEditor): void {
-    if (this._editors.has(editor) && !this._editorSelector(editor)) {
-      const sync = this._editors.get(editor);
+    const sync = this._editors.get(editor);
+    if (sync != null && !this._editorSelector(editor)) {
       this._editors.delete(editor);
       this._disposable.remove(sync);
       sync.dispose();
-    } else if (!this._editors.has(editor) && this._editorSelector(editor)) {
+    } else if (sync == null && this._editorSelector(editor)) {
       this._handleNewEditor(editor);
     }
   }
@@ -111,7 +111,7 @@ export default class DocumentSyncAdapter {
     }));
   }
 
-  getEditorSyncAdapter(editor: atom$TextEditor): TextEditorSyncAdapter {
+  getEditorSyncAdapter(editor: atom$TextEditor): ?TextEditorSyncAdapter {
     return this._editors.get(editor);
   }
 }

--- a/lib/auto-languageclient.js
+++ b/lib/auto-languageclient.js
@@ -239,7 +239,7 @@ export default class AutoLanguageClient {
   }
 
   // Linter push v2 API via LS publishDiagnostics
-  consumeLinterV2(registerIndie: () => linter$V2IndieDelegate): void {
+  consumeLinterV2(registerIndie: ({name: string}) => linter$V2IndieDelegate): void {
     this._linterDelegate = registerIndie({name: this.name});
     if (this._linterDelegate == null) return;
 

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -1,11 +1,11 @@
 // @flow
 
 export type Logger = {
-  warn(args: any): void,
-  error(args: any): void,
-  info(args: any): void,
-  log(args: any): void,
-  debug(args: any): void,
+  warn(...args: any): void,
+  error(...args: any): void,
+  info(...args: any): void,
+  log(...args: any): void,
+  debug(...args: any): void,
 }
 
 export class ConsoleLogger {
@@ -52,9 +52,9 @@ export class ConsoleLogger {
 }
 
 export class NullLogger {
-  warn(args: any): void { }
-  error(args: any): void { }
-  info(args: any): void { }
-  log(args: any): void { }
-  debug(args: any): void { }
+  warn(...args: any): void { }
+  error(...args: any): void { }
+  info(...args: any): void { }
+  log(...args: any): void { }
+  debug(...args: any): void { }
 }

--- a/lib/server-manager.js
+++ b/lib/server-manager.js
@@ -1,10 +1,12 @@
 // @flow
 
+import {type Logger} from './logger';
+import type LinterPushV2Adapter from './adapters/linter-push-v2-adapter';
+import type DocumentSyncAdapter from './adapters/document-sync-adapter';
+
 import path from 'path';
 import * as ls from './languageclient';
 import {CompositeDisposable} from 'atom';
-import {type Logger} from './logger';
-import LinterPushV2Adapter from './adapters/linter-push-v2-adapter';
 
 // The necessary elements for a server that has started or is starting.
 export type ActiveServer = {
@@ -14,7 +16,7 @@ export type ActiveServer = {
   connection: ls.LanguageClientConnection;
   capabilities: ls.ServerCapabilities;
   linterPushV2?: LinterPushV2Adapter;
-  docSyncAdapter: DocumentSyncAdapter;
+  docSyncAdapter?: DocumentSyncAdapter;
 }
 
 // Manages the language server lifecycles and their associated objects necessary
@@ -77,10 +79,12 @@ export class ServerManager {
         // If LS is running for the unsupported editor then disconnect the editor from LS and shut down LS if necessary
       if (server) {
         // LS is up for unsupported server
-        const syncAdapter = server.docSyncAdapter.getEditorSyncAdapter(editor);
-        if (syncAdapter) {
-          // Immitate editor close to disconnect LS from the editor
-          syncAdapter.didDestroy();
+        if (server.docSyncAdapter) {
+          const syncAdapter = server.docSyncAdapter.getEditorSyncAdapter(editor);
+          if (syncAdapter) {
+            // Immitate editor close to disconnect LS from the editor
+            syncAdapter.didDestroy();
+          }
         }
         // Remove editor from the cache
         this._editorToServer.delete(editor);

--- a/lib/server-manager.js
+++ b/lib/server-manager.js
@@ -91,7 +91,7 @@ export class ServerManager {
   }
 
   getActiveServers(): Array<ActiveServer> {
-    return this._activeServers.splice();
+    return this._activeServers.slice();
   }
 
   async getServer(textEditor: atom$TextEditor,

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "chai": "^3.5.0",
     "eslint": "^3.19.0",
     "eslint-config-fbjs-opensource": "^1.0.0",
-    "flow-bin": "^0.42.0",
+    "flow-bin": "^0.52.0",
     "mocha": "^3.2.0",
     "mocha-appveyor-reporter": "^0.3.0",
     "sinon": "^2.0.0"

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   "scripts": {
     "clean": "rm -rf build",
     "compile": "babel lib --out-dir build/lib && babel test --out-dir build/test",
+    "lint": "flow",
     "postinstall": "postinstall-build --only-as-dependency build \"npm run compile\"",
     "prepublish": "npm run clean && npm run compile",
     "test": "npm run compile && atom --test build/test",

--- a/script/cibuild
+++ b/script/cibuild
@@ -1,5 +1,8 @@
 #!/bin/sh
 
+# Exit if any single command fails.
+set -e
+
 echo "Downloading latest Atom release..."
 ATOM_CHANNEL="${ATOM_CHANNEL:=stable}"
 
@@ -94,10 +97,8 @@ if [ -n "${APM_TEST_PACKAGES}" ]; then
   done
 fi
 
+echo "Running lint..."
+npm run lint
+
 echo "Running specs..."
 "$ATOM_SCRIPT_PATH" --test build/test
-TEST_RESULT=$?
-
-echo "=================="
-echo "Test exit code: $TEST_RESULT"
-if [ $TEST_RESULT -ne 0 ]; then exit $TEST_RESULT; fi

--- a/test/adapters/custom-linter-push-v2-adapter.test.js
+++ b/test/adapters/custom-linter-push-v2-adapter.test.js
@@ -6,7 +6,7 @@ import {expect} from 'chai';
 import {Point, Range} from 'atom';
 
 const messageUrl = "dummy";
-const messageSolutions = ["dummy"];
+const messageSolutions: Array<any> = ["dummy"];
 
 class CustomLinterPushV2Adapter extends LinterPushV2Adapter {
 
@@ -35,7 +35,7 @@ describe('CustomLinterPushV2Adapter', () => {
         type: ls.DiagnosticSeverity.Information,
       };
 
-      const connection = { onPublishDiagnostics: function(){} };
+      const connection: any = { onPublishDiagnostics: function(){} };
       const adapter = new CustomLinterPushV2Adapter(connection);
       const result = adapter.diagnosticToV2Message(filePath, diagnostic);
 

--- a/test/adapters/document-sync-adapter.test.js
+++ b/test/adapters/document-sync-adapter.test.js
@@ -39,7 +39,7 @@ describe('DocumentSyncAdapter', () => {
 
   describe('constructor', () => {
     function create(textDocumentSync) {
-      return new DocumentSyncAdapter(null, textDocumentSync, null);
+      return new DocumentSyncAdapter((null: any), textDocumentSync, (null: any));
     }
 
     it('sets _documentSyncKind correctly Incremental for v2 capabilities', () => {

--- a/test/adapters/linter-push-v2-adapter.test.js
+++ b/test/adapters/linter-push-v2-adapter.test.js
@@ -45,7 +45,7 @@ describe('LinterPushV2Adapter', () => {
         type: ls.DiagnosticSeverity.Information,
       };
 
-      const connection = { onPublishDiagnostics: function(){} };
+      const connection: any = { onPublishDiagnostics: function(){} };
       const adapter = new LinterPushV2Adapter(connection);
       const result = adapter.diagnosticToV2Message(filePath, diagnostic);
 

--- a/test/auto-languageclient.test.js
+++ b/test/auto-languageclient.test.js
@@ -14,7 +14,7 @@ describe('AutoLanguageClient', () => {
 
     const client = new CustomAutoLanguageClient();
 
-    function mockEditor(uri, scopeName) {
+    function mockEditor(uri, scopeName): any {
       return {
          getURI: () => uri,
          getGrammar: () => { return { scopeName: scopeName } }


### PR DESCRIPTION
Note that this caught a very real bug: `getActiveServers()` would empty the array! (slice vs splice)
The rest are pretty trivial changes. I'll add Flow to the Travis CI config as well.

Contributed under CC0.