### PR TITLE
Send atom file renames as LSP close, then open

### DIFF
--- a/lib/adapters/document-sync-adapter.js
+++ b/lib/adapters/document-sync-adapter.js
@@ -120,6 +120,7 @@ export default class DocumentSyncAdapter {
 class TextEditorSyncAdapter {
   _disposable = new CompositeDisposable();
   _editor: atom$TextEditor;
+  _lastFileUri: ?string;
   _connection: LanguageClientConnection;
   _version = 1;
 
@@ -142,7 +143,27 @@ class TextEditorSyncAdapter {
       editor.onDidDestroy(this.didDestroy.bind(this)),
     );
 
+    if (this._editor.getBuffer().file) {
+      this.setupFileRenameTracking();
+    }
+
     this.didOpen();
+  }
+
+  setupFileRenameTracking() {
+    if (this._lastFileUri) {
+      throw new Error('Attempted to set up tracking for a buffer that already had a file');
+    }
+
+    // either this is a new buffer that has a file already, or
+    // begin watching for renames on the file since we skipped this
+    // before when it was an anonymous buffer
+    const file = this._editor.getBuffer().file;
+    if (!file) {
+      throw new Error('Expected buffer to have a file');
+    }
+    this._disposable.add(file.onDidRename(this.didRename.bind(this)));
+    this._lastFileUri = this.getEditorUri();
   }
 
   // The change tracking disposable listener that will ensure that changes are sent to the
@@ -249,7 +270,33 @@ class TextEditorSyncAdapter {
     this._connection.didSaveTextDocument({textDocument: {uri: this.getEditorUri()}});
     // TODO: Move this to a file watching event once Atom has API support.
     this._connection.didChangeWatchedFiles({changes: [{uri: this.getEditorUri(), type: FileChangeType.Changed}]}); // Replace with file watch
+
+    if (!this._lastFileUri) {
+      this.setupFileRenameTracking();
+    }
   }
+
+  didRename() {
+    const lastFileUri = this._lastFileUri;
+    if (!lastFileUri) {
+      this._lastFileUri = this.getEditorUri();
+      return;
+    }
+
+    this._connection.didCloseTextDocument({textDocument: {uri: lastFileUri}});
+    this._connection.didChangeWatchedFiles({
+      changes: [
+        {uri: lastFileUri, type: FileChangeType.Deleted},
+        {uri: this.getEditorUri(), type: FileChangeType.Created}
+      ]
+    });
+    this._lastFileUri = this.getEditorUri();
+
+    // send an equivalent open event for this editor, which will now use the new
+    // file path
+    this.didOpen();
+  }
+
 
   // Public: Obtain the current {TextEditor} path and convert it to a Uri.
   getEditorUri(): string {


### PR DESCRIPTION
Send atom file renames as LSP close, then open

This tracks renames of the underlying atom `File`s in atom `Editor`s by issuing a close event to the LSP server using the file's old name, and sending a new open event to the LSP server using the file's new name.

Uses `Editor`'s `didChangePath` to monitor renames.

fixes #58

Released under CC0.