### PR TITLE
Add adapter for code highlights (textDocument/documentHighlight)

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ The language server protocol consists of a number of capabilities. Some of these
 | textDocument/signatureHelp      | TBD                           |
 | textDocument/definition         | Atom-IDE definitions          |
 | textDocument/findReferences     | Atom-IDE findReferences       |
-| textDocument/documentHighlight  | Atom-IDE definitions          |
+| textDocument/documentHighlight  | Atom-IDE code highlights      |
 | textDocument/documentSymbol     | Atom-IDE outline view         |
 | workspace/symbol                | TBD                           |
 | textDocument/codeAction         | TBD                           |
@@ -82,7 +82,7 @@ Note that you will also need to add various entries to the `providedServices` an
 
 ### Using other connection types
 
-The default connection type is *stdio* however both *ipc* and *sockets* are also available.  
+The default connection type is *stdio* however both *ipc* and *sockets* are also available.
 
 #### IPC
 

--- a/flow-libs/atom-ide.js.flow
+++ b/flow-libs/atom-ide.js.flow
@@ -25,7 +25,8 @@ export type atomIde$Outline = {
   outlineTrees: Array<atomIde$OutlineTree>,
 };
 
-export type atomIde$TokenKind = 'keyword'
+export type atomIde$TokenKind =
+  | 'keyword'
   | 'class-name'
   | 'constructor'
   | 'method'
@@ -33,8 +34,7 @@ export type atomIde$TokenKind = 'keyword'
   | 'string'
   | 'whitespace'
   | 'plain'
-  | 'type'
-  ;
+  | 'type';
 
 export type atomIde$TextToken = {
   kind: atomIde$TokenKind,
@@ -77,8 +77,8 @@ export type atomIde$FindReferencesProvider = {
 };
 
 export type atomIde$Reference = {
-  uri: IdeUri,      // URI of the file path
-  name: ?string,    // name of calling method/function/symbol
+  uri: IdeUri, // URI of the file path
+  name: ?string, // name of calling method/function/symbol
   range: atom$Range,
 };
 
@@ -133,10 +133,7 @@ export type atomIde$DatatipService = {
 };
 
 export type atomIde$RangeCodeFormatProvider = {|
-  formatCode: (
-    editor: atom$TextEditor,
-    range: atom$Range,
-  ) => Promise<Array<atomIde$TextEdit>>,
+  formatCode: (editor: atom$TextEditor, range: atom$Range) => Promise<Array<atomIde$TextEdit>>,
   priority: number,
   grammarScopes: Array<string>,
 |};
@@ -146,4 +143,10 @@ export type atomIde$TextEdit = {
   newText: string,
   // If included, this will be used to verify that the edit still applies cleanly.
   oldText?: string,
+};
+
+export type atomIde$CodeHighlightProvider = {
+  highlight(editor: atom$TextEditor, bufferPosition: atom$Point): Promise<?Array<atom$Range>>,
+  priority: number,
+  grammarScopes: Array<string>,
 };

--- a/lib/adapters/code-highlight-adapter.js
+++ b/lib/adapters/code-highlight-adapter.js
@@ -1,0 +1,35 @@
+// @flow
+
+import invariant from 'assert';
+import {LanguageClientConnection, type ServerCapabilities} from '../languageclient';
+import Convert from '../convert';
+
+export default class CodeHighlightAdapter {
+  // Returns a {Boolean} indicating this adapter can adapt the server based on the
+  // given serverCapabilities.
+  static canAdapt(serverCapabilities: ServerCapabilities): boolean {
+    return serverCapabilities.documentHighlightProvider === true;
+  }
+
+  // Public: Creates highlight markers for a given editor position.
+  // Throws an error if documentHighlightProvider is not a registered capability.
+  //
+  // * `connection` A {LanguageClientConnection} to the language server that provides highlights.
+  // * `serverCapabilities` The {ServerCapabilities} of the language server that will be used.
+  // * `editor` The Atom {TextEditor} containing the text to be highlighted.
+  // * `position` The Atom {Point} to fetch highlights for.
+  //
+  // Returns a {Promise} of an {Array} of {Range}s to be turned into highlights.
+  static async highlight(
+    connection: LanguageClientConnection,
+    serverCapabilities: ServerCapabilities,
+    editor: atom$TextEditor,
+    position: atom$Point,
+  ): Promise<?Array<atom$Range>> {
+    invariant(serverCapabilities.documentHighlightProvider, 'Must have the documentHighlight capability');
+    const highlights = await connection.documentHighlight(Convert.editorToTextDocumentPositionParams(editor, position));
+    return highlights.map(highlight => {
+      return Convert.lsRangeToAtomRange(highlight.range);
+    });
+  }
+}

--- a/lib/auto-languageclient.js
+++ b/lib/auto-languageclient.js
@@ -9,6 +9,7 @@ import {ServerManager, type ActiveServer} from './server-manager.js';
 
 import AutocompleteAdapter from './adapters/autocomplete-adapter';
 import CodeFormatAdapter from './adapters/code-format-adapter';
+import CodeHighlightAdapter from './adapters/code-highlight-adapter';
 import DatatipAdapter from './adapters/datatip-adapter';
 import DefinitionAdapter from './adapters/definition-adapter';
 import DocumentSyncAdapter from './adapters/document-sync-adapter';
@@ -330,5 +331,24 @@ export default class AutoLanguageClient {
     }
 
     return CodeFormatAdapter.format(server.connection, server.capabilities, editor, range);
+  }
+
+  provideCodeHighlight(): atomIde$CodeHighlightProvider {
+    return {
+      grammarScopes: this.getGrammarScopes(),
+      priority: 1,
+      highlight: (editor, position) => {
+        return this.getCodeHighlight(editor, position);
+      },
+    };
+  }
+
+  async getCodeHighlight(editor: atom$TextEditor, position: atom$Point): Promise<?Array<atom$Range>> {
+    const server = await this._serverManager.getServer(editor);
+    if (server == null || !CodeHighlightAdapter.canAdapt(server.capabilities)) {
+      return null;
+    }
+
+    return CodeHighlightAdapter.highlight(server.connection, server.capabilities, editor, position);
   }
 }

--- a/test/adapters/code-highlight-adapter.test.js
+++ b/test/adapters/code-highlight-adapter.test.js
@@ -1,0 +1,68 @@
+// @flow
+
+import invariant from 'assert';
+import {Point, Range} from 'atom';
+import {expect} from 'chai';
+import sinon from 'sinon';
+import * as ls from '../../lib/languageclient';
+import CodeHighlightAdapter from '../../lib/adapters/code-highlight-adapter';
+import {createSpyConnection, createFakeEditor} from '../helpers.js';
+
+describe('CodeHighlightAdapter', () => {
+  let fakeEditor;
+  let connection;
+
+  beforeEach(() => {
+    connection = new ls.LanguageClientConnection(createSpyConnection());
+    fakeEditor = createFakeEditor();
+  });
+
+  describe('canAdapt', () => {
+    it('returns true if document highlights are supported', () => {
+      const result = CodeHighlightAdapter.canAdapt({
+        documentHighlightProvider: true,
+      });
+      expect(result).to.be.true;
+    });
+
+    it('returns false it no formatting supported', () => {
+      const result = CodeHighlightAdapter.canAdapt({});
+      expect(result).to.be.false;
+    });
+  });
+
+  describe('highlight', () => {
+    it('highlights some ranges', async () => {
+      const highlightStub = sinon.stub(connection, 'documentHighlight').returns(
+        Promise.resolve([
+          {
+            range: {
+              start: {line: 0, character: 1},
+              end: {line: 0, character: 2},
+            },
+          },
+        ]),
+      );
+      const result = await CodeHighlightAdapter.highlight(
+        connection,
+        {documentHighlightProvider: true},
+        fakeEditor,
+        new Point(0, 0),
+      );
+      expect(highlightStub.called).to.be.true;
+
+      invariant(result != null);
+      expect(result.length).to.equal(1);
+      expect(result[0].isEqual(new Range([0, 1], [0, 2]))).to.be.true;
+    });
+
+    it('throws if document highlights are not supported', async () => {
+      const result = await CodeHighlightAdapter.highlight(connection, {}, fakeEditor, new Point(0, 0)).catch(
+        err => err,
+      );
+      expect(result).to.be.an.instanceof(Error);
+      invariant(result instanceof Error);
+      expect(result.message).to.equal('Must have the documentHighlight capability');
+    });
+  });
+});


### PR DESCRIPTION
Atom IDE UI's code highlight provider shows small highlights when you put your cursor over a symbol. I know the 'definitions' provider is already doing this, but I think this is what most people expect when they hear of code highlights.

The underlying implementation is very simple - it just creates some highlight markers at the returned set of ranges.

Tested with the Java provider:

![code highlights](https://thumbs.gfycat.com/FoolishMammothAmericancrocodile-size_restricted.gif)

Released under CC0.