### PR TITLE
Use editor.onDidChangePath to monitor renames instead of manual file tracking

### DIFF
--- a/lib/adapters/document-sync-adapter.js
+++ b/lib/adapters/document-sync-adapter.js
@@ -141,29 +141,11 @@ class TextEditorSyncAdapter {
     this._disposable.add(
       editor.onDidSave(this.didSave.bind(this)),
       editor.onDidDestroy(this.didDestroy.bind(this)),
+      editor.onDidChangePath(this.didRename.bind(this)),
     );
 
-    if (this._editor.getBuffer().file) {
-      this.setupFileRenameTracking();
-    }
-
-    this.didOpen();
-  }
-
-  setupFileRenameTracking() {
-    if (this._lastFileUri) {
-      throw new Error('Attempted to set up tracking for a buffer that already had a file');
-    }
-
-    // either this is a new buffer that has a file already, or
-    // begin watching for renames on the file since we skipped this
-    // before when it was an anonymous buffer
-    const file = this._editor.getBuffer().file;
-    if (!file) {
-      throw new Error('Expected buffer to have a file');
-    }
-    this._disposable.add(file.onDidRename(this.didRename.bind(this)));
     this._lastFileUri = this.getEditorUri();
+    this.didOpen();
   }
 
   // The change tracking disposable listener that will ensure that changes are sent to the
@@ -270,10 +252,6 @@ class TextEditorSyncAdapter {
     this._connection.didSaveTextDocument({textDocument: {uri: this.getEditorUri()}});
     // TODO: Move this to a file watching event once Atom has API support.
     this._connection.didChangeWatchedFiles({changes: [{uri: this.getEditorUri(), type: FileChangeType.Changed}]}); // Replace with file watch
-
-    if (!this._lastFileUri) {
-      this.setupFileRenameTracking();
-    }
   }
 
   didRename() {


### PR DESCRIPTION
Somehow this missed the last PR :(

Released under CC0