### PR TITLE
Handle and resolve duplicate named containers 

### DIFF
--- a/lib/adapters/code-format-adapter.js
+++ b/lib/adapters/code-format-adapter.js
@@ -146,7 +146,7 @@ export default class CodeFormatAdapter {
   //
   // Returns an {Array} of Atom {TextEdit} objects.
   static convertLsTextEdits(textEdits: Array<TextEdit>): Array<atomIde$TextEdit> {
-    return textEdits.map(CodeFormatAdapter.convertLsTextEdit);
+    return (textEdits || []).map(CodeFormatAdapter.convertLsTextEdit);
   }
 
   // Public: Convert a language server protocol {TextEdit} object to the

--- a/lib/adapters/outline-view-adapter.js
+++ b/lib/adapters/outline-view-adapter.js
@@ -4,11 +4,6 @@ import {LanguageClientConnection, SymbolKind, type ServerCapabilities, type Symb
 import Convert from '../convert';
 import {Point} from 'atom';
 
-type ContainerNamedOutline = {
-  containerName: ?string,
-  outline: atomIde$OutlineTree,
-};
-
 // Public: Adapts the documentSymbolProvider of the language server to the Outline View
 // supplied by Atom IDE UI.
 export default class OutlineViewAdapter {
@@ -49,52 +44,59 @@ export default class OutlineViewAdapter {
   //
   // Returns an {OutlineTree} containing the given symbols that the Outline View can display.
   static createOutlineTrees(symbols: Array<SymbolInformation>): Array<atomIde$OutlineTree> {
-    const byContainerName = OutlineViewAdapter.createContainerNamedOutline(symbols);
-    const roots: Map<string, atomIde$OutlineTree> = new Map();
-    byContainerName.forEach((v, k) => {
-      const containerName = v.containerName;
-      if (containerName === '' || containerName == null || k === containerName) {
-        // No container name or contained within itself belong as top-level items
-        roots.set(k, v.outline);
-      } else {
-        const container = byContainerName.get(containerName);
-        if (container) {
-          // Items with a container we know about get put in that container
-          container.outline.children.push(v.outline);
+    // Temporarily keep containerName through the conversion process
+    const allItems = symbols.map(symbol => ({
+      containerName: symbol.containerName,
+      outline: OutlineViewAdapter.symbolToOutline(symbol),
+    }));
+
+    // Create a map of containers by name with all items that have that name
+    const containers = allItems.reduce((map, item) => {
+      const name = item.outline.representativeName;
+      if (name != null) {
+        const container = map.get(name);
+        if (container == null) {
+          map.set(name, [item.outline]);
         } else {
-          // Items with a container we don't know about we dynamically create one for
-          let rootContainer = roots.get(containerName);
-          if (rootContainer == null) {
-            rootContainer = {
-              plainText: containerName,
-              children: [],
-              startPosition: new Point(0, 0),
-            };
-            roots.set(containerName, rootContainer);
-          }
-          rootContainer.children.push(v.outline);
+          container.push(item.outline);
         }
       }
-    });
-    return Array.from(roots.values());
-  }
-
-  // Public: Converts an {Array} of {SymbolInformation} received from a language server into a
-  // {Map} of {ContainerNamedOutline} keyed by their symbol names. This allows us to find parents
-  // quickly when assembling the tree through containerNames.
-  //
-  // * `symbols` An {Array} of {SymbolInformation}s to convert into the map.
-  //
-  // Returns a {Map} of {ContainerNamedOutline}s each converted from a {SymbolInformation}
-  // and keyed by its containerName.
-  static createContainerNamedOutline(symbols: Array<SymbolInformation>): Map<string, ContainerNamedOutline> {
-    return symbols.reduce((map, symbol) => {
-      map.set(symbol.name, {
-        containerName: symbol.containerName,
-        outline: OutlineViewAdapter.symbolToOutline(symbol),
-      });
       return map;
     }, new Map());
+
+    const roots: Array<atomIde$OutlineTree> = [];
+
+    // Put each item within its parent and extract out the roots
+    for (const item of allItems) {
+      const containerName = item.containerName;
+      if (containerName == null || containerName === '') {
+        roots.push(item.outline);
+      } else {
+        const possibleParents = containers.get(containerName);
+        if (possibleParents == null) {
+          const missingParent = {
+            plainText: containerName,
+            representativeName: containerName,
+            startPosition: new Point(0, 0),
+            children: [item.outline],
+          };
+          containers.set(containerName, [missingParent]);
+          roots.push(missingParent);
+        } else {
+          const child = item.outline;
+          const parent =
+            possibleParents.find(
+              p =>
+                p.startPosition.isLessThanOrEqual(child.startPosition) &&
+                p.endPosition != null &&
+                p.endPosition.isGreaterThanOrEqual(child.endPosition),
+            ) || possibleParents[0];
+          parent.children.push(item.outline);
+        }
+      }
+    }
+
+    return roots;
   }
 
   // Public: Convert an individual {SymbolInformation} from the language server

--- a/lib/adapters/outline-view-adapter.js
+++ b/lib/adapters/outline-view-adapter.js
@@ -69,6 +69,7 @@ export default class OutlineViewAdapter {
     // Put each item within its parent and extract out the roots
     for (const item of allItems) {
       const containerName = item.containerName;
+      const child = item.outline;
       if (containerName == null || containerName === '') {
         roots.push(item.outline);
       } else {
@@ -78,25 +79,41 @@ export default class OutlineViewAdapter {
             plainText: containerName,
             representativeName: containerName,
             startPosition: new Point(0, 0),
-            children: [item.outline],
+            children: [child],
           };
           containers.set(containerName, [missingParent]);
           roots.push(missingParent);
         } else {
-          const child = item.outline;
-          const parent =
-            possibleParents.find(
-              p =>
-                p.startPosition.isLessThanOrEqual(child.startPosition) &&
-                p.endPosition != null &&
-                p.endPosition.isGreaterThanOrEqual(child.endPosition),
-            ) || possibleParents[0];
-          parent.children.push(item.outline);
+          OutlineViewAdapter._getClosestParent(possibleParents, child).children.push(child);
         }
       }
     }
 
     return roots;
+  }
+
+  static _getClosestParent(candidates: Array<atomIde$OutlineTree>, child: atomIde$OutlineTree): atomIde$OutlineTree {
+    if (candidates.length === 1) {
+      return candidates[0];
+    }
+
+    let parent = null;
+    for (const candidate of candidates) {
+      if (
+        candidate !== child &&
+        candidate.startPosition.isLessThanOrEqual(child.startPosition) &&
+        (candidate.endPosition == null || candidate.endPosition.isGreaterThanOrEqual(child.endPosition))
+      ) {
+        if (
+          parent == null ||
+          (parent.startPosition.isLessThanOrEqual(candidate.startPosition) ||
+            (parent.endPosition != null && parent.endPosition.isGreaterThanOrEqual(candidate.endPosition)))
+        ) {
+          parent = candidate;
+        }
+      }
+    }
+    return parent || candidates[0];
   }
 
   // Public: Convert an individual {SymbolInformation} from the language server

--- a/lib/adapters/outline-view-adapter.js
+++ b/lib/adapters/outline-view-adapter.js
@@ -74,17 +74,22 @@ export default class OutlineViewAdapter {
         roots.push(item.outline);
       } else {
         const possibleParents = containers.get(containerName);
-        if (possibleParents == null) {
-          const missingParent = {
+        let closestParent = OutlineViewAdapter._getClosestParent(possibleParents, child);
+        if (closestParent == null) {
+          closestParent = {
             plainText: containerName,
             representativeName: containerName,
             startPosition: new Point(0, 0),
             children: [child],
           };
-          containers.set(containerName, [missingParent]);
-          roots.push(missingParent);
+          roots.push(closestParent);
+          if (possibleParents == null) {
+            containers.set(containerName, [closestParent]);
+          } else {
+            possibleParents.push(closestParent);
+          }
         } else {
-          OutlineViewAdapter._getClosestParent(possibleParents, child).children.push(child);
+          closestParent.children.push(child);
         }
       }
     }
@@ -92,9 +97,9 @@ export default class OutlineViewAdapter {
     return roots;
   }
 
-  static _getClosestParent(candidates: Array<atomIde$OutlineTree>, child: atomIde$OutlineTree): atomIde$OutlineTree {
-    if (candidates.length === 1) {
-      return candidates[0];
+  static _getClosestParent(candidates: ?Array<atomIde$OutlineTree>, child: atomIde$OutlineTree): ?atomIde$OutlineTree {
+    if (candidates == null || candidates.length === 0) {
+      return null;
     }
 
     let parent = null;
@@ -113,7 +118,8 @@ export default class OutlineViewAdapter {
         }
       }
     }
-    return parent || candidates[0];
+
+    return parent;
   }
 
   // Public: Convert an individual {SymbolInformation} from the language server

--- a/test/adapters/datatip-adapter.test.js
+++ b/test/adapters/datatip-adapter.test.js
@@ -13,8 +13,12 @@ describe('DatatipAdapter', () => {
   let connection;
 
   beforeEach(() => {
+    global.sinon = sinon.sandbox.create();
     connection = new ls.LanguageClientConnection(createSpyConnection());
     fakeEditor = createFakeEditor();
+  });
+  afterEach(() => {
+    global.sinon.restore();
   });
 
   describe('canAdapt', () => {

--- a/test/adapters/outline-view-adapter.test.js
+++ b/test/adapters/outline-view-adapter.test.js
@@ -89,6 +89,45 @@ describe('OutlineViewAdapter', () => {
       expect(result[1].children.length).to.equal(1);
       expect(result[1].children[0].representativeName).to.equal('main');
     });
+
+    it("does not become it's own parent", () => {
+      const sourceItems = [
+        {kind: ls.SymbolKind.Namespace, name: 'duplicate', location: createLocation(1, 0, 10, 0)},
+        {
+          kind: ls.SymbolKind.Namespace,
+          name: 'duplicate',
+          location: createLocation(6, 0, 7, 0),
+          containerName: 'duplicate',
+        },
+      ];
+      const result = OutlineViewAdapter.createOutlineTrees(sourceItems);
+      expect(result.length).to.equal(1);
+      const r = (result: any);
+      expect(r[0].endPosition.row).to.equal(10);
+      expect(r[0].children.length).to.equal(1);
+      expect(r[0].children[0].endPosition.row).to.equal(7);
+    });
+
+    it('parents to the innnermost named container', () => {
+      const sourceItems = [
+        {kind: ls.SymbolKind.Namespace, name: 'turtles', location: createLocation(1, 0, 10, 0)},
+        {
+          kind: ls.SymbolKind.Namespace,
+          name: 'turtles',
+          location: createLocation(4, 0, 8, 0),
+          containerName: 'turtles',
+        },
+        {kind: ls.SymbolKind.Class, name: 'disc', location: createLocation(4, 0, 5, 0), containerName: 'turtles'},
+      ];
+      const result = OutlineViewAdapter.createOutlineTrees(sourceItems);
+      expect(result.length).to.equal(1);
+      const r = (result: any);
+      expect(r[0].endPosition.row).to.equal(10);
+      expect(r[0].children.length).to.equal(1);
+      expect(r[0].children[0].endPosition.row).to.equal(8);
+      expect(r[0].children[0].children.length).to.equal(1);
+      expect(r[0].children[0].children[0].endPosition.row).to.equal(5);
+    });
   });
 
   describe('symbolToOutline', () => {

--- a/test/adapters/outline-view-adapter.test.js
+++ b/test/adapters/outline-view-adapter.test.js
@@ -50,6 +50,20 @@ describe('OutlineViewAdapter', () => {
       const result = OutlineViewAdapter.createOutlineTrees([missingContainerSource]);
       expect(result.length).to.equal(1);
       expect(result[0].representativeName).to.equal('missing');
+      expect(result[0].startPosition.row).to.equal(0);
+      expect(result[0].startPosition.column).to.equal(0);
+      expect(result[0].children).to.deep.equal([expected]);
+    });
+
+    it('creates an empty root container with a single source item when containerName is missing and matches own name', () => {
+      const sourceItem = {kind: ls.SymbolKind.Class, name: 'simple', location: createLocation(1, 2, 3, 4)};
+      const expected = OutlineViewAdapter.symbolToOutline(sourceItem);
+      const missingContainerSource = Object.assign(sourceItem, {containerName: 'simple'});
+      const result = OutlineViewAdapter.createOutlineTrees([missingContainerSource]);
+      expect(result.length).to.equal(1);
+      expect(result[0].representativeName).to.equal('simple');
+      expect(result[0].startPosition.row).to.equal(0);
+      expect(result[0].startPosition.column).to.equal(0);
       expect(result[0].children).to.deep.equal([expected]);
     });
 

--- a/test/adapters/outline-view-adapter.test.js
+++ b/test/adapters/outline-view-adapter.test.js
@@ -1,0 +1,66 @@
+// @flow
+
+import OutlineViewAdapter from '../../lib/adapters/outline-view-adapter';
+import * as ls from '../../lib/languageclient';
+import sinon from 'sinon';
+import {expect} from 'chai';
+
+describe('OutlineViewAdapter', () => {
+  const sourceItem = {
+    kind: ls.SymbolKind.Class,
+    name: 'Program',
+    location: {
+      range: {
+        start: {line: 1, character: 2},
+        end: {line: 3, character: 4},
+      },
+    },
+  };
+
+  beforeEach(() => {
+    global.sinon = sinon.sandbox.create();
+  });
+  afterEach(() => {
+    global.sinon.restore();
+  });
+
+  describe('canAdapt', () => {
+    it('returns true if documentSymbolProvider is supported', () => {
+      const result = OutlineViewAdapter.canAdapt({documentSymbolProvider: true});
+      expect(result).to.be.true;
+    });
+
+    it('returns false if documentSymbolProvider not supported', () => {
+      const result = OutlineViewAdapter.canAdapt({});
+      expect(result).to.be.false;
+    });
+  });
+
+  describe('createOutlineTree', () => {
+    it('creates an empty array given an empty array', () => {
+      const result = OutlineViewAdapter.createOutlineTrees([]);
+      expect(result).to.deep.equal([]);
+    });
+
+    it('creates a single converted item from a single source item', () => {
+      const expected = OutlineViewAdapter.symbolToOutline(sourceItem);
+      const result = OutlineViewAdapter.createOutlineTrees([sourceItem]);
+      expect(result).to.deep.equal([expected]);
+    });
+  });
+
+  describe('symbolToOutline', () => {
+    it('converts an individual item', () => {
+      const result = OutlineViewAdapter.symbolToOutline(sourceItem);
+      expect(result.icon).to.equal('type-class');
+      expect(result.representativeName).to.equal('Program');
+      expect(result.tokenizedText[0].kind).to.equal('type');
+      expect(result.tokenizedText[0].value).to.equal('Program');
+      expect(result.startPosition.row).to.equal(1);
+      expect(result.startPosition.column).to.equal(2);
+      expect(result.endPosition.row).to.equal(3);
+      expect(result.endPosition.column).to.equal(4);
+      expect(result.children).to.deep.equal([]);
+    });
+  });
+});


### PR DESCRIPTION
Because the LSP represents a tree as a flat list with a simple "containerName" property to indicate the parent name which may be non-unique we have to do all sorts of logic to unravel it. 

Fixes #81 