### PR TITLE
Link workspace/didChangeWatchedFiles to Atom file change api

### DIFF
--- a/flow-libs/atom.js.flow
+++ b/flow-libs/atom.js.flow
@@ -1360,6 +1360,7 @@ declare class atom$MenuManager {
 declare class atom$Project {
   // Event Subscription
   onDidChangePaths(callback: (projectPaths: Array<string>) => mixed): IDisposable,
+  onDidChangeFiles(callback: (fileEvents: Array<atom$ProjectFileEvent) => mixed): IDisposable,
   onDidAddBuffer(callback: (buffer: atom$TextBuffer) => mixed): IDisposable,
 
   // Accessing the git repository
@@ -1394,6 +1395,14 @@ type TextBufferScanIterator = (arg: {
 // need to know is that if something needs a checkpoint you should only pass it values received from
 // TextBuffer::createCheckpoint
 type atom$TextBufferCheckpoint = number;
+
+type atom$ProjectFileEvent = {
+  action: atom$ProjectFileEventType,
+  path: string,
+  oldPath: string,
+}
+
+type atom$ProjectFileEventType = 'created' | 'modified' | 'deleted' | 'renamed';
 
 // TextBuffer did-change/will-change
 type atom$TextEditEvent = {

--- a/flow-libs/atom.js.flow
+++ b/flow-libs/atom.js.flow
@@ -1360,7 +1360,7 @@ declare class atom$MenuManager {
 declare class atom$Project {
   // Event Subscription
   onDidChangePaths(callback: (projectPaths: Array<string>) => mixed): IDisposable,
-  onDidChangeFiles(callback: (fileEvents: Array<atom$ProjectFileEvent) => mixed): IDisposable,
+  onDidChangeFiles(callback: (fileEvents: Array<atom$ProjectFileEvent>) => mixed): IDisposable,
   onDidAddBuffer(callback: (buffer: atom$TextBuffer) => mixed): IDisposable,
 
   // Accessing the git repository

--- a/flow-libs/atom.js.flow
+++ b/flow-libs/atom.js.flow
@@ -1399,7 +1399,7 @@ type atom$TextBufferCheckpoint = number;
 type atom$ProjectFileEvent = {
   action: atom$ProjectFileEventType,
   path: string,
-  oldPath: string,
+  oldPath?: string,
 }
 
 type atom$ProjectFileEventType = 'created' | 'modified' | 'deleted' | 'renamed';

--- a/lib/adapters/document-sync-adapter.js
+++ b/lib/adapters/document-sync-adapter.js
@@ -132,7 +132,7 @@ export default class DocumentSyncAdapter {
 class TextEditorSyncAdapter {
   _disposable = new CompositeDisposable();
   _editor: atom$TextEditor;
-  _currentUri: ?string;
+  _currentUri: string;
   _connection: LanguageClientConnection;
   _version = 1;
   _fakeDidChangeWatchedFiles: boolean;
@@ -204,7 +204,7 @@ class TextEditorSyncAdapter {
 
     this._connection.didOpenTextDocument({
       textDocument: {
-        uri: this.getEditorUri(),
+        uri,
         languageId: this.getLanguageId().toLowerCase(),
         version: this._version,
         text: this._editor.getText(),
@@ -257,7 +257,7 @@ class TextEditorSyncAdapter {
   // Called when the {TextEditor} is closed and sends the 'didCloseTextDocument' notification to
   // the connected language server.
   didClose(): void {
-    const uri = this._editor.getURI();
+    const uri = this.getEditorUri();
     if (uri === '') {
       return; // Not yet saved
     }
@@ -269,7 +269,7 @@ class TextEditorSyncAdapter {
   // Note: Right now this also sends the `didChangeWatchedFiles` notification as well but that
   // will be sent from elsewhere soon.
   didSave(): void {
-    const uri = this._editor.getURI();
+    const uri = this.getEditorUri();
     this._connection.didSaveTextDocument({textDocument: {uri}});
     if (this._fakeDidChangeWatchedFiles) {
       this._connection.didChangeWatchedFiles({

--- a/lib/adapters/document-sync-adapter.js
+++ b/lib/adapters/document-sync-adapter.js
@@ -132,7 +132,7 @@ export default class DocumentSyncAdapter {
 class TextEditorSyncAdapter {
   _disposable = new CompositeDisposable();
   _editor: atom$TextEditor;
-  _lastFileUri: ?string;
+  _currentUri: ?string;
   _connection: LanguageClientConnection;
   _version = 1;
 
@@ -144,6 +144,7 @@ class TextEditorSyncAdapter {
   constructor(editor: atom$TextEditor, connection: LanguageClientConnection, documentSyncKind: number) {
     this._editor = editor;
     this._connection = connection;
+    this._fakeDidChangeWatchedFiles = atom.project.onDidChangeFiles == null;
 
     const changeTracking = this.setupChangeTracking(documentSyncKind);
     if (changeTracking != null) {
@@ -152,11 +153,11 @@ class TextEditorSyncAdapter {
 
     this._disposable.add(
       editor.onDidSave(this.didSave.bind(this)),
-      editor.onDidDestroy(this.didDestroy.bind(this)),
+      editor.onDidDestroy(this.didClose.bind(this)),
       editor.onDidChangePath(this.didRename.bind(this)),
     );
 
-    this._lastFileUri = this.getEditorUri();
+    this._currentUri = this.getEditorUri();
     this.didOpen();
   }
 
@@ -195,9 +196,10 @@ class TextEditorSyncAdapter {
   // Ensure when the document is opened we send notification to the language server
   // so it can load it in and keep track of diagnostics etc.
   didOpen(): void {
-    if (this._editor.getURI() == null) {
-      return;
-    } // Not yet saved
+    const uri = this.getEditorUri();
+    if (uri === '') {
+      return; // Not yet saved
+    }
 
     this._connection.didOpenTextDocument({
       textDocument: {
@@ -253,13 +255,12 @@ class TextEditorSyncAdapter {
 
   // Called when the {TextEditor} is closed and sends the 'didCloseTextDocument' notification to
   // the connected language server.
-  didDestroy(): void {
-    if (this._editor.getURI() == null) {
-      return;
-    } // Not yet saved
-    this._connection.didCloseTextDocument({
-      textDocument: {uri: this.getEditorUri()},
-    });
+  didClose(): void {
+    const uri = this._editor.getURI();
+    if (uri === '') {
+      return; // Not yet saved
+    }
+    this._connection.didCloseTextDocument({textDocument: {uri}});
   }
 
   // Called when the {TextEditor} saves and sends the 'didSaveTextDocument' notification to
@@ -267,35 +268,35 @@ class TextEditorSyncAdapter {
   // Note: Right now this also sends the `didChangeWatchedFiles` notification as well but that
   // will be sent from elsewhere soon.
   didSave(): void {
-    this._connection.didSaveTextDocument({
-      textDocument: {uri: this.getEditorUri()},
-    });
-    // TODO: Move this to a file watching event once Atom has API support.
-    this._connection.didChangeWatchedFiles({
-      changes: [{uri: this.getEditorUri(), type: FileChangeType.Changed}],
-    }); // Replace with file watch
+    const uri = this._editor.getURI();
+    this._connection.didSaveTextDocument({textDocument: {uri}});
+    if (this._fakeDidChangeWatchedFiles) {
+      this._connection.didChangeWatchedFiles({
+        changes: [{uri, type: FileChangeType.Changed}],
+      });
+    }
   }
 
   didRename() {
-    const lastFileUri = this._lastFileUri;
-    if (!lastFileUri) {
-      this._lastFileUri = this.getEditorUri();
+    const oldUri = this._currentUri;
+    this._currentUri = this.getEditorUri();
+    if (!oldUri) {
+      // Didn't previously have a name
       return;
     }
 
     this._connection.didCloseTextDocument({
-      textDocument: {uri: lastFileUri},
+      textDocument: {uri: oldUri},
     });
-    this._connection.didChangeWatchedFiles({
-      changes: [
-        {uri: lastFileUri, type: FileChangeType.Deleted},
-        {uri: this.getEditorUri(), type: FileChangeType.Created},
-      ],
-    });
-    this._lastFileUri = this.getEditorUri();
 
-    // send an equivalent open event for this editor, which will now use the new
-    // file path
+    if (this._fakeDidChangeWatchedFiles) {
+      this._connection.didChangeWatchedFiles({
+        changes: [{uri: oldUri, type: FileChangeType.Deleted}, {uri: this._currentUri, type: FileChangeType.Created}],
+      });
+    }
+
+    // Send an equivalent open event for this editor, which will now use the new
+    // file path.
     this.didOpen();
   }
 

--- a/lib/adapters/document-sync-adapter.js
+++ b/lib/adapters/document-sync-adapter.js
@@ -135,6 +135,7 @@ class TextEditorSyncAdapter {
   _currentUri: ?string;
   _connection: LanguageClientConnection;
   _version = 1;
+  _fakeDidChangeWatchedFiles: boolean;
 
   // Public: Create a {TextEditorSyncAdapter} in sync with a given language server.
   //
@@ -277,7 +278,7 @@ class TextEditorSyncAdapter {
     }
   }
 
-  didRename() {
+  didRename(): void {
     const oldUri = this._currentUri;
     this._currentUri = this.getEditorUri();
     if (!oldUri) {

--- a/lib/convert.js
+++ b/lib/convert.js
@@ -142,10 +142,10 @@ export default class Convert {
   // but renames will be represented by a deletion and a subsequent creation as LSP does not know about
   // renames.
   //
-  // * 'fileEvent' An {atom$FileEvent} to be converted.
+  // * 'fileEvent' An {atom$ProjectFileEvent} to be converted.
   //
   // Returns an array of LSP {ls.FileEvent} objects that equivalent conversions to the fileEvent parameter.
-  static atomFileEventToLSFileEvents(fileEvent: atom$FileEvent): ls.FileEvent[] {
+  static atomFileEventToLSFileEvents(fileEvent: atom$ProjectFileEvent): ls.FileEvent[] {
     switch (fileEvent.action) {
       case 'created':
         return [{uri: Convert.pathToUri(fileEvent.path), type: ls.FileChangeType.Created}];
@@ -153,11 +153,16 @@ export default class Convert {
         return [{uri: Convert.pathToUri(fileEvent.path), type: ls.FileChangeType.Changed}];
       case 'deleted':
         return [{uri: Convert.pathToUri(fileEvent.path), type: ls.FileChangeType.Deleted}];
-      case 'renamed':
-        return [
-          {uri: Convert.pathToUri(fileEvent.oldPath), type: ls.FileChangeType.Deleted},
-          {uri: Convert.pathToUri(fileEvent.path), type: ls.FileChangeType.Created},
-        ];
+      case 'renamed': {
+        const results = [];
+        if (fileEvent.oldPath) {
+          results.push({uri: Convert.pathToUri(fileEvent.oldPath || ''), type: ls.FileChangeType.Deleted});
+        }
+        if (fileEvent.path) {
+          results.push({uri: Convert.pathToUri(fileEvent.path), type: ls.FileChangeType.Created});
+        }
+        return results;
+      }
       default:
         return [];
     }

--- a/lib/convert.js
+++ b/lib/convert.js
@@ -136,4 +136,30 @@ export default class Convert {
     };
     return s.replace(/[&<>'"]/g, c => attributeMap[c]);
   }
+
+  // Public: Convert an Atom File Event as received from atom.project.onDidChangeFiles and convert
+  // it into an Array of Language Server Protocol {FileEvent} objects. Normally this will be a 1-to-1
+  // but renames will be represented by a deletion and a subsequent creation as LSP does not know about
+  // renames.
+  //
+  // * 'fileEvent' An {atom$FileEvent} to be converted.
+  //
+  // Returns an array of LSP {ls.FileEvent} objects that equivalent conversions to the fileEvent parameter.
+  static atomFileEventToLSFileEvents(fileEvent: atom$FileEvent): ls.FileEvent[] {
+    switch (fileEvent.action) {
+      case 'created':
+        return [{uri: Convert.pathToUri(fileEvent.path), type: ls.FileChangeType.Created}];
+      case 'modified':
+        return [{uri: Convert.pathToUri(fileEvent.path), type: ls.FileChangeType.Changed}];
+      case 'deleted':
+        return [{uri: Convert.pathToUri(fileEvent.path), type: ls.FileChangeType.Deleted}];
+      case 'renamed':
+        return [
+          {uri: Convert.pathToUri(fileEvent.oldPath), type: ls.FileChangeType.Deleted},
+          {uri: Convert.pathToUri(fileEvent.path), type: ls.FileChangeType.Created},
+        ];
+      default:
+        return [];
+    }
+  }
 }

--- a/lib/server-manager.js
+++ b/lib/server-manager.js
@@ -93,7 +93,7 @@ export class ServerManager {
           const syncAdapter = server.docSyncAdapter.getEditorSyncAdapter(editor);
           if (syncAdapter) {
             // Immitate editor close to disconnect LS from the editor
-            syncAdapter.didDestroy();
+            syncAdapter.didClose();
           }
         }
         // Remove editor from the cache

--- a/lib/server-manager.js
+++ b/lib/server-manager.js
@@ -6,6 +6,7 @@ import type DocumentSyncAdapter from './adapters/document-sync-adapter';
 
 import path from 'path';
 import * as ls from './languageclient';
+import Convert from './convert';
 import {CompositeDisposable} from 'atom';
 
 // The necessary elements for a server that has started or is starting.
@@ -20,7 +21,7 @@ export type ActiveServer = {
 };
 
 // Manages the language server lifecycles and their associated objects necessary
-// for adapting them to Atom and Atom IDE UI.
+// for adapting them to Atom IDE.
 export class ServerManager {
   _activeServers: Array<ActiveServer> = [];
   _startingServerPromises: Map<string, Promise<ActiveServer>> = new Map();
@@ -41,8 +42,11 @@ export class ServerManager {
     this._startForEditor = startForEditor;
     this.updateNormalizedProjectPaths();
     this._disposable = new CompositeDisposable();
-    this._disposable.add(atom.project.onDidChangePaths(this.projectPathsChanged.bind(this)));
     this._disposable.add(atom.textEditors.observe(this.observeTextEditors.bind(this)));
+    this._disposable.add(atom.project.onDidChangePaths(this.projectPathsChanged.bind(this)));
+    if (atom.project.onDidChangeFiles) {
+      this._disposable.add(atom.project.onDidChangeFiles(this.projectFilesChanged.bind(this)));
+    }
   }
 
   dispose(): void {
@@ -184,5 +188,26 @@ export class ServerManager {
     const serversToStop = this._activeServers.filter(s => !pathsSet.has(s.projectPath));
     Promise.all(serversToStop.map(s => this.stopServer(s)));
     this.updateNormalizedProjectPaths();
+  }
+
+  projectFilesChanged(fileEvents: Array<atom$ProjectFileEvent>): void {
+    if (this._activeServers.length === 0) {
+      return;
+    }
+
+    for (const activeServer of this._activeServers) {
+      const changes = [];
+      for (const fileEvent of fileEvents) {
+        if (fileEvent.path.startsWith(activeServer.projectPath)) {
+          changes.push(Convert.atomFileEventToLSFileEvents(fileEvent)[0]);
+        }
+        if (fileEvent.oldPath && fileEvent.oldPath.startsWith(activeServer.projectPath)) {
+          changes.push(Convert.atomFileEventToLSFileEvents(fileEvent)[1]);
+        }
+      }
+      if (changes.length > 0) {
+        activeServer.connection.didChangeWatchedFiles({changes});
+      }
+    }
   }
 }

--- a/test/convert.test.js
+++ b/test/convert.test.js
@@ -1,5 +1,6 @@
 // @flow
 
+import * as ls from '../lib/languageclient';
 import Convert from '../lib/convert';
 import {Point, Range, TextEditor} from 'atom';
 import {expect} from 'chai';
@@ -171,6 +172,33 @@ describe('Convert', () => {
       const stringToEncode = 'a"b\'c&d>e<f';
       const encoded = Convert.encodeHTMLAttribute(stringToEncode);
       expect(encoded).equals('a&quot;b&apos;c&amp;d&gt;e&lt;f');
+    });
+  });
+
+  describe('atomFileEventToLSFileEvents', () => {
+    it('converts a created event', () => {
+      const source = {path: '/a/b/c/d.txt', action: 'created'};
+      const converted = Convert.atomFileEventToLSFileEvents(source);
+      expect(converted[0]).deep.equals({uri: 'file:///a/b/c/d.txt', type: ls.FileChangeType.Created});
+    });
+
+    it('converts a modified event', () => {
+      const source = {path: '/a/b/c/d.txt', action: 'modified'};
+      const converted = Convert.atomFileEventToLSFileEvents(source);
+      expect(converted[0]).deep.equals({uri: 'file:///a/b/c/d.txt', type: ls.FileChangeType.Changed});
+    });
+
+    it('converts a deleted event', () => {
+      const source = {path: '/a/b/c/d.txt', action: 'deleted'};
+      const converted = Convert.atomFileEventToLSFileEvents(source);
+      expect(converted[0]).deep.equals({uri: 'file:///a/b/c/d.txt', type: ls.FileChangeType.Deleted});
+    });
+
+    it('converts a renamed event', () => {
+      const source = {path: '/a/b/c/d.txt', oldPath: '/a/z/e.lst', action: 'renamed'};
+      const converted = Convert.atomFileEventToLSFileEvents(source);
+      expect(converted[0]).deep.equals({uri: 'file:///a/z/e.lst', type: ls.FileChangeType.Deleted});
+      expect(converted[1]).deep.equals({uri: 'file:///a/b/c/d.txt', type: ls.FileChangeType.Created});
     });
   });
 });


### PR DESCRIPTION
Previously we had to fake the `workspace/didChangeWatchedFiles` message as we did not have a file watcher available in Atom so we manually triggered it when we spotted an opened file changed on disk.  This worked quite well but isn't really the point of this message and it easily messed up autocomplete and diagnostics for files that weren't open but subsequently changed such as performing git reset, git pull etc.

For now we do still support sending those messages if the Atom `atom.project.onDidChangeFiles` API is not available.

Fixes #6