### PR TITLE
[RFC] Lint clean and enable Prettier

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,3 +1,24 @@
 module.exports = {
-    "extends": "fbjs-opensource"
+  'extends': [
+    'fbjs-opensource',
+    'prettier',
+  ],
+  'plugins': [
+    'flowtype',
+    'prettier',
+  ],
+  'rules': {
+    'babel/no-await-in-loop': 0,
+    'camelcase': 0,
+    'flowtype/no-weak-types': 0,
+    'no-new': 0,
+    'prettier/prettier': [1, {
+      'bracketSpacing': false,
+      'jsxBracketSameLine': true,
+      'parser': 'flow',
+      'printWidth': 120,
+      'singleQuote': true,
+      'trailingComma': 'all',
+    }],
+  },
 };

--- a/lib/adapters/autocomplete-adapter.js
+++ b/lib/adapters/autocomplete-adapter.js
@@ -7,7 +7,7 @@ import {
   type CompletionList,
   type TextDocumentPositionParams,
   type TextEdit,
-  type ServerCapabilities
+  type ServerCapabilities,
 } from '../languageclient';
 import Convert from '../convert';
 
@@ -26,8 +26,13 @@ export default class AutocompleteAdapter {
   //
   // Returns a {Promise} of an {Array} of {Object}s containing the AutoComplete+
   // suggestions to display.
-  async getSuggestions(connection: LanguageClientConnection, request: atom$AutocompleteRequest): Promise<Array<atom$AutocompleteSuggestion>> {
-    const completionItems = await connection.completion(AutocompleteAdapter.requestToTextDocumentPositionParams(request));
+  async getSuggestions(
+    connection: LanguageClientConnection,
+    request: atom$AutocompleteRequest,
+  ): Promise<Array<atom$AutocompleteSuggestion>> {
+    const completionItems = await connection.completion(
+      AutocompleteAdapter.requestToTextDocumentPositionParams(request),
+    );
     return AutocompleteAdapter.completionItemsToSuggestions(completionItems, request);
   }
 
@@ -54,9 +59,13 @@ export default class AutocompleteAdapter {
   // * `request` An {Object} with the AutoComplete+ request to use.
   //
   // Returns an {Array} of AutoComplete+ suggestions.
-  static completionItemsToSuggestions(completionItems: Array<CompletionItem> | CompletionList, request: atom$AutocompleteRequest): Array<atom$AutocompleteSuggestion> {
-    return (Array.isArray(completionItems) ? completionItems : completionItems.items || [])
-      .map(s => AutocompleteAdapter.completionItemToSuggestion(s, request));
+  static completionItemsToSuggestions(
+    completionItems: Array<CompletionItem> | CompletionList,
+    request: atom$AutocompleteRequest,
+  ): Array<atom$AutocompleteSuggestion> {
+    return (Array.isArray(completionItems) ? completionItems : completionItems.items || []).map(s =>
+      AutocompleteAdapter.completionItemToSuggestion(s, request),
+    );
   }
 
   // Public: Convert a language server protocol CompletionItem to an AutoComplete+ suggestion.
@@ -66,7 +75,10 @@ export default class AutocompleteAdapter {
   // * `request` An {Object} with the AutoComplete+ request to use.
   //
   // Returns an AutoComplete+ suggestion.
-  static completionItemToSuggestion(item: CompletionItem, request: atom$AutocompleteRequest): atom$AutocompleteSuggestion {
+  static completionItemToSuggestion(
+    item: CompletionItem,
+    request: atom$AutocompleteRequest,
+  ): atom$AutocompleteSuggestion {
     const suggestion = AutocompleteAdapter.basicCompletionItemToSuggestion(item);
     AutocompleteAdapter.applyTextEditToSuggestion(item.textEdit, request.editor, suggestion);
     // TODO: Snippets
@@ -80,7 +92,7 @@ export default class AutocompleteAdapter {
   //
   // Returns an AutoComplete+ suggestion.
   static basicCompletionItemToSuggestion(item: CompletionItem): atom$AutocompleteSuggestion {
-    //noinspection JSAnnotator
+    // noinspection JSAnnotator
     return {
       text: item.insertText || item.label,
       displayText: item.label,
@@ -88,7 +100,7 @@ export default class AutocompleteAdapter {
       type: AutocompleteAdapter.completionKindToSuggestionType(item.kind),
       leftLabel: item.detail,
       description: item.documentation,
-      descriptionMarkdown: item.documentation
+      descriptionMarkdown: item.documentation,
     };
   }
 
@@ -98,7 +110,11 @@ export default class AutocompleteAdapter {
   // * `textEdit` A {TextEdit} from a CompletionItem to apply.
   // * `editor` An Atom {TextEditor} used to obtain the necessary text replacement.
   // * `suggestion` An AutoComplete+ suggestion to set the replacementPrefix and text properties of.
-  static applyTextEditToSuggestion(textEdit: ?TextEdit, editor: atom$TextEditor, suggestion: atom$AutocompleteSuggestion): void {
+  static applyTextEditToSuggestion(
+    textEdit: ?TextEdit,
+    editor: atom$TextEditor,
+    suggestion: atom$AutocompleteSuggestion,
+  ): void {
     if (textEdit != null) {
       suggestion.replacementPrefix = editor.getTextInBufferRange(Convert.lsRangeToAtomRange(textEdit.range));
       suggestion.text = textEdit.newText;

--- a/lib/adapters/code-format-adapter.js
+++ b/lib/adapters/code-format-adapter.js
@@ -6,14 +6,13 @@ import {
   type DocumentRangeFormattingParams,
   type FormattingOptions,
   type ServerCapabilities,
-  type TextEdit
+  type TextEdit,
 } from '../languageclient';
 import Convert from '../convert';
 
 // Public: Adapts the language server protocol "textDocument/completion" to the
 // Atom IDE UI Code-format package.
 export default class CodeFormatAdapter {
-
   // Public: Determine whether this adapter can be used to adapt a language server
   // based on the serverCapabilities matrix containing either a documentFormattingProvider
   // or a documentRangeFormattingProvider.
@@ -23,7 +22,10 @@ export default class CodeFormatAdapter {
   // Returns a {Boolean} indicating this adapter can adapt the server based on the
   // given serverCapabilities.
   static canAdapt(serverCapabilities: ServerCapabilities): boolean {
-    return serverCapabilities.documentRangeFormattingProvider === true || serverCapabilities.documentFormattingProvider === true;
+    return (
+      serverCapabilities.documentRangeFormattingProvider === true ||
+      serverCapabilities.documentFormattingProvider === true
+    );
   }
 
   // Public: Format text in the editor using the given language server connection and an optional range.
@@ -36,7 +38,12 @@ export default class CodeFormatAdapter {
   //
   // Returns a {Promise} of an {Array} of {Object}s containing the AutoComplete+
   // suggestions to display.
-  static format(connection: LanguageClientConnection, serverCapabilities: ServerCapabilities, editor: atom$TextEditor, range: atom$Range): Promise<Array<nuclide$TextEdit>> {
+  static format(
+    connection: LanguageClientConnection,
+    serverCapabilities: ServerCapabilities,
+    editor: atom$TextEditor,
+    range: atom$Range,
+  ): Promise<Array<nuclide$TextEdit>> {
     if (serverCapabilities.documentRangeFormattingProvider) {
       return CodeFormatAdapter.formatRange(connection, editor, range);
     }
@@ -55,7 +62,10 @@ export default class CodeFormatAdapter {
   //
   // Returns a {Promise} of an {Array} of {TextEdit} objects that can be applied to the Atom TextEditor
   // to format the document.
-  static async formatDocument(connection: LanguageClientConnection, editor: atom$TextEditor): Promise<Array<nuclide$TextEdit>> {
+  static async formatDocument(
+    connection: LanguageClientConnection,
+    editor: atom$TextEditor,
+  ): Promise<Array<nuclide$TextEdit>> {
     const edits = await connection.documentFormatting(CodeFormatAdapter.createDocumentFormattingParams(editor));
     return CodeFormatAdapter.convertLsTextEdits(edits);
   }
@@ -82,8 +92,14 @@ export default class CodeFormatAdapter {
   //
   // Returns a {Promise} of an {Array} of {TextEdit} objects that can be applied to the Atom TextEditor
   // to format the document.
-  static async formatRange(connection: LanguageClientConnection, editor: atom$TextEditor, range: atom$Range): Promise<Array<nuclide$TextEdit>> {
-    const edits = await connection.documentRangeFormatting(CodeFormatAdapter.createDocumentRangeFormattingParams(editor, range));
+  static async formatRange(
+    connection: LanguageClientConnection,
+    editor: atom$TextEditor,
+    range: atom$Range,
+  ): Promise<Array<nuclide$TextEdit>> {
+    const edits = await connection.documentRangeFormatting(
+      CodeFormatAdapter.createDocumentRangeFormattingParams(editor, range),
+    );
     return CodeFormatAdapter.convertLsTextEdits(edits);
   }
 
@@ -96,7 +112,10 @@ export default class CodeFormatAdapter {
   // Returns {DocumentRangeFormattingParams} containing the identity of the text document, the
   // range of the text to be formatted as well as the options to be used in formatting the
   // document such as tab size and tabs vs spaces.
-  static createDocumentRangeFormattingParams(editor: atom$TextEditor, range: atom$Range): DocumentRangeFormattingParams {
+  static createDocumentRangeFormattingParams(
+    editor: atom$TextEditor,
+    range: atom$Range,
+  ): DocumentRangeFormattingParams {
     return {
       textDocument: Convert.editorToTextDocumentIdentifier(editor),
       range: Convert.atomRangeToLSRange(range),
@@ -139,7 +158,7 @@ export default class CodeFormatAdapter {
   static convertLsTextEdit(textEdit: TextEdit): nuclide$TextEdit {
     return {
       oldRange: Convert.lsRangeToAtomRange(textEdit.range),
-      newText: textEdit.newText
-    }
+      newText: textEdit.newText,
+    };
   }
 }

--- a/lib/adapters/datatip-adapter.js
+++ b/lib/adapters/datatip-adapter.js
@@ -1,17 +1,12 @@
 // @flow
 
-import {
-  LanguageClientConnection,
-  type MarkedString,
-  type ServerCapabilities,
-} from '../languageclient';
+import {LanguageClientConnection, type MarkedString, type ServerCapabilities} from '../languageclient';
 import Convert from '../convert';
 import Utils from '../utils';
 
 // Public: Adapts the language server protocol "textDocument/hover" to the
 // Atom IDE UI Datatip package.
 export default class DatatipAdapter {
-
   // Public: Determine whether this adapter can be used to adapt a language server
   // based on the serverCapabilities matrix containing a hoverProvider.
   //
@@ -37,10 +32,7 @@ export default class DatatipAdapter {
     editor: atom$TextEditor,
     point: atom$Point,
   ): Promise<?nuclide$Datatip> {
-    const documentPositionParams = Convert.editorToTextDocumentPositionParams(
-      editor,
-      point,
-    );
+    const documentPositionParams = Convert.editorToTextDocumentPositionParams(editor, point);
 
     const hover = await connection.hover(documentPositionParams);
     if (
@@ -52,30 +44,22 @@ export default class DatatipAdapter {
       return null;
     }
 
-    const range = hover.range == null
-      ? Utils.getWordAtPosition(editor, point)
-      : Convert.lsRangeToAtomRange(hover.range);
+    const range =
+      hover.range == null ? Utils.getWordAtPosition(editor, point) : Convert.lsRangeToAtomRange(hover.range);
 
-    const markedStrings = (Array.isArray(hover.contents)
-      ? hover.contents
-      : [hover.contents]).map(str =>
+    const markedStrings = (Array.isArray(hover.contents) ? hover.contents : [hover.contents]).map(str =>
       DatatipAdapter.convertMarkedString(editor, str),
     );
 
     return {range, markedStrings};
   }
 
-  static convertMarkedString(
-    editor: atom$TextEditor,
-    markedString: MarkedString,
-  ): nuclide$MarkedString {
+  static convertMarkedString(editor: atom$TextEditor, markedString: MarkedString): nuclide$MarkedString {
     if (typeof markedString === 'object') {
       return {
         type: 'snippet',
         // TODO: find a better mapping from language -> grammar
-        grammar: atom.grammars.grammarForScopeName(
-          `source.${markedString.language}`,
-        ) || editor.getGrammar(),
+        grammar: atom.grammars.grammarForScopeName(`source.${markedString.language}`) || editor.getGrammar(),
         value: markedString.value,
       };
     }

--- a/lib/adapters/definition-adapter.js
+++ b/lib/adapters/definition-adapter.js
@@ -1,10 +1,6 @@
 // @flow
 
-import {
-  LanguageClientConnection,
-  type Location,
-  type ServerCapabilities,
-} from '../languageclient';
+import {LanguageClientConnection, type Location, type ServerCapabilities} from '../languageclient';
 import Convert from '../convert';
 import Utils from '../utils';
 import {Range} from 'atom';
@@ -47,7 +43,9 @@ export default class DefinitionAdapter {
     const definitionLocations = DefinitionAdapter.normalizeLocations(
       await connection.gotoDefinition(documentPositionParams),
     );
-    if (definitionLocations == null || definitionLocations.length === 0) { return null; }
+    if (definitionLocations == null || definitionLocations.length === 0) {
+      return null;
+    }
 
     let queryRange;
     if (serverCapabilities.documentHighlightProvider) {
@@ -70,7 +68,9 @@ export default class DefinitionAdapter {
   //
   // Returns an {Array} of {Location}s or {null} if the locationResult was null.
   static normalizeLocations(locationResult: Location | Array<Location>): ?Array<Location> {
-    if (locationResult == null) { return null; }
+    if (locationResult == null) {
+      return null;
+    }
     return (Array.isArray(locationResult) ? locationResult : [locationResult]).filter(d => d.range.start != null);
   }
 

--- a/lib/adapters/document-sync-adapter.js
+++ b/lib/adapters/document-sync-adapter.js
@@ -113,11 +113,11 @@ export default class DocumentSyncAdapter {
     this._disposable.add(sync);
     this._disposable.add(
       editor.onDidDestroy(() => {
-        const sync = this._editors.get(editor);
-        if (sync) {
+        const destroyedSync = this._editors.get(editor);
+        if (destroyedSync) {
           this._editors.delete(editor);
-          this._disposable.remove(sync);
-          sync.dispose();
+          this._disposable.remove(destroyedSync);
+          destroyedSync.dispose();
         }
       }),
     );

--- a/lib/adapters/document-sync-adapter.js
+++ b/lib/adapters/document-sync-adapter.js
@@ -7,7 +7,7 @@ import {
   TextDocumentSyncOptions,
   type TextDocumentContentChangeEvent,
   type VersionedTextDocumentIdentifier,
-  type ServerCapabilities
+  type ServerCapabilities,
 } from '../languageclient';
 import Convert from '../convert';
 import {CompositeDisposable} from 'atom';
@@ -16,7 +16,7 @@ import {CompositeDisposable} from 'atom';
 // each end of changes, opening, closing and other events as well as sending and applying
 // changes either in whole or in part depending on what the language server supports.
 export default class DocumentSyncAdapter {
-  _editorSelector: (atom$TextEditor) => boolean;
+  _editorSelector: atom$TextEditor => boolean;
   _disposable = new CompositeDisposable();
   _documentSyncKind: number;
   _editors: WeakMap<atom$TextEditor, TextEditorSyncAdapter> = new WeakMap();
@@ -35,15 +35,19 @@ export default class DocumentSyncAdapter {
   }
 
   static canAdaptV2(serverCapabilities: ServerCapabilities): boolean {
-    return serverCapabilities.textDocumentSync === TextDocumentSyncKind.Incremental
-        || serverCapabilities.textDocumentSync === TextDocumentSyncKind.Full;
+    return (
+      serverCapabilities.textDocumentSync === TextDocumentSyncKind.Incremental ||
+      serverCapabilities.textDocumentSync === TextDocumentSyncKind.Full
+    );
   }
 
   static canAdaptV3(serverCapabilities: ServerCapabilities): boolean {
     const options = serverCapabilities.textDocumentSync;
-    return options !== null && typeof options === 'object'
-        && (options.change === TextDocumentSyncKind.Incremental
-            || options.change === TextDocumentSyncKind.Full);
+    return (
+      options !== null &&
+      typeof options === 'object' &&
+      (options.change === TextDocumentSyncKind.Incremental || options.change === TextDocumentSyncKind.Full)
+    );
   }
 
   // Public: Create a new {DocumentSyncAdapter} for the given language server.
@@ -52,7 +56,11 @@ export default class DocumentSyncAdapter {
   // * `documentSyncKind` The type of document syncing supported - Full or Incremental.
   // * `editorSelector` A predicate function that takes a {TextEditor} and returns a {boolean}
   //                    indicating whether this adapter should care about the contents of the editor.
-  constructor(connection: LanguageClientConnection, documentSyncKind: ?(TextDocumentSyncOptions | number), editorSelector: atom$TextEditor => boolean) {
+  constructor(
+    connection: LanguageClientConnection,
+    documentSyncKind: ?(TextDocumentSyncOptions | number),
+    editorSelector: atom$TextEditor => boolean,
+  ) {
     this._connection = connection;
     if (typeof documentSyncKind === 'number') {
       this._documentSyncKind = documentSyncKind;
@@ -76,10 +84,12 @@ export default class DocumentSyncAdapter {
   // * `editor` A {TextEditor} to consider for observation.
   observeTextEditor(editor: atom$TextEditor): void {
     const listener = editor.observeGrammar(grammar => this._handleGrammarChange(editor));
-    this._disposable.add(editor.onDidDestroy(() => {
-      this._disposable.remove(listener);
-      listener.dispose();
-    }));
+    this._disposable.add(
+      editor.onDidDestroy(() => {
+        this._disposable.remove(listener);
+        listener.dispose();
+      }),
+    );
     this._disposable.add(listener);
     if (!this._editors.has(editor) && this._editorSelector(editor)) {
       this._handleNewEditor(editor);
@@ -98,17 +108,19 @@ export default class DocumentSyncAdapter {
   }
 
   _handleNewEditor(editor: atom$TextEditor): void {
-    let sync = new TextEditorSyncAdapter(editor, this._connection, this._documentSyncKind);
+    const sync = new TextEditorSyncAdapter(editor, this._connection, this._documentSyncKind);
     this._editors.set(editor, sync);
     this._disposable.add(sync);
-    this._disposable.add(editor.onDidDestroy(() => {
-      let sync = this._editors.get(editor);
-      if (sync) {
-        this._editors.delete(editor);
-        this._disposable.remove(sync);
-        sync.dispose();
-      }
-    }));
+    this._disposable.add(
+      editor.onDidDestroy(() => {
+        const sync = this._editors.get(editor);
+        if (sync) {
+          this._editors.delete(editor);
+          this._disposable.remove(sync);
+          sync.dispose();
+        }
+      }),
+    );
   }
 
   getEditorSyncAdapter(editor: atom$TextEditor): ?TextEditorSyncAdapter {
@@ -183,7 +195,9 @@ class TextEditorSyncAdapter {
   // Ensure when the document is opened we send notification to the language server
   // so it can load it in and keep track of diagnostics etc.
   didOpen(): void {
-    if (this._editor.getURI() == null) return; // Not yet saved
+    if (this._editor.getURI() == null) {
+      return;
+    } // Not yet saved
 
     this._connection.didOpenTextDocument({
       textDocument: {
@@ -240,8 +254,12 @@ class TextEditorSyncAdapter {
   // Called when the {TextEditor} is closed and sends the 'didCloseTextDocument' notification to
   // the connected language server.
   didDestroy(): void {
-    if (this._editor.getURI() == null) return; // Not yet saved
-    this._connection.didCloseTextDocument({textDocument: {uri: this.getEditorUri()}});
+    if (this._editor.getURI() == null) {
+      return;
+    } // Not yet saved
+    this._connection.didCloseTextDocument({
+      textDocument: {uri: this.getEditorUri()},
+    });
   }
 
   // Called when the {TextEditor} saves and sends the 'didSaveTextDocument' notification to
@@ -249,9 +267,13 @@ class TextEditorSyncAdapter {
   // Note: Right now this also sends the `didChangeWatchedFiles` notification as well but that
   // will be sent from elsewhere soon.
   didSave(): void {
-    this._connection.didSaveTextDocument({textDocument: {uri: this.getEditorUri()}});
+    this._connection.didSaveTextDocument({
+      textDocument: {uri: this.getEditorUri()},
+    });
     // TODO: Move this to a file watching event once Atom has API support.
-    this._connection.didChangeWatchedFiles({changes: [{uri: this.getEditorUri(), type: FileChangeType.Changed}]}); // Replace with file watch
+    this._connection.didChangeWatchedFiles({
+      changes: [{uri: this.getEditorUri(), type: FileChangeType.Changed}],
+    }); // Replace with file watch
   }
 
   didRename() {
@@ -261,12 +283,14 @@ class TextEditorSyncAdapter {
       return;
     }
 
-    this._connection.didCloseTextDocument({textDocument: {uri: lastFileUri}});
+    this._connection.didCloseTextDocument({
+      textDocument: {uri: lastFileUri},
+    });
     this._connection.didChangeWatchedFiles({
       changes: [
         {uri: lastFileUri, type: FileChangeType.Deleted},
-        {uri: this.getEditorUri(), type: FileChangeType.Created}
-      ]
+        {uri: this.getEditorUri(), type: FileChangeType.Created},
+      ],
     });
     this._lastFileUri = this.getEditorUri();
 
@@ -274,7 +298,6 @@ class TextEditorSyncAdapter {
     // file path
     this.didOpen();
   }
-
 
   // Public: Obtain the current {TextEditor} path and convert it to a Uri.
   getEditorUri(): string {

--- a/lib/adapters/find-references-adapter.js
+++ b/lib/adapters/find-references-adapter.js
@@ -11,7 +11,6 @@ import Convert from '../convert';
 // Public: Adapts the language server definition provider to the
 // Atom IDE UI Definitions package for 'Go To Definition' functionality.
 export default class FindReferencesAdapter {
-
   // Public: Determine whether this adapter can be used to adapt a language server
   // based on the serverCapabilities matrix containing a referencesProvider.
   //
@@ -33,9 +32,18 @@ export default class FindReferencesAdapter {
   //
   // Returns a {Promise} containing a {FindReferencesReturn} with all the references the language server
   // could find.
-  async getReferences(connection: LanguageClientConnection, editor: atom$TextEditor, point: atom$Point, projectRoot: ?string): Promise<?nuclide$FindReferencesReturn> {
-    const locations = await connection.findReferences(FindReferencesAdapter.createTextDocumentPositionParams(editor, point));
-    if (locations == null) { return null; }
+  async getReferences(
+    connection: LanguageClientConnection,
+    editor: atom$TextEditor,
+    point: atom$Point,
+    projectRoot: ?string,
+  ): Promise<?nuclide$FindReferencesReturn> {
+    const locations = await connection.findReferences(
+      FindReferencesAdapter.createTextDocumentPositionParams(editor, point),
+    );
+    if (locations == null) {
+      return null;
+    }
 
     const references = locations.map(FindReferencesAdapter.locationToReference);
     return {
@@ -56,7 +64,7 @@ export default class FindReferencesAdapter {
     return {
       textDocument: Convert.editorToTextDocumentIdentifier(editor),
       position: Convert.pointToPosition(point),
-      context: {includeDeclaration: true}
+      context: {includeDeclaration: true},
     };
   }
 
@@ -74,8 +82,14 @@ export default class FindReferencesAdapter {
   }
 
   // Public: Get a symbol name from a {TextEditor} for a specific {Point} in the document.
-  static getReferencedSymbolName(editor: atom$TextEditor, point: atom$Point, references: Array<nuclide$Reference>): string {
-    if (references.length === 0) { return ''; }
+  static getReferencedSymbolName(
+    editor: atom$TextEditor,
+    point: atom$Point,
+    references: Array<nuclide$Reference>,
+  ): string {
+    if (references.length === 0) {
+      return '';
+    }
     const currentReference = references.find(r => r.range.containsPoint(point)) || references[0];
     return editor.getBuffer().getTextInRange(currentReference.range);
   }

--- a/lib/adapters/linter-push-v2-adapter.js
+++ b/lib/adapters/linter-push-v2-adapter.js
@@ -5,7 +5,7 @@ import {
   LanguageClientConnection,
   type Diagnostic,
   type PublishDiagnosticsParams,
-  type ServerCapabilities
+  type ServerCapabilities,
 } from '../languageclient';
 import Convert from '../convert';
 
@@ -29,7 +29,9 @@ export default class LinterPushV2Adapter {
   attach(indie: linter$V2IndieDelegate): void {
     this._indies.add(indie);
     this._diagnosticMap.forEach((value, key) => indie.setMessages(key, value));
-    indie.onDidDestroy(() => { this._indies.delete(indie) });
+    indie.onDidDestroy(() => {
+      this._indies.delete(indie);
+    });
   }
 
   // Public: Capture the diagnostics sent from a langguage server, convert them to the

--- a/lib/adapters/linter-push-v2-adapter.js
+++ b/lib/adapters/linter-push-v2-adapter.js
@@ -5,7 +5,6 @@ import {
   LanguageClientConnection,
   type Diagnostic,
   type PublishDiagnosticsParams,
-  type ServerCapabilities,
 } from '../languageclient';
 import Convert from '../convert';
 

--- a/lib/adapters/notifications-adapter.js
+++ b/lib/adapters/notifications-adapter.js
@@ -4,7 +4,6 @@ import {
   LanguageClientConnection,
   MessageType,
   type MessageActionItem,
-  type ServerCapabilities,
   type ShowMessageParams,
   type ShowMessageRequestParams,
 } from '../languageclient';
@@ -20,7 +19,6 @@ export default class NotificationsAdapter {
 
   static onShowMessageRequest(params: ShowMessageRequestParams, name: string): Promise<?MessageActionItem> {
     return new Promise((resolve, reject) => {
-      let notification: ?atom$Notification;
       const options: atom$NotificationOptions = {
         dismissable: true,
         detail: name,
@@ -37,7 +35,7 @@ export default class NotificationsAdapter {
         }));
       }
 
-      notification = addNotificationForMessage(params.type, params.message, {
+      const notification = addNotificationForMessage(params.type, params.message, {
         dismissable: true,
         detail: name,
       });
@@ -88,7 +86,7 @@ function addNotificationForMessage(
       return atom.notifications.addWarning(message, options);
     case MessageType.Log:
       // console.log(params.message);
-      return;
+      return null;
     case MessageType.Info:
     default:
       return atom.notifications.addInfo(message, options);

--- a/lib/adapters/notifications-adapter.js
+++ b/lib/adapters/notifications-adapter.js
@@ -6,7 +6,7 @@ import {
   type MessageActionItem,
   type ServerCapabilities,
   type ShowMessageParams,
-  type ShowMessageRequestParams
+  type ShowMessageRequestParams,
 } from '../languageclient';
 
 // Public: Adapts Atom's user notifications to those of the language server protocol.
@@ -21,14 +21,17 @@ export default class NotificationsAdapter {
   static onShowMessageRequest(params: ShowMessageRequestParams, name: string): Promise<?MessageActionItem> {
     return new Promise((resolve, reject) => {
       let notification: ?atom$Notification;
-      const options: atom$NotificationOptions = {dismissable: true, detail: name};
+      const options: atom$NotificationOptions = {
+        dismissable: true,
+        detail: name,
+      };
       if (params.actions) {
         options.buttons = params.actions.map(a => ({
           text: a.title,
           onDidClick: () => {
             resolve(a);
             if (notification != null) {
-              notification.dismiss()
+              notification.dismiss();
             }
           },
         }));
@@ -36,11 +39,13 @@ export default class NotificationsAdapter {
 
       notification = addNotificationForMessage(params.type, params.message, {
         dismissable: true,
-        detail: name
+        detail: name,
       });
 
       if (notification != null) {
-        notification.onDidDismiss(() => { resolve(null) });
+        notification.onDidDismiss(() => {
+          resolve(null);
+        });
       }
     });
   }
@@ -54,7 +59,7 @@ export default class NotificationsAdapter {
   static onShowMessage(params: ShowMessageParams, name: string): void {
     addNotificationForMessage(params.type, params.message, {
       dismissable: true,
-      detail: name
+      detail: name,
     });
   }
 
@@ -67,11 +72,15 @@ export default class NotificationsAdapter {
   static actionItemToNotificationButton(actionItem: MessageActionItem): atom$NotificationButton {
     return {
       text: actionItem.title,
-    }
+    };
   }
 }
 
-function addNotificationForMessage(messageType: number, message: string, options: atom$NotificationOptions): ?atom$Notification {
+function addNotificationForMessage(
+  messageType: number,
+  message: string,
+  options: atom$NotificationOptions,
+): ?atom$Notification {
   switch (messageType) {
     case MessageType.Error:
       return atom.notifications.addError(message, options);

--- a/lib/adapters/outline-view-adapter.js
+++ b/lib/adapters/outline-view-adapter.js
@@ -1,23 +1,17 @@
 // @flow
 
-import {
-  LanguageClientConnection,
-  SymbolKind,
-  type ServerCapabilities,
-  type SymbolInformation
-} from '../languageclient';
+import {LanguageClientConnection, SymbolKind, type ServerCapabilities, type SymbolInformation} from '../languageclient';
 import Convert from '../convert';
 import {Point} from 'atom';
 
 type ContainerNamedOutline = {
   containerName: ?string,
-  outline: nuclide$OutlineTree
+  outline: nuclide$OutlineTree,
 };
 
 // Public: Adapts the documentSymbolProvider of the language server to the Outline View
 // supplied by Atom IDE UI.
 export default class OutlineViewAdapter {
-
   // Public: Determine whether this adapter can be used to adapt a language server
   // based on the serverCapabilities matrix containing a documentSymbolProvider.
   //
@@ -38,10 +32,12 @@ export default class OutlineViewAdapter {
   //
   // Returns a {Promise} containing the {Outline} of this document.
   async getOutline(connection: LanguageClientConnection, editor: atom$TextEditor): Promise<?nuclide$Outline> {
-    const results = await connection.documentSymbol({textDocument: Convert.editorToTextDocumentIdentifier(editor)});
+    const results = await connection.documentSymbol({
+      textDocument: Convert.editorToTextDocumentIdentifier(editor),
+    });
     return {
       outlineTrees: OutlineViewAdapter.createOutlineTrees(results),
-    }
+    };
   }
 
   // Public: Create an {Array} of {OutlineTree}s from the Array of {SymbolInformation} recieved
@@ -71,8 +67,8 @@ export default class OutlineViewAdapter {
           if (rootContainer == null) {
             rootContainer = {
               plainText: containerName,
-              children: [ ],
-              startPosition: new Point(0, 0)
+              children: [],
+              startPosition: new Point(0, 0),
             };
             roots.set(containerName, rootContainer);
           }
@@ -95,7 +91,7 @@ export default class OutlineViewAdapter {
     return symbols.reduce((map, symbol) => {
       map.set(symbol.name, {
         containerName: symbol.containerName,
-        outline: OutlineViewAdapter.symbolToOutline(symbol)
+        outline: OutlineViewAdapter.symbolToOutline(symbol),
       });
       return map;
     }, new Map());
@@ -108,18 +104,20 @@ export default class OutlineViewAdapter {
   //
   // Returns the {OutlineTree} equivalent to the given {SymbolInformation}.
   static symbolToOutline(symbol: SymbolInformation): nuclide$OutlineTree {
-    const icon = OutlineViewAdapter.symbolKindToEntityKind(symbol.kind)
+    const icon = OutlineViewAdapter.symbolKindToEntityKind(symbol.kind);
     return {
-      tokenizedText: [ {
-        kind: OutlineViewAdapter.symbolKindToTokenKind(symbol.kind),
-        value: symbol.name,
-      } ],
+      tokenizedText: [
+        {
+          kind: OutlineViewAdapter.symbolKindToTokenKind(symbol.kind),
+          value: symbol.name,
+        },
+      ],
       icon: icon != null ? icon : undefined,
       representativeName: symbol.name,
       startPosition: Convert.positionToPoint(symbol.location.range.start),
       endPosition: Convert.positionToPoint(symbol.location.range.end),
       children: [],
-    }
+    };
   }
 
   // Public: Convert a symbol kind into an outline entity kind used to determine
@@ -130,25 +128,44 @@ export default class OutlineViewAdapter {
   // Returns a string representing the equivalent OutlineView entity kind.
   static symbolKindToEntityKind(symbol: number): ?string {
     switch (symbol) {
-      case SymbolKind.Array: return 'type-array';
-      case SymbolKind.Boolean: return 'type-boolean';
-      case SymbolKind.Class: return 'type-class';
-      case SymbolKind.Constant: return 'type-constant';
-      case SymbolKind.Constructor: return 'type-constructor';
-      case SymbolKind.Enum: return 'type-enum';
-      case SymbolKind.Field: return 'type-field';
-      case SymbolKind.File: return 'type-file';
-      case SymbolKind.Function: return 'type-function';
-      case SymbolKind.Interface: return 'type-interface';
-      case SymbolKind.Method: return 'type-method';
-      case SymbolKind.Module: return 'type-module';
-      case SymbolKind.Namespace: return 'type-namespace';
-      case SymbolKind.Number: return 'type-number';
-      case SymbolKind.Package: return 'type-package';
-      case SymbolKind.Property: return 'type-property';
-      case SymbolKind.String: return 'type-string';
-      case SymbolKind.Variable: return 'type-variable';
-      default: return null;
+      case SymbolKind.Array:
+        return 'type-array';
+      case SymbolKind.Boolean:
+        return 'type-boolean';
+      case SymbolKind.Class:
+        return 'type-class';
+      case SymbolKind.Constant:
+        return 'type-constant';
+      case SymbolKind.Constructor:
+        return 'type-constructor';
+      case SymbolKind.Enum:
+        return 'type-enum';
+      case SymbolKind.Field:
+        return 'type-field';
+      case SymbolKind.File:
+        return 'type-file';
+      case SymbolKind.Function:
+        return 'type-function';
+      case SymbolKind.Interface:
+        return 'type-interface';
+      case SymbolKind.Method:
+        return 'type-method';
+      case SymbolKind.Module:
+        return 'type-module';
+      case SymbolKind.Namespace:
+        return 'type-namespace';
+      case SymbolKind.Number:
+        return 'type-number';
+      case SymbolKind.Package:
+        return 'type-package';
+      case SymbolKind.Property:
+        return 'type-property';
+      case SymbolKind.String:
+        return 'type-string';
+      case SymbolKind.Variable:
+        return 'type-variable';
+      default:
+        return null;
     }
   }
 

--- a/lib/adapters/outline-view-adapter.js
+++ b/lib/adapters/outline-view-adapter.js
@@ -53,7 +53,7 @@ export default class OutlineViewAdapter {
     const roots: Map<string, nuclide$OutlineTree> = new Map();
     byContainerName.forEach((v, k) => {
       const containerName = v.containerName;
-      if (containerName == '' || containerName == null || k == containerName) {
+      if (containerName === '' || containerName == null || k === containerName) {
         // No container name or contained within itself belong as top-level items
         roots.set(k, v.outline);
       } else {

--- a/lib/auto-languageclient.js
+++ b/lib/auto-languageclient.js
@@ -75,18 +75,16 @@ export default class AutoLanguageClient {
   getInitializeParams(projectPath: string, process: child_process$ChildProcess): ls.InitializeParams {
     return {
       processId: process.pid,
-      capabilities: { },
+      capabilities: {},
       rootPath: projectPath,
     };
   }
 
   // Early wire-up of listeners before initialize method is sent
-  preInitialization(connection: ls.LanguageClientConnection): void {
-  }
+  preInitialization(connection: ls.LanguageClientConnection): void {}
 
   // Late wire-up of listeners after initialize method has been sent
-  postInitialization(server: ActiveServer): void {
-  }
+  postInitialization(server: ActiveServer): void {}
 
   // Determine whether to use ipc, stdio or socket to connect to the server
   getConnectionType(): ConnectionType {
@@ -110,12 +108,12 @@ export default class AutoLanguageClient {
     this._serverManager.dispose();
   }
 
-  spawnChildNode(args: Array<string>, options?: child_process$spawnOpts = { }): child_process$ChildProcess {
-    this.logger.debug(`starting child Node "${args.join(' ')}"`)
-    options.env = options.env || Object.create(process.env)
-    options.env.ELECTRON_RUN_AS_NODE = "1"
-    options.env.ELECTRON_NO_ATTACH_CONSOLE = "1"
-    return cp.spawn(process.execPath, args, options)
+  spawnChildNode(args: Array<string>, options?: child_process$spawnOpts = {}): child_process$ChildProcess {
+    this.logger.debug(`starting child Node "${args.join(' ')}"`);
+    options.env = options.env || Object.create(process.env);
+    options.env.ELECTRON_RUN_AS_NODE = '1';
+    options.env.ELECTRON_NO_ATTACH_CONSOLE = '1';
+    return cp.spawn(process.execPath, args, options);
   }
 
   // By default LSP logging is switched off but you can switch it on via the core.debugLSP setting
@@ -135,7 +133,7 @@ export default class AutoLanguageClient {
       process,
       connection,
       capabilities: initializeResponse.capabilities,
-      disposable: new CompositeDisposable()
+      disposable: new CompositeDisposable(),
     };
     this.postInitialization(newServer);
     this.startExclusiveAdapters(newServer);
@@ -163,7 +161,11 @@ export default class AutoLanguageClient {
       default:
         throw new Error(`Unknown RPC connection type '${connectionType}' - must be 'ipc', 'socket' or 'stdio'`);
     }
-    return rpc.createMessageConnection(reader, writer, {error: m => { this.logger.error(m); }});
+    return rpc.createMessageConnection(reader, writer, {
+      error: m => {
+        this.logger.error(m);
+      },
+    });
   }
 
   // Start adapters that are not shared between servers
@@ -171,8 +173,9 @@ export default class AutoLanguageClient {
     NotificationsAdapter.attach(server.connection, this.name);
 
     if (DocumentSyncAdapter.canAdapt(server.capabilities)) {
-      server.docSyncAdapter = new DocumentSyncAdapter(server.connection, server.capabilities.textDocumentSync,
-              editor => this.shouldSyncForEditor(editor, server.projectPath));
+      server.docSyncAdapter = new DocumentSyncAdapter(server.connection, server.capabilities.textDocumentSync, editor =>
+        this.shouldSyncForEditor(editor, server.projectPath),
+      );
       server.disposable.add(server.docSyncAdapter);
     }
 
@@ -201,7 +204,9 @@ export default class AutoLanguageClient {
 
   async getSuggestions(request: atom$AutocompleteRequest): Promise<Array<atom$AutocompleteSuggestion>> {
     const server = await this._serverManager.getServer(request.editor);
-    if (server == null || !AutocompleteAdapter.canAdapt(server.capabilities) ) { return []; }
+    if (server == null || !AutocompleteAdapter.canAdapt(server.capabilities)) {
+      return [];
+    }
 
     this.autoComplete = this.autoComplete || new AutocompleteAdapter();
     return this.autoComplete.getSuggestions(server.connection, request);
@@ -213,16 +218,24 @@ export default class AutoLanguageClient {
       name: this.name,
       priority: 20,
       grammarScopes: this.getGrammarScopes(),
-      getDefinition: this.getDefinition.bind(this)
+      getDefinition: this.getDefinition.bind(this),
     };
   }
 
   async getDefinition(editor: TextEditor, point: atom$Point): Promise<?nuclide$DefinitionQueryResult> {
     const server = await this._serverManager.getServer(editor);
-    if (server == null || !DefinitionAdapter.canAdapt(server.capabilities)) { return null; }
+    if (server == null || !DefinitionAdapter.canAdapt(server.capabilities)) {
+      return null;
+    }
 
     this.definitions = this.definitions || new DefinitionAdapter();
-    return this.definitions.getDefinition(server.connection, server.capabilities, this.getLanguageName(), editor, point);
+    return this.definitions.getDefinition(
+      server.connection,
+      server.capabilities,
+      this.getLanguageName(),
+      editor,
+      point,
+    );
   }
 
   // Outline View via LS documentSymbol---------------------------------
@@ -237,7 +250,9 @@ export default class AutoLanguageClient {
 
   async getOutline(editor: atom$TextEditor): Promise<?nuclide$Outline> {
     const server = await this._serverManager.getServer(editor);
-    if (server == null || !OutlineViewAdapter.canAdapt(server.capabilities)) { return null; }
+    if (server == null || !OutlineViewAdapter.canAdapt(server.capabilities)) {
+      return null;
+    }
 
     this.outlineView = this.outlineView || new OutlineViewAdapter();
     return this.outlineView.getOutline(server.connection, editor);
@@ -246,9 +261,11 @@ export default class AutoLanguageClient {
   // Linter push v2 API via LS publishDiagnostics
   consumeLinterV2(registerIndie: ({name: string}) => linter$V2IndieDelegate): void {
     this._linterDelegate = registerIndie({name: this.name});
-    if (this._linterDelegate == null) return;
+    if (this._linterDelegate == null) {
+      return;
+    }
 
-    for (var server of this._serverManager.getActiveServers()) {
+    for (const server of this._serverManager.getActiveServers()) {
       if (server.linterPushV2 != null) {
         server.linterPushV2.attach(this._linterDelegate);
       }
@@ -265,7 +282,9 @@ export default class AutoLanguageClient {
 
   async getReferences(editor: atom$TextEditor, point: atom$Point): Promise<?nuclide$FindReferencesReturn> {
     const server = await this._serverManager.getServer(editor);
-    if (server == null || !FindReferencesAdapter.canAdapt(server.capabilities)) { return null; }
+    if (server == null || !FindReferencesAdapter.canAdapt(server.capabilities)) {
+      return null;
+    }
 
     this.findReferences = this.findReferences || new FindReferencesAdapter();
     return this.findReferences.getReferences(server.connection, editor, point, server.projectPath);
@@ -273,20 +292,24 @@ export default class AutoLanguageClient {
 
   // Datatip via LS textDocument/hover----------------------------------
   consumeDatatip(service: nuclide$DatatipService): void {
-    this._disposable.add(service.addProvider({
-      providerName: this.name,
-      priority: 1,
-      grammarScopes: this.getGrammarScopes(),
-      validForScope: (scopeName: string) => {
-        return this.getGrammarScopes().includes(scopeName);
-      },
-      datatip: this.getDatatip.bind(this),
-    }));
+    this._disposable.add(
+      service.addProvider({
+        providerName: this.name,
+        priority: 1,
+        grammarScopes: this.getGrammarScopes(),
+        validForScope: (scopeName: string) => {
+          return this.getGrammarScopes().includes(scopeName);
+        },
+        datatip: this.getDatatip.bind(this),
+      }),
+    );
   }
 
   async getDatatip(editor: atom$TextEditor, point: atom$Point): Promise<?nuclide$Datatip> {
     const server = await this._serverManager.getServer(editor);
-    if (server == null || !DatatipAdapter.canAdapt(server.capabilities)) { return null; }
+    if (server == null || !DatatipAdapter.canAdapt(server.capabilities)) {
+      return null;
+    }
 
     this.datatip = this.datatip || new DatatipAdapter();
     return this.datatip.getDatatip(server.connection, editor, point);
@@ -298,12 +321,14 @@ export default class AutoLanguageClient {
       grammarScopes: this.getGrammarScopes(),
       priority: 1,
       formatCode: this.getCodeFormat.bind(this),
-    }
+    };
   }
 
   async getCodeFormat(editor: atom$TextEditor, range: atom$Range): Promise<Array<nuclide$TextEdit>> {
     const server = await this._serverManager.getServer(editor);
-    if (server == null || !CodeFormatAdapter.canAdapt(server.capabilities)) { return []; }
+    if (server == null || !CodeFormatAdapter.canAdapt(server.capabilities)) {
+      return [];
+    }
 
     return CodeFormatAdapter.format(server.connection, server.capabilities, editor, range);
   }

--- a/lib/auto-languageclient.js
+++ b/lib/auto-languageclient.js
@@ -1,7 +1,6 @@
 // @flow
 
 import * as cp from 'child_process';
-import * as net from 'net';
 import * as ls from './languageclient';
 import * as rpc from 'vscode-jsonrpc';
 import {CompositeDisposable} from 'atom';
@@ -169,7 +168,7 @@ export default class AutoLanguageClient {
   }
 
   // Start adapters that are not shared between servers
-  async startExclusiveAdapters(server: ActiveServer): Promise<void> {
+  startExclusiveAdapters(server: ActiveServer): void {
     NotificationsAdapter.attach(server.connection, this.name);
 
     if (DocumentSyncAdapter.canAdapt(server.capabilities)) {

--- a/lib/convert.js
+++ b/lib/convert.js
@@ -6,7 +6,6 @@ import {Point, Range} from 'atom';
 // Public: Class that contains a number of helper methods for general conversions
 // between the language server protocol and Atom/Atom packages.
 export default class Convert {
-
   // Public: Convert a path to a Uri.
   //
   // * `filePath` A file path to convert to a Uri.
@@ -73,7 +72,10 @@ export default class Convert {
   //
   // Returns the language server {Range} representation of the given Atom {Range}.
   static atomRangeToLSRange(range: atom$Range): ls.Range {
-    return {start: Convert.pointToPosition(range.start), end: Convert.pointToPosition(range.end)};
+    return {
+      start: Convert.pointToPosition(range.start),
+      end: Convert.pointToPosition(range.end),
+    };
   }
 
   // Public: Create a {TextDocumentIdentifier} from an Atom {TextEditor}.
@@ -94,7 +96,10 @@ export default class Convert {
   //
   // Returns a {TextDocumentPositionParams} that has textDocument property with the editors {TextDocumentIdentifier}
   // and a position property with the supplied point (or current cursor position when not specified).
-  static editorToTextDocumentPositionParams(editor: atom$TextEditor, point: ?atom$Point): ls.TextDocumentPositionParams {
+  static editorToTextDocumentPositionParams(
+    editor: atom$TextEditor,
+    point: ?atom$Point,
+  ): ls.TextDocumentPositionParams {
     return {
       textDocument: Convert.editorToTextDocumentIdentifier(editor),
       position: Convert.pointToPosition(point != null ? point : editor.getCursorBufferPosition()),
@@ -109,8 +114,9 @@ export default class Convert {
   // Returns a single comma-separated list of CSS selectors targetting the grammars of Atom text editors.
   // e.g. `['c', 'cpp']` => `'atom-text-editor[data-grammar='c'], atom-text-editor[data-grammar='cpp']`
   static grammarScopesToTextEditorScopes(grammarScopes: Array<string>): string {
-    return grammarScopes.map(g =>
-      `atom-text-editor[data-grammar="${Convert.encodeHTMLAttribute(g.replace(/\./g, ' '))}"]`).join(', ');
+    return grammarScopes
+      .map(g => `atom-text-editor[data-grammar="${Convert.encodeHTMLAttribute(g.replace(/\./g, ' '))}"]`)
+      .join(', ');
   }
 
   // Public: Encode a string so that it can be safely used within a HTML attribute - i.e. replacing all quoted
@@ -121,7 +127,13 @@ export default class Convert {
   // Returns a string that is HTML attribute encoded by replacing &, <, >, " and ' with their HTML entity
   // named equivalents.
   static encodeHTMLAttribute(s: string): string {
-    const attributeMap = {'&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&apos;'};
+    const attributeMap = {
+      '&': '&amp;',
+      '<': '&lt;',
+      '>': '&gt;',
+      '"': '&quot;',
+      "'": '&apos;',
+    };
     return s.replace(/[&<>'"]/g, c => attributeMap[c]);
   }
 }

--- a/lib/download-file.js
+++ b/lib/download-file.js
@@ -13,7 +13,12 @@ import fs from 'fs';
 //                      percentage on the callback can not be determined.
 //
 // Returns a {Promise} that will accept when complete.
-export default async function downloadFile(sourceUrl: string, targetFile: string, progressCallback: ?ByteProgressCallback, length: ?number): Promise<void> {
+export default (async function downloadFile(
+  sourceUrl: string,
+  targetFile: string,
+  progressCallback: ?ByteProgressCallback,
+  length: ?number,
+): Promise<void> {
   const request = new Request(sourceUrl, {
     headers: new Headers({'Content-Type': 'application/octet-stream'}),
   });
@@ -34,7 +39,7 @@ export default async function downloadFile(sourceUrl: string, targetFile: string
 
   await streamWithProgress(finalLength, reader, writer, progressCallback);
   writer.end();
-}
+});
 
 // Stream from a {ReadableStreamReader} to a {WriteStream} with progress callback.
 //
@@ -45,7 +50,12 @@ export default async function downloadFile(sourceUrl: string, targetFile: string
 //                      both bytesDone and percent.
 //
 // Returns a {Promise} that will accept when complete.
-async function streamWithProgress(length: number, reader: ReadableStreamReader, writer: fs.WriteStream, progressCallback: ?ByteProgressCallback): Promise<void> {
+async function streamWithProgress(
+  length: number,
+  reader: ReadableStreamReader,
+  writer: fs.WriteStream,
+  progressCallback: ?ByteProgressCallback,
+): Promise<void> {
   let bytesDone = 0;
 
   while (true) {

--- a/lib/languageclient.js
+++ b/lib/languageclient.js
@@ -90,7 +90,6 @@ export class LanguageClientConnection {
     this._onNotification({method: 'window/logMessage'}, callback);
   }
 
-
   // Public: Register a callback for the 'telemetry/event' message.
   //
   // * `callback` The function to be called when the 'telemetry/event' message is
@@ -309,7 +308,7 @@ export type TextEdit = {
 
 export type WorkspaceEdit = {
   // Holds changes to existing resources.
-  changes: { [uri: string]: TextEdit[] },
+  changes: {[uri: string]: TextEdit[]},
 };
 
 export type TextDocumentIdentifier = {
@@ -357,8 +356,7 @@ export type InitializeParams = {
   capabilities: ClientCapabilities,
 };
 
-export type ClientCapabilities = {
-};
+export type ClientCapabilities = {};
 
 export type InitializeResult = {
   //  The capabilities the language server provides.
@@ -384,34 +382,34 @@ export const TextDocumentSyncKind = {
 };
 
 export interface SaveOptions {
-	/**
+  /**
 	 * The client is supposed to include the content on save.
 	 */
-	includeText?: boolean;
+  includeText?: boolean,
 }
 
 export interface TextDocumentSyncOptions {
-	/**
+  /**
 	 * Open and close notifications are sent to the server.
 	 */
-	openClose?: boolean;
-	/**
+  openClose?: boolean,
+  /**
 	 * Change notificatins are sent to the server. See TextDocumentSyncKind.None, TextDocumentSyncKind.Full
 	 * and TextDocumentSyncKindIncremental.
 	 */
-	change?: number;
-	/**
+  change?: number,
+  /**
 	 * Will save notifications are sent to the server.
 	 */
-	willSave?: boolean;
-	/**
+  willSave?: boolean,
+  /**
 	 * Will save wait until requests are sent to the server.
 	 */
-	willSaveWaitUntil?: boolean;
-	/**
+  willSaveWaitUntil?: boolean,
+  /**
 	 * Save notifications are sent to the server.
 	 */
-	save?: SaveOptions;
+  save?: SaveOptions,
 }
 
 // Completion options.
@@ -480,7 +478,7 @@ export type ServerCapabilities = {
 export type PublishDiagnosticsParams = {
   // The URI for which diagnostic information is reported.
   uri: string,
-   // An array of diagnostic information items.
+  // An array of diagnostic information items.
   diagnostics: Diagnostic[],
 };
 
@@ -571,7 +569,7 @@ export type Hover = {
  * ${value};
  * ```
  */
-export type MarkedString = string | { language: string, value: string };
+export type MarkedString = string | {language: string, value: string};
 
 /**
  * Signature help represents the signature of something

--- a/lib/languageclient.js
+++ b/lib/languageclient.js
@@ -1,15 +1,15 @@
 // @flow
 
-import * as rpc from 'vscode-jsonrpc';
+import * as jsonrpc from 'vscode-jsonrpc';
 import {NullLogger, type Logger} from './logger';
 
 // Flow-typed wrapper around JSONRPC to implement Microsoft Language Server Protocol v2
 // https://github.com/Microsoft/language-server-protocol/blob/master/versions/protocol-2-x.md
 export class LanguageClientConnection {
-  _rpc: rpc.connection;
+  _rpc: jsonrpc.connection;
   _log: Logger;
 
-  constructor(rpc: rpc.connection, logger: ?Logger) {
+  constructor(rpc: jsonrpc.connection, logger: ?Logger) {
     this._rpc = rpc;
     this._log = logger || new NullLogger();
     this.setupLogging();
@@ -25,7 +25,7 @@ export class LanguageClientConnection {
         this._log.warn('rpc.onUnhandledNotification', notification);
       }
     });
-    this._rpc.onNotification(() => this._log.debug('rpc.onNotification', arguments));
+    this._rpc.onNotification((...args) => this._log.debug('rpc.onNotification', args));
   }
 
   dispose(): void {

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -8,6 +8,8 @@ export type Logger = {
   debug(...args: any): void,
 };
 
+/* eslint-disable no-console */
+
 export class ConsoleLogger {
   prefix: string;
 
@@ -35,8 +37,8 @@ export class ConsoleLogger {
     console.log(...this.format(args));
   }
 
-  format(args: any): any {
-    args = args.filter(a => a != null);
+  format(args_: any): any {
+    const args = args_.filter(a => a != null);
     if (typeof args[0] === 'string') {
       if (args.length === 1) {
         return [`${this.prefix} ${args[0]}`];

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -6,7 +6,7 @@ export type Logger = {
   info(...args: any): void,
   log(...args: any): void,
   debug(...args: any): void,
-}
+};
 
 export class ConsoleLogger {
   prefix: string;
@@ -52,9 +52,9 @@ export class ConsoleLogger {
 }
 
 export class NullLogger {
-  warn(...args: any): void { }
-  error(...args: any): void { }
-  info(...args: any): void { }
-  log(...args: any): void { }
-  debug(...args: any): void { }
+  warn(...args: any): void {}
+  error(...args: any): void {}
+  info(...args: any): void {}
+  log(...args: any): void {}
+  debug(...args: any): void {}
 }

--- a/lib/main.js
+++ b/lib/main.js
@@ -7,5 +7,5 @@ module.exports = {
   AutoLanguageClient,
   Convert,
   DownloadFile,
-  LinterPushV2Adapter
+  LinterPushV2Adapter,
 };

--- a/lib/server-manager.js
+++ b/lib/server-manager.js
@@ -10,14 +10,14 @@ import {CompositeDisposable} from 'atom';
 
 // The necessary elements for a server that has started or is starting.
 export type ActiveServer = {
-  disposable: CompositeDisposable;
-  projectPath: string;
-  process: child_process$ChildProcess;
-  connection: ls.LanguageClientConnection;
-  capabilities: ls.ServerCapabilities;
-  linterPushV2?: LinterPushV2Adapter;
-  docSyncAdapter?: DocumentSyncAdapter;
-}
+  disposable: CompositeDisposable,
+  projectPath: string,
+  process: child_process$ChildProcess,
+  connection: ls.LanguageClientConnection,
+  capabilities: ls.ServerCapabilities,
+  linterPushV2?: LinterPushV2Adapter,
+  docSyncAdapter?: DocumentSyncAdapter,
+};
 
 // Manages the language server lifecycles and their associated objects necessary
 // for adapting them to Atom and Atom IDE UI.
@@ -31,7 +31,11 @@ export class ServerManager {
   _startForEditor: (editor: atom$TextEditor) => boolean;
   _startServer: (projectPath: string) => Promise<ActiveServer>;
 
-  constructor(startServer: (projectPath: string) => Promise<ActiveServer>, logger: Logger, startForEditor: (editor: atom$TextEditor) => boolean) {
+  constructor(
+    startServer: (projectPath: string) => Promise<ActiveServer>,
+    logger: Logger,
+    startForEditor: (editor: atom$TextEditor) => boolean,
+  ) {
     this._startServer = startServer;
     this._logger = logger;
     this._startForEditor = startForEditor;
@@ -61,10 +65,12 @@ export class ServerManager {
       if (server != null) {
         // There LS for the editor (either started now and already running)
         this._editorToServer.set(editor, server);
-        this._disposable.add(editor.onDidDestroy(() => {
-          this._editorToServer.delete(editor);
-          this.stopUnusedServers();
-        }));
+        this._disposable.add(
+          editor.onDidDestroy(() => {
+            this._editorToServer.delete(editor);
+            this.stopUnusedServers();
+          }),
+        );
       }
     }
   }
@@ -76,7 +82,7 @@ export class ServerManager {
     } else {
       // Editor is not supported by the LS
       const server = this._editorToServer.get(editor);
-        // If LS is running for the unsupported editor then disconnect the editor from LS and shut down LS if necessary
+      // If LS is running for the unsupported editor then disconnect the editor from LS and shut down LS if necessary
       if (server) {
         // LS is up for unsupported server
         if (server.docSyncAdapter) {
@@ -98,15 +104,20 @@ export class ServerManager {
     return this._activeServers.slice();
   }
 
-  async getServer(textEditor: atom$TextEditor,
-    {shouldStart}: {shouldStart?: boolean} = {shouldStart: false}): Promise<?ActiveServer> {
+  async getServer(
+    textEditor: atom$TextEditor,
+    {shouldStart}: {shouldStart?: boolean} = {shouldStart: false},
+  ): Promise<?ActiveServer> {
     const finalProjectPath = this.determineProjectPath(textEditor);
-    if (finalProjectPath == null) { // Files not yet saved have no path
+    if (finalProjectPath == null) {
+      // Files not yet saved have no path
       return null;
     }
 
     const foundActiveServer = this._activeServers.find(s => finalProjectPath == s.projectPath);
-    if (foundActiveServer) { return foundActiveServer; }
+    if (foundActiveServer) {
+      return foundActiveServer;
+    }
 
     const startingPromise = this._startingServerPromises.get(finalProjectPath);
     if (startingPromise) {
@@ -137,7 +148,7 @@ export class ServerManager {
   }
 
   async stopAllServers(): Promise<void> {
-    this._logger.debug("Stopping all servers");
+    this._logger.debug('Stopping all servers');
     await Promise.all(this._activeServers.map(s => this.stopServer(s)));
   }
 
@@ -155,7 +166,9 @@ export class ServerManager {
 
   determineProjectPath(textEditor: atom$TextEditor): ?string {
     const filePath = textEditor.getPath();
-    if (filePath == null) { return null; }
+    if (filePath == null) {
+      return null;
+    }
     return this._normalizedProjectPaths.find(d => filePath.startsWith(d));
   }
 

--- a/lib/server-manager.js
+++ b/lib/server-manager.js
@@ -50,7 +50,7 @@ export class ServerManager {
     this._disposable.dispose();
   }
 
-  async observeTextEditors(editor: atom$TextEditor): Promise<void> {
+  observeTextEditors(editor: atom$TextEditor): void {
     // Track grammar changes for opened editors
     const listener = editor.observeGrammar(grammar => this._handleGrammarChange(editor));
     this._disposable.add(editor.onDidDestroy(() => listener.dispose()));
@@ -114,7 +114,7 @@ export class ServerManager {
       return null;
     }
 
-    const foundActiveServer = this._activeServers.find(s => finalProjectPath == s.projectPath);
+    const foundActiveServer = this._activeServers.find(s => finalProjectPath === s.projectPath);
     if (foundActiveServer) {
       return foundActiveServer;
     }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -9,9 +9,7 @@ export default class Utils {
    */
   static getWordAtPosition(editor: TextEditor, position: atom$Point): Range {
     const scopeDescriptor = editor.scopeDescriptorForBufferPosition(position);
-    const nonWordCharacters = Utils.escapeRegExp(
-      editor.getNonWordCharacters(scopeDescriptor),
-    );
+    const nonWordCharacters = Utils.escapeRegExp(editor.getNonWordCharacters(scopeDescriptor));
     const range = Utils._getRegexpRangeAtPosition(
       editor.getBuffer(),
       position,
@@ -28,11 +26,7 @@ export default class Utils {
     return string.replace(/[-/\\^$*+?.()|[\]{}]/g, '\\$&');
   }
 
-  static _getRegexpRangeAtPosition(
-    buffer: atom$TextBuffer,
-    position: atom$Point,
-    wordRegex: RegExp,
-  ): ?Range {
+  static _getRegexpRangeAtPosition(buffer: atom$TextBuffer, position: atom$Point, wordRegex: RegExp): ?Range {
     const {row, column} = position;
     const rowRange = buffer.rangeForRow(row);
     let matchData;

--- a/package.json
+++ b/package.json
@@ -47,9 +47,13 @@
     "chai": "^3.5.0",
     "eslint": "^3.19.0",
     "eslint-config-fbjs-opensource": "^1.0.0",
+    "eslint-config-prettier": "^2.3.0",
+    "eslint-plugin-flowtype": "^2.35.0",
+    "eslint-plugin-prettier": "^2.1.2",
     "flow-bin": "^0.52.0",
     "mocha": "^3.2.0",
     "mocha-appveyor-reporter": "^0.3.0",
+    "prettier": "^1.5.3",
     "sinon": "^2.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -8,9 +8,10 @@
   "scripts": {
     "clean": "rm -rf build",
     "compile": "babel lib --out-dir build/lib && babel test --out-dir build/test",
-    "lint": "flow",
+    "flow": "flow",
+    "lint": "eslint lib test",
     "prepublish": "npm run clean && npm run compile",
-    "test": "npm run compile && atom --test build/test",
+    "test": "npm run compile && npm run lint && atom --test build/test",
     "watch": "babel lib --out-dir build/lib -w"
   },
   "dependencies": {

--- a/script/cibuild
+++ b/script/cibuild
@@ -100,5 +100,8 @@ fi
 echo "Running lint..."
 npm run lint
 
+echo "Running flow..."
+npm run flow
+
 echo "Running specs..."
 "$ATOM_SCRIPT_PATH" --test build/test

--- a/test/adapters/autocomplete-adapter.test.js
+++ b/test/adapters/autocomplete-adapter.test.js
@@ -8,8 +8,12 @@ import {expect} from 'chai';
 import {createSpyConnection, createFakeEditor} from '../helpers.js';
 
 describe('AutoCompleteAdapter', () => {
-  beforeEach(() => { global.sinon = sinon.sandbox.create(); });
-  afterEach(() => { global.sinon.restore(); });
+  beforeEach(() => {
+    global.sinon = sinon.sandbox.create();
+  });
+  afterEach(() => {
+    global.sinon.restore();
+  });
 
   const request: atom$AutocompleteRequest = {
     editor: createFakeEditor(),
@@ -112,7 +116,10 @@ describe('AutoCompleteAdapter', () => {
         detail: 'number',
         documentation: 'a truly useful variable',
         textEdit: {
-          range: {start: {line: 10, character: 20}, end: {line: 30, character: 40}},
+          range: {
+            start: {line: 10, character: 20},
+            end: {line: 30, character: 40},
+          },
           newText: 'newText',
         },
       };
@@ -132,7 +139,9 @@ describe('AutoCompleteAdapter', () => {
       expect(result.replacementPrefix).equals('replacementPrefix');
       expect(result.text).equals('newText');
       expect(autocompleteRequest.editor.getTextInBufferRange.calledOnce).equals(true);
-      expect(autocompleteRequest.editor.getTextInBufferRange.getCall(0).args).deep.equals([new Range(new Point(10, 20), new Point(30, 40))]);
+      expect(autocompleteRequest.editor.getTextInBufferRange.getCall(0).args).deep.equals([
+        new Range(new Point(10, 20), new Point(30, 40)),
+      ]);
     });
   });
 
@@ -181,20 +190,23 @@ describe('AutoCompleteAdapter', () => {
     };
 
     it('does not do anything if there is no textEdit', () => {
-      const completionItem = Object.assign({}, basicCompletionItem);
+      const completionItem = {...basicCompletionItem};
       AutoCompleteAdapter.applyTextEditToSuggestion(null, new TextEditor(), completionItem);
       expect(completionItem).deep.equals(basicCompletionItem);
     });
 
     it('applies changes from TextEdit to replacementPrefix and text', () => {
       const textEdit = {
-        range: {start: {line: 1, character: 2}, end: {line: 3, character: 4}},
+        range: {
+          start: {line: 1, character: 2},
+          end: {line: 3, character: 4},
+        },
         newText: 'newText',
       };
       const editor = new TextEditor();
       sinon.stub(editor, 'getTextInBufferRange').returns('replacementPrefix');
 
-      const completionItem = Object.assign({}, basicCompletionItem);
+      const completionItem = {...basicCompletionItem};
       AutoCompleteAdapter.applyTextEditToSuggestion(textEdit, editor, completionItem);
       expect(completionItem.replacementPrefix).equals('replacementPrefix');
       expect(completionItem.text).equals('newText');

--- a/test/adapters/code-format-adapter.test.js
+++ b/test/adapters/code-format-adapter.test.js
@@ -1,7 +1,6 @@
 // @flow
 
-import invariant from 'assert';
-import {Point, Range} from 'atom';
+import {Range} from 'atom';
 import {expect} from 'chai';
 import sinon from 'sinon';
 import * as ls from '../../lib/languageclient';
@@ -41,7 +40,7 @@ describe('CodeFormatAdapter', () => {
   });
 
   describe('format', () => {
-    it('prefers range formatting if available', async () => {
+    it('prefers range formatting if available', () => {
       const rangeStub = sinon.spy(connection, 'documentRangeFormatting');
       const docStub = sinon.spy(connection, 'documentFormatting');
       CodeFormatAdapter.format(
@@ -57,7 +56,7 @@ describe('CodeFormatAdapter', () => {
       expect(docStub.called).to.be.false;
     });
 
-    it('falls back to document formatting if range formatting not available', async () => {
+    it('falls back to document formatting if range formatting not available', () => {
       const rangeStub = sinon.spy(connection, 'documentRangeFormatting');
       const docStub = sinon.spy(connection, 'documentFormatting');
       CodeFormatAdapter.format(connection, {documentFormattingProvider: true}, fakeEditor, range);
@@ -65,7 +64,7 @@ describe('CodeFormatAdapter', () => {
       expect(docStub.called).to.be.true;
     });
 
-    it('throws if neither range or document formatting are supported', async () => {
+    it('throws if neither range or document formatting are supported', () => {
       expect(() => CodeFormatAdapter.format(connection, {}, fakeEditor, range)).to.throw('');
     });
   });
@@ -167,7 +166,7 @@ describe('CodeFormatAdapter', () => {
       expect(options.tabSize).to.equal(17);
     });
 
-    it('returns the tab size from the editor', () => {
+    it('returns the soft tab setting from the editor', () => {
       sinon.stub(fakeEditor, 'getSoftTabs').returns(true);
       const options = CodeFormatAdapter.getFormatOptions(fakeEditor);
       expect(options.insertSpaces).to.be.true;

--- a/test/adapters/code-format-adapter.test.js
+++ b/test/adapters/code-format-adapter.test.js
@@ -16,22 +16,26 @@ describe('CodeFormatAdapter', () => {
   beforeEach(() => {
     connection = new ls.LanguageClientConnection(createSpyConnection());
     fakeEditor = createFakeEditor();
-    range = new Range([0, 0], [100,100]);
+    range = new Range([0, 0], [100, 100]);
   });
 
   describe('canAdapt', () => {
     it('returns true if range formatting is supported', () => {
-      const result = CodeFormatAdapter.canAdapt({ documentRangeFormattingProvider: true });
+      const result = CodeFormatAdapter.canAdapt({
+        documentRangeFormattingProvider: true,
+      });
       expect(result).to.be.true;
     });
 
     it('returns true if document formatting is supported', () => {
-      const result = CodeFormatAdapter.canAdapt({ documentFormattingProvider: true });
+      const result = CodeFormatAdapter.canAdapt({
+        documentFormattingProvider: true,
+      });
       expect(result).to.be.true;
     });
 
     it('returns false it no formatting supported', () => {
-      const result = CodeFormatAdapter.canAdapt({ });
+      const result = CodeFormatAdapter.canAdapt({});
       expect(result).to.be.false;
     });
   });
@@ -40,7 +44,15 @@ describe('CodeFormatAdapter', () => {
     it('prefers range formatting if available', async () => {
       const rangeStub = sinon.spy(connection, 'documentRangeFormatting');
       const docStub = sinon.spy(connection, 'documentFormatting');
-      CodeFormatAdapter.format(connection, { documentRangeFormattingProvider: true, documentFormattingProvider: true }, fakeEditor, range);
+      CodeFormatAdapter.format(
+        connection,
+        {
+          documentRangeFormattingProvider: true,
+          documentFormattingProvider: true,
+        },
+        fakeEditor,
+        range,
+      );
       expect(rangeStub.called).to.be.true;
       expect(docStub.called).to.be.false;
     });
@@ -48,13 +60,13 @@ describe('CodeFormatAdapter', () => {
     it('falls back to document formatting if range formatting not available', async () => {
       const rangeStub = sinon.spy(connection, 'documentRangeFormatting');
       const docStub = sinon.spy(connection, 'documentFormatting');
-      CodeFormatAdapter.format(connection, { documentFormattingProvider: true }, fakeEditor, range);
+      CodeFormatAdapter.format(connection, {documentFormattingProvider: true}, fakeEditor, range);
       expect(rangeStub.called).to.be.false;
       expect(docStub.called).to.be.true;
     });
 
     it('throws if neither range or document formatting are supported', async () => {
-      expect(() => CodeFormatAdapter.format(connection, { }, fakeEditor, range)).to.throw('');
+      expect(() => CodeFormatAdapter.format(connection, {}, fakeEditor, range)).to.throw('');
     });
   });
 
@@ -66,15 +78,15 @@ describe('CodeFormatAdapter', () => {
             start: {line: 0, character: 1},
             end: {line: 0, character: 2},
           },
-          newText: 'abc'
+          newText: 'abc',
         },
         {
           range: {
             start: {line: 5, character: 10},
             end: {line: 15, character: 20},
           },
-          newText: 'def'
-        }
+          newText: 'def',
+        },
       ]);
       const actual = await CodeFormatAdapter.formatDocument(connection, fakeEditor);
       expect(actual.length).to.equal(2);
@@ -95,7 +107,7 @@ describe('CodeFormatAdapter', () => {
 
       const actual = CodeFormatAdapter.createDocumentFormattingParams(fakeEditor);
 
-      expect(actual.textDocument).to.eql({ uri: 'file:///a/b/c/d.txt' });
+      expect(actual.textDocument).to.eql({uri: 'file:///a/b/c/d.txt'});
       expect(actual.options.tabSize).to.equal(1);
       expect(actual.options.insertSpaces).to.equal(false);
     });
@@ -109,15 +121,15 @@ describe('CodeFormatAdapter', () => {
             start: {line: 0, character: 1},
             end: {line: 0, character: 2},
           },
-          newText: 'abc'
+          newText: 'abc',
         },
         {
           range: {
             start: {line: 5, character: 10},
             end: {line: 15, character: 20},
           },
-          newText: 'def'
-        }
+          newText: 'def',
+        },
       ]);
       const actual = await CodeFormatAdapter.formatRange(connection, fakeEditor, new Range([0, 0], [1, 1]));
       expect(actual.length).to.equal(2);
@@ -136,12 +148,13 @@ describe('CodeFormatAdapter', () => {
       sinon.stub(fakeEditor, 'getTabLength').returns(1);
       sinon.stub(fakeEditor, 'getSoftTabs').returns(false);
 
-      const actual = CodeFormatAdapter
-        .createDocumentRangeFormattingParams(fakeEditor, new Range([1, 0], [2, 3]));
+      const actual = CodeFormatAdapter.createDocumentRangeFormattingParams(fakeEditor, new Range([1, 0], [2, 3]));
 
-      expect(actual.textDocument).to.eql({ uri: 'file:///a/b/c/d.txt' });
-      expect(actual.range).to.eql({ start: { line: 1, character: 0 },
-                                      end: { line: 2, character: 3 }});
+      expect(actual.textDocument).to.eql({uri: 'file:///a/b/c/d.txt'});
+      expect(actual.range).to.eql({
+        start: {line: 1, character: 0},
+        end: {line: 2, character: 3},
+      });
       expect(actual.options.tabSize).to.equal(1);
       expect(actual.options.insertSpaces).to.equal(false);
     });
@@ -165,10 +178,10 @@ describe('CodeFormatAdapter', () => {
     it('returns oldRange and newText from a textEdit', () => {
       const textEdit = {
         range: {
-          start: { line: 1, character: 0 },
-          end: { line: 2, character: 3 }
+          start: {line: 1, character: 0},
+          end: {line: 2, character: 3},
         },
-        newText: 'abc-def'
+        newText: 'abc-def',
       };
       const actual = CodeFormatAdapter.convertLsTextEdit(textEdit);
       expect(actual.oldRange).to.eql(new Range([1, 0], [2, 3]));

--- a/test/adapters/custom-linter-push-v2-adapter.test.js
+++ b/test/adapters/custom-linter-push-v2-adapter.test.js
@@ -9,10 +9,6 @@ const messageUrl = 'dummy';
 const messageSolutions: Array<any> = ['dummy'];
 
 class CustomLinterPushV2Adapter extends LinterPushV2Adapter {
-  constructor(connection) {
-    super(connection);
-  }
-
   diagnosticToV2Message(path, diagnostic) {
     const message = super.diagnosticToV2Message(path, diagnostic);
     message.url = messageUrl;

--- a/test/adapters/custom-linter-push-v2-adapter.test.js
+++ b/test/adapters/custom-linter-push-v2-adapter.test.js
@@ -5,17 +5,16 @@ import * as ls from '../../lib/languageclient';
 import {expect} from 'chai';
 import {Point, Range} from 'atom';
 
-const messageUrl = "dummy";
-const messageSolutions: Array<any> = ["dummy"];
+const messageUrl = 'dummy';
+const messageSolutions: Array<any> = ['dummy'];
 
 class CustomLinterPushV2Adapter extends LinterPushV2Adapter {
-
   constructor(connection) {
     super(connection);
   }
 
   diagnosticToV2Message(path, diagnostic) {
-    var message = super.diagnosticToV2Message(path, diagnostic);
+    const message = super.diagnosticToV2Message(path, diagnostic);
     message.url = messageUrl;
     message.solutions = messageSolutions;
     return message;
@@ -28,14 +27,17 @@ describe('CustomLinterPushV2Adapter', () => {
       const filePath = '/a/b/c/d';
       const diagnostic: ls.Diagnostic = {
         message: 'This is a message',
-        range: {start: {line: 1, character: 2}, end: {line: 3, character: 4}},
+        range: {
+          start: {line: 1, character: 2},
+          end: {line: 3, character: 4},
+        },
         source: 'source',
         code: 'code',
         severity: ls.DiagnosticSeverity.Information,
         type: ls.DiagnosticSeverity.Information,
       };
 
-      const connection: any = { onPublishDiagnostics: function(){} };
+      const connection: any = {onPublishDiagnostics() {}};
       const adapter = new CustomLinterPushV2Adapter(connection);
       const result = adapter.diagnosticToV2Message(filePath, diagnostic);
 

--- a/test/adapters/datatip-adapter.test.js
+++ b/test/adapters/datatip-adapter.test.js
@@ -19,12 +19,12 @@ describe('DatatipAdapter', () => {
 
   describe('canAdapt', () => {
     it('returns true if hoverProvider is supported', () => {
-      const result = DatatipAdapter.canAdapt({ hoverProvider: true });
+      const result = DatatipAdapter.canAdapt({hoverProvider: true});
       expect(result).to.be.true;
     });
 
     it('returns false if hoverProvider not supported', () => {
-      const result = DatatipAdapter.canAdapt({ });
+      const result = DatatipAdapter.canAdapt({});
       expect(result).to.be.false;
     });
   });
@@ -42,11 +42,7 @@ describe('DatatipAdapter', () => {
       const grammarSpy = sinon.spy(atom.grammars, 'grammarForScopeName');
 
       const datatipAdapter = new DatatipAdapter();
-      const datatip = await datatipAdapter.getDatatip(
-        connection,
-        fakeEditor,
-        new Point(0, 0),
-      );
+      const datatip = await datatipAdapter.getDatatip(connection, fakeEditor, new Point(0, 0));
       expect(datatip).to.be.ok;
       invariant(datatip != null);
 

--- a/test/adapters/document-sync-adapter.test.js
+++ b/test/adapters/document-sync-adapter.test.js
@@ -7,32 +7,44 @@ import DocumentSyncAdapter from '../../lib/adapters/document-sync-adapter';
 describe('DocumentSyncAdapter', () => {
   describe('canAdapt', () => {
     it('returns true if v2 incremental change notifications are supported', () => {
-      const result = DocumentSyncAdapter.canAdapt({ textDocumentSync: TextDocumentSyncKind.Incremental });
+      const result = DocumentSyncAdapter.canAdapt({
+        textDocumentSync: TextDocumentSyncKind.Incremental,
+      });
       expect(result).to.be.true;
     });
 
     it('returns true if v2 full change notifications are supported', () => {
-      const result = DocumentSyncAdapter.canAdapt({ textDocumentSync: TextDocumentSyncKind.Full });
+      const result = DocumentSyncAdapter.canAdapt({
+        textDocumentSync: TextDocumentSyncKind.Full,
+      });
       expect(result).to.be.true;
     });
 
     it('returns false if v2 none change notifications are supported', () => {
-      const result = DocumentSyncAdapter.canAdapt({ textDocumentSync: TextDocumentSyncKind.None });
+      const result = DocumentSyncAdapter.canAdapt({
+        textDocumentSync: TextDocumentSyncKind.None,
+      });
       expect(result).to.be.false;
     });
 
     it('returns true if v3 incremental change notifications are supported', () => {
-      const result = DocumentSyncAdapter.canAdapt({ textDocumentSync: { change: TextDocumentSyncKind.Incremental } });
+      const result = DocumentSyncAdapter.canAdapt({
+        textDocumentSync: {change: TextDocumentSyncKind.Incremental},
+      });
       expect(result).to.be.true;
     });
 
     it('returns true if v3 full change notifications are supported', () => {
-      const result = DocumentSyncAdapter.canAdapt({ textDocumentSync: { change: TextDocumentSyncKind.Full } });
+      const result = DocumentSyncAdapter.canAdapt({
+        textDocumentSync: {change: TextDocumentSyncKind.Full},
+      });
       expect(result).to.be.true;
     });
 
     it('returns false if v3 none change notifications are supported', () => {
-      const result = DocumentSyncAdapter.canAdapt({ textDocumentSync: { change: TextDocumentSyncKind.None } });
+      const result = DocumentSyncAdapter.canAdapt({
+        textDocumentSync: {change: TextDocumentSyncKind.None},
+      });
       expect(result).to.be.false;
     });
   });
@@ -53,12 +65,12 @@ describe('DocumentSyncAdapter', () => {
     });
 
     it('sets _documentSyncKind correctly Incremental for v3 capabilities', () => {
-      const result = create({ change: TextDocumentSyncKind.Incremental })._documentSyncKind;
+      const result = create({change: TextDocumentSyncKind.Incremental})._documentSyncKind;
       expect(result).equals(TextDocumentSyncKind.Incremental);
     });
 
     it('sets _documentSyncKind correctly Full for v3 capabilities', () => {
-      const result = create({ change: TextDocumentSyncKind.Full })._documentSyncKind;
+      const result = create({change: TextDocumentSyncKind.Full})._documentSyncKind;
       expect(result).equals(TextDocumentSyncKind.Full);
     });
   });

--- a/test/adapters/linter-push-v2-adapter.test.js
+++ b/test/adapters/linter-push-v2-adapter.test.js
@@ -4,7 +4,6 @@ import LinterPushV2Adapter from '../../lib/adapters/linter-push-v2-adapter';
 import * as ls from '../../lib/languageclient';
 import sinon from 'sinon';
 import {expect} from 'chai';
-import Convert from '../../lib/convert';
 import {Point, Range} from 'atom';
 import {createSpyConnection} from '../helpers.js';
 
@@ -15,30 +14,6 @@ describe('LinterPushV2Adapter', () => {
   afterEach(() => {
     global.sinon.restore();
   });
-
-  const flatMap = (source, lambda) => Array.prototype.concat.apply([], source.map(lambda));
-  const defaultLanguageClient = new ls.LanguageClientConnection(createSpyConnection());
-  const compareLinter = (a: linter$V2Message, b: linter$V2Message): number => {
-    if (a == null) {
-      return 1;
-    }
-    if (b == null) {
-      return -1;
-    }
-    if ((a.location.file || '') < (b.location.file || '')) {
-      return -1;
-    }
-    if ((a.location.file || '') > (b.location.file || '')) {
-      return 1;
-    }
-    if ((a.location.position.start || 0) < (b.location.position.start || 0)) {
-      return -1;
-    }
-    if ((a.location.position.start || 0) > (b.location.position.start || 0)) {
-      return 1;
-    }
-    return 0;
-  };
 
   describe('constructor', () => {
     it('subscribes to onPublishDiagnostics', () => {

--- a/test/adapters/linter-push-v2-adapter.test.js
+++ b/test/adapters/linter-push-v2-adapter.test.js
@@ -9,18 +9,34 @@ import {Point, Range} from 'atom';
 import {createSpyConnection} from '../helpers.js';
 
 describe('LinterPushV2Adapter', () => {
-  beforeEach(() => { global.sinon = sinon.sandbox.create(); });
-  afterEach(() => { global.sinon.restore(); });
+  beforeEach(() => {
+    global.sinon = sinon.sandbox.create();
+  });
+  afterEach(() => {
+    global.sinon.restore();
+  });
 
   const flatMap = (source, lambda) => Array.prototype.concat.apply([], source.map(lambda));
   const defaultLanguageClient = new ls.LanguageClientConnection(createSpyConnection());
   const compareLinter = (a: linter$V2Message, b: linter$V2Message): number => {
-    if (a == null) { return 1; }
-    if (b == null) { return -1; }
-    if ((a.location.file || '') < (b.location.file || '')) { return -1; }
-    if ((a.location.file || '') > (b.location.file || '')) { return 1; }
-    if ((a.location.position.start || 0) < (b.location.position.start || 0)) { return -1; }
-    if ((a.location.position.start || 0) > (b.location.position.start || 0)) { return 1; }
+    if (a == null) {
+      return 1;
+    }
+    if (b == null) {
+      return -1;
+    }
+    if ((a.location.file || '') < (b.location.file || '')) {
+      return -1;
+    }
+    if ((a.location.file || '') > (b.location.file || '')) {
+      return 1;
+    }
+    if ((a.location.position.start || 0) < (b.location.position.start || 0)) {
+      return -1;
+    }
+    if ((a.location.position.start || 0) > (b.location.position.start || 0)) {
+      return 1;
+    }
     return 0;
   };
 
@@ -38,14 +54,17 @@ describe('LinterPushV2Adapter', () => {
       const filePath = '/a/b/c/d';
       const diagnostic: ls.Diagnostic = {
         message: 'This is a message',
-        range: {start: {line: 1, character: 2}, end: {line: 3, character: 4}},
+        range: {
+          start: {line: 1, character: 2},
+          end: {line: 3, character: 4},
+        },
         source: 'source',
         code: 'code',
         severity: ls.DiagnosticSeverity.Information,
         type: ls.DiagnosticSeverity.Information,
       };
 
-      const connection: any = { onPublishDiagnostics: function(){} };
+      const connection: any = {onPublishDiagnostics() {}};
       const adapter = new LinterPushV2Adapter(connection);
       const result = adapter.diagnosticToV2Message(filePath, diagnostic);
 

--- a/test/auto-languageclient.test.js
+++ b/test/auto-languageclient.test.js
@@ -7,7 +7,7 @@ import {expect} from 'chai';
 describe('AutoLanguageClient', () => {
   describe('shouldSyncForEditor', () => {
     class CustomAutoLanguageClient extends AutoLanguageClient {
-      getGrammarScopes () {
+      getGrammarScopes() {
         return ['Java', 'Python'];
       }
     }
@@ -16,29 +16,31 @@ describe('AutoLanguageClient', () => {
 
     function mockEditor(uri, scopeName): any {
       return {
-         getURI: () => uri,
-         getGrammar: () => { return { scopeName: scopeName } }
+        getURI: () => uri,
+        getGrammar: () => {
+          return {scopeName};
+        },
       };
     }
 
     it('selects documents in project and in supported language', () => {
-        const editor = mockEditor("/path/to/somewhere", client.getGrammarScopes()[0]);
-        expect(client.shouldSyncForEditor(editor, "/path/to/somewhere")).equals(true);
+      const editor = mockEditor('/path/to/somewhere', client.getGrammarScopes()[0]);
+      expect(client.shouldSyncForEditor(editor, '/path/to/somewhere')).equals(true);
     });
 
     it('does not select documents outside of project', () => {
-        const editor = mockEditor("/path/to/elsewhere/file", client.getGrammarScopes()[0]);
-        expect(client.shouldSyncForEditor(editor, "/path/to/somewhere")).equals(false);
-    })
+      const editor = mockEditor('/path/to/elsewhere/file', client.getGrammarScopes()[0]);
+      expect(client.shouldSyncForEditor(editor, '/path/to/somewhere')).equals(false);
+    });
 
     it('does not select documents in unsupported language', () => {
-      const editor = mockEditor("/path/to/somewhere", client.getGrammarScopes()[0] + '-dummy');
-      expect(client.shouldSyncForEditor(editor, "/path/to/somewhere")).equals(false);
+      const editor = mockEditor('/path/to/somewhere', client.getGrammarScopes()[0] + '-dummy');
+      expect(client.shouldSyncForEditor(editor, '/path/to/somewhere')).equals(false);
     });
 
     it('does not select documents in unsupported language outside of project', () => {
-      const editor = mockEditor("/path/to/elsewhere/file", client.getGrammarScopes()[0] + '-dummy');
-      expect(client.shouldSyncForEditor(editor, "/path/to/somewhere")).equals(false);
+      const editor = mockEditor('/path/to/elsewhere/file', client.getGrammarScopes()[0] + '-dummy');
+      expect(client.shouldSyncForEditor(editor, '/path/to/somewhere')).equals(false);
     });
   });
 });

--- a/test/auto-languageclient.test.js
+++ b/test/auto-languageclient.test.js
@@ -1,7 +1,6 @@
 // @flow
 
 import AutoLanguageClient from '../lib/auto-languageclient';
-import path from 'path';
 import {expect} from 'chai';
 
 describe('AutoLanguageClient', () => {

--- a/test/convert.test.js
+++ b/test/convert.test.js
@@ -19,8 +19,12 @@ const createFakeEditor = (path: string, text: ?string): atom$TextEditor => {
 };
 
 describe('Convert', () => {
-  beforeEach(() => { originalPlatform = process.platform; });
-  afterEach(() => { Object.defineProperty(process, 'platform', {value: originalPlatform}); });
+  beforeEach(() => {
+    originalPlatform = process.platform;
+  });
+  afterEach(() => {
+    Object.defineProperty(process, 'platform', {value: originalPlatform});
+  });
 
   describe('pathToUri', () => {
     it('prefixes an absolute path with file://', () => {
@@ -148,15 +152,17 @@ describe('Convert', () => {
     it('converts a multiple grammarScopes to a comma-seperated list of atom-text-editor scopes', () => {
       const grammarScopes = ['abc.def', 'ghi.jkl'];
       const textEditorScopes = Convert.grammarScopesToTextEditorScopes(grammarScopes);
-      expect(textEditorScopes)
-        .equals('atom-text-editor[data-grammar="abc def"], atom-text-editor[data-grammar="ghi jkl"]');
+      expect(textEditorScopes).equals(
+        'atom-text-editor[data-grammar="abc def"], atom-text-editor[data-grammar="ghi jkl"]',
+      );
     });
 
     it('converts grammarScopes containing HTML sensitive characters to escaped sequences', () => {
       const grammarScopes = ['abc<def', 'ghi"jkl'];
       const textEditorScopes = Convert.grammarScopesToTextEditorScopes(grammarScopes);
-      expect(textEditorScopes)
-        .equals('atom-text-editor[data-grammar="abc&lt;def"], atom-text-editor[data-grammar="ghi&quot;jkl"]');
+      expect(textEditorScopes).equals(
+        'atom-text-editor[data-grammar="abc&lt;def"], atom-text-editor[data-grammar="ghi&quot;jkl"]',
+      );
     });
   });
 

--- a/test/languageclient.test.js
+++ b/test/languageclient.test.js
@@ -7,8 +7,12 @@ import {expect} from 'chai';
 import {createSpyConnection} from './helpers.js';
 
 describe('LanguageClientConnection', () => {
-  beforeEach(() => { global.sinon = sinon.sandbox.create(); });
-  afterEach(() => { global.sinon.restore(); });
+  beforeEach(() => {
+    global.sinon = sinon.sandbox.create();
+  });
+  afterEach(() => {
+    global.sinon.restore();
+  });
 
   it('listens to the RPC connection it is given', () => {
     const rpc = createSpyConnection();
@@ -38,7 +42,7 @@ describe('LanguageClientConnection', () => {
     });
 
     it('sends a request for initialize', async () => {
-      const params: ls.InitializeParams = {capabilities: { }};
+      const params: ls.InitializeParams = {capabilities: {}};
       await lc.initialize(params);
 
       expect(lc._sendRequest.called).equals(true);
@@ -130,7 +134,10 @@ describe('LanguageClientConnection', () => {
     it('sends a request for codeAction', async () => {
       const params: ls.CodeActionParams = {
         textDocument: textDocumentPositionParams.textDocument,
-        range: {start: {line: 1, character: 1}, end: {line: 24, character: 32}},
+        range: {
+          start: {line: 1, character: 1},
+          end: {line: 24, character: 32},
+        },
         context: {diagnostics: []},
       };
       await lc.codeAction(params);
@@ -153,7 +160,10 @@ describe('LanguageClientConnection', () => {
 
     it('sends a request for codeLensResolve', async () => {
       const params: ls.CodeLens = {
-        range: {start: {line: 1, character: 1}, end: {line: 24, character: 32}},
+        range: {
+          start: {line: 1, character: 1},
+          end: {line: 24, character: 32},
+        },
       };
       await lc.codeLensResolve(params);
 
@@ -175,7 +185,10 @@ describe('LanguageClientConnection', () => {
 
     it('sends a request for documentLinkResolve', async () => {
       const params: ls.DocumentLink = {
-        range: {start: {line: 1, character: 1}, end: {line: 24, character: 32}},
+        range: {
+          start: {line: 1, character: 1},
+          end: {line: 24, character: 32},
+        },
         target: 'abc.def.ghi',
       };
       await lc.documentLinkResolve(params);
@@ -200,7 +213,10 @@ describe('LanguageClientConnection', () => {
     it('sends a request for documentRangeFormatting', async () => {
       const params: ls.DocumentRangeFormattingParams = {
         textDocument: textDocumentPositionParams.textDocument,
-        range: {start: {line: 1, character: 1}, end: {line: 24, character: 32}},
+        range: {
+          start: {line: 1, character: 1},
+          end: {line: 24, character: 32},
+        },
         options: {tabSize: 6, insertSpaces: true, someValue: 'optional'},
       };
       await lc.documentRangeFormatting(params);
@@ -239,7 +255,7 @@ describe('LanguageClientConnection', () => {
   });
 
   describe('send notifications', () => {
-    const textDocumentItem : ls.TextDocumentItem = {
+    const textDocumentItem: ls.TextDocumentItem = {
       uri: 'file:///best/bits.js',
       languageId: 'javascript',
       text: 'function a() { return "b"; };',
@@ -260,7 +276,9 @@ describe('LanguageClientConnection', () => {
     });
 
     it('didChangeConfiguration sends notification', () => {
-      const params: ls.DidChangeConfigurationParams = {settings: {a: {b: 'c'}}};
+      const params: ls.DidChangeConfigurationParams = {
+        settings: {a: {b: 'c'}},
+      };
       lc.didChangeConfiguration(params);
 
       expect(lc._sendNotification.called).equals(true);
@@ -269,7 +287,9 @@ describe('LanguageClientConnection', () => {
     });
 
     it('didOpenTextDocument sends notification', () => {
-      const params: ls.DidOpenTextDocumentParams = {textDocument: textDocumentItem};
+      const params: ls.DidOpenTextDocumentParams = {
+        textDocument: textDocumentItem,
+      };
       lc.didOpenTextDocument(params);
 
       expect(lc._sendNotification.called).equals(true);
@@ -280,7 +300,7 @@ describe('LanguageClientConnection', () => {
     it('didChangeTextDocument sends notification', () => {
       const params: ls.DidChangeTextDocumentParams = {
         textDocument: versionedTextDocumentIdentifier,
-        contentChanges: []
+        contentChanges: [],
       };
       lc.didChangeTextDocument(params);
 
@@ -290,7 +310,9 @@ describe('LanguageClientConnection', () => {
     });
 
     it('didCloseTextDocument sends notification', () => {
-      const params: ls.DidCloseTextDocumentParams = {textDocument: textDocumentItem};
+      const params: ls.DidCloseTextDocumentParams = {
+        textDocument: textDocumentItem,
+      };
       lc.didCloseTextDocument(params);
 
       expect(lc._sendNotification.called).equals(true);
@@ -299,7 +321,9 @@ describe('LanguageClientConnection', () => {
     });
 
     it('didSaveTextDocument sends notification', () => {
-      const params: ls.DidSaveTextDocumentParams = {textDocument: textDocumentItem};
+      const params: ls.DidSaveTextDocumentParams = {
+        textDocument: textDocumentItem,
+      };
       lc.didSaveTextDocument(params);
 
       expect(lc._sendNotification.called).equals(true);
@@ -319,7 +343,7 @@ describe('LanguageClientConnection', () => {
 
   describe('notification methods', () => {
     let lc;
-    const eventMap = { };
+    const eventMap = {};
 
     beforeEach(() => {
       lc = new ls.LanguageClientConnection(createSpyConnection(), new NullLogger());
@@ -330,14 +354,18 @@ describe('LanguageClientConnection', () => {
 
     it('onExit calls back on exit', () => {
       let called = false;
-      lc.onExit(() => { called = true; });
+      lc.onExit(() => {
+        called = true;
+      });
       eventMap.exit();
       expect(called).equals(true);
     });
 
     it('onShowMessage calls back on window/showMessage', () => {
       let called = false;
-      lc.onShowMessage(() => { called = true; });
+      lc.onShowMessage(() => {
+        called = true;
+      });
       eventMap['window/showMessage']();
       expect(called).equals(true);
     });

--- a/test/runner.js
+++ b/test/runner.js
@@ -2,14 +2,17 @@
 
 const {createRunner} = require('atom-mocha-test-runner');
 
-module.exports = createRunner({
-  htmlTitle: `atom-languageclient Tests - pid ${process.pid}`,
-  reporter: process.env.MOCHA_REPORTER || 'spec',
-  colors: process.platform !== 'win32',
-  overrideTestPaths: [/spec$/, /test/],
-}, mocha => {
-  mocha.timeout(parseInt(process.env.MOCHA_TIMEOUT || '5000', 10));
-  if (process.env.APPVEYOR_API_URL) {
-    mocha.reporter(require('mocha-appveyor-reporter'));
-  }
-});
+module.exports = createRunner(
+  {
+    htmlTitle: `atom-languageclient Tests - pid ${process.pid}`,
+    reporter: process.env.MOCHA_REPORTER || 'spec',
+    colors: process.platform !== 'win32',
+    overrideTestPaths: [/spec$/, /test/],
+  },
+  mocha => {
+    mocha.timeout(parseInt(process.env.MOCHA_TIMEOUT || '5000', 10));
+    if (process.env.APPVEYOR_API_URL) {
+      mocha.reporter(require('mocha-appveyor-reporter'));
+    }
+  },
+);


### PR DESCRIPTION
This enables https://github.com/prettier/prettier-eslint and https://github.com/prettier/eslint-config-prettier to ensure that all code under `lib/` and `test`/ is lint clean and auto-formatted!

If you're using `atom-ide-diagnostics` with `linter-eslint`, you can hit alt-shift-A to automatically format your code to match Prettier :)

I mostly just ran `eslint --fix lib test`, but there were some manual changes necessary. I separated them into separate commits.

Finally, this enables linting on `npm test`, `npm run lint`, and Travis so hopefully it'll stay clean :)

Released under CC0.