### PR TITLE
Implement textDocument/codeAction

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -7,6 +7,7 @@ flow-libs/
 flow-typed/
 
 [options]
+experimental.const_params=true
 
 [version]
 0.52.0

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ The language server protocol consists of a number of capabilities. Some of these
 | textDocument/documentHighlight  | Atom-IDE code highlights      |
 | textDocument/documentSymbol     | Atom-IDE outline view         |
 | workspace/symbol                | TBD                           |
-| textDocument/codeAction         | TBD                           |
+| textDocument/codeAction         | Atom-IDE code actions         |
 | textDocument/codeLens           | TBD                           |
 | textDocument/formatting         | Format File command           |
 | textDocument/rangeFormatting    | Format Selection command      |

--- a/flow-libs/atom-ide.js.flow
+++ b/flow-libs/atom-ide.js.flow
@@ -150,3 +150,29 @@ export type atomIde$CodeHighlightProvider = {
   priority: number,
   grammarScopes: Array<string>,
 };
+
+export type atomIde$DiagnosticType = 'Error' | 'Warning' | 'Info';
+
+export type atomIde$Diagnostic = {
+  providerName: string,
+  type: atomIde$DiagnosticType,
+  filePath: string,
+  text?: string,
+  range: atom$Range,
+};
+
+export interface atomIde$CodeAction {
+  apply(): Promise<void>,
+  getTitle(): Promise<string>,
+  dispose(): void,
+}
+
+export type atomIde$CodeActionProvider = {
+  grammarScopes: Array<string>,
+  priority: number,
+  getCodeActions(
+    editor: atom$TextEditor,
+    range: atom$Range,
+    diagnostics: Array<atomIde$Diagnostic>,
+  ): Promise<Array<CodeAction>>,
+};

--- a/lib/adapters/apply-edit-adapter.js
+++ b/lib/adapters/apply-edit-adapter.js
@@ -1,0 +1,79 @@
+// @flow
+
+import {
+  LanguageClientConnection,
+  type ApplyWorkspaceEditParams,
+  type ApplyWorkspaceEditResponse,
+} from '../languageclient';
+import Convert from '../convert';
+
+// Public: Adapts workspace/applyEdit commands to editors.
+export default class ApplyEditAdapter {
+  // Public: Attach to a {LanguageClientConnection} to receive edit events.
+  static attach(connection: LanguageClientConnection) {
+    connection.onApplyEdit(m => ApplyEditAdapter.onApplyEdit(m));
+  }
+
+  static async onApplyEdit(params: ApplyWorkspaceEditParams): Promise<ApplyWorkspaceEditResponse> {
+    // TODO(protocol v3.0): Handle versioned documentChanges
+    const {changes} = params.edit;
+    const uris = Object.keys(changes);
+    const paths = uris.map(Convert.uriToPath);
+    const editors = await Promise.all(
+      paths.map(path => {
+        return atom.workspace.open(path, {
+          searchAllPanes: true,
+          // Open new editors in the background.
+          activatePane: false,
+          activateItem: false,
+        });
+      }),
+    );
+
+    const checkpoints = [];
+    try {
+      for (let i = 0; i < editors.length; i++) {
+        const editor = editors[i];
+        const uri = uris[i];
+        // Get an existing editor for the file, or open a new one if it doesn't exist.
+        const edits = Convert.convertLsTextEdits(changes[uri]);
+        // Sort edits in reverse order to prevent edit conflicts.
+        edits.sort((edit1, edit2) => -edit1.oldRange.compare(edit2.oldRange));
+        const buffer = editor.getBuffer();
+        const checkpoint = buffer.createCheckpoint();
+        checkpoints.push({buffer, checkpoint});
+        let prevEdit = null;
+        for (const edit of edits) {
+          ApplyEditAdapter.validateEdit(buffer, edit, prevEdit);
+          buffer.setTextInRange(edit.oldRange, edit.newText);
+          prevEdit = edit;
+        }
+        buffer.groupChangesSinceCheckpoint(checkpoint);
+      }
+      return {applied: true};
+    } catch (e) {
+      atom.notifications.addError('workspace/applyEdits failed', {
+        description: 'Failed to apply edits.',
+        detail: e.message,
+      });
+      checkpoints.forEach(({buffer, checkpoint}) => {
+        buffer.revertToCheckpoint(checkpoint);
+      });
+      return {applied: false};
+    }
+  }
+
+  // Private: Do some basic sanity checking on the edit ranges.
+  static validateEdit(buffer: atom$TextBuffer, edit: atomIde$TextEdit, prevEdit: ?atomIde$TextEdit): void {
+    const path = buffer.getPath() || '';
+    if (prevEdit != null && edit.oldRange.end.compare(prevEdit.oldRange.start) > 0) {
+      throw Error(`Found overlapping edit ranges in ${path}`);
+    }
+    const startRow = edit.oldRange.start.row;
+    const startCol = edit.oldRange.start.column;
+    const lineLength = buffer.lineLengthForRow(startRow);
+    if (lineLength == null || startCol > lineLength) {
+      throw Error(`Out of range edit on ${path}:${startRow + 1}:${startCol + 1}`);
+    }
+  }
+}

--- a/lib/adapters/code-action-adapter.js
+++ b/lib/adapters/code-action-adapter.js
@@ -1,0 +1,71 @@
+// @flow
+
+import type LinterPushV2Adapter from './linter-push-v2-adapter';
+
+import invariant from 'assert';
+import {LanguageClientConnection, type ServerCapabilities} from '../languageclient';
+import Convert from '../convert';
+
+export default class CodeActionAdapter {
+  // Returns a {Boolean} indicating this adapter can adapt the server based on the
+  // given serverCapabilities.
+  static canAdapt(serverCapabilities: ServerCapabilities): boolean {
+    return serverCapabilities.codeActionProvider === true;
+  }
+
+  // Public: Retrieves code actions for a given editor, range, and context (diagnostics).
+  // Throws an error if codeActionProvider is not a registered capability.
+  //
+  // * `connection` A {LanguageClientConnection} to the language server that provides highlights.
+  // * `serverCapabilities` The {ServerCapabilities} of the language server that will be used.
+  // * `editor` The Atom {TextEditor} containing the diagnostics.
+  // * `range` The Atom {Range} to fetch code actions for.
+  // * `diagnostics` An {Array<atomIde$Diagnostic>} to fetch code actions for.
+  //                 This is typically a list of diagnostics intersecting `range`.
+  //
+  // Returns a {Promise} of an {Array} of {atomIde$CodeAction}s to display.
+  static async getCodeActions(
+    connection: LanguageClientConnection,
+    serverCapabilities: ServerCapabilities,
+    linterAdapter: ?LinterPushV2Adapter,
+    editor: atom$TextEditor,
+    range: atom$Range,
+    diagnostics: Array<atomIde$Diagnostic>,
+  ): Promise<Array<atomIde$CodeAction>> {
+    if (linterAdapter == null) {
+      return [];
+    }
+    invariant(serverCapabilities.codeActionProvider, 'Must have the textDocument/codeAction capability');
+    const commands = await connection.codeAction({
+      textDocument: Convert.editorToTextDocumentIdentifier(editor),
+      range: Convert.atomRangeToLSRange(range),
+      context: {
+        diagnostics: diagnostics.map(diagnostic => {
+          // Retrieve the stored diagnostic code if it exists.
+          // Until the Linter API provides a place to store the code,
+          // there's no real way for the code actions API to give it back to us.
+          const converted = Convert.atomIdeDiagnosticToLSDiagnostic(diagnostic);
+          if (diagnostic.range != null && diagnostic.text != null) {
+            const code = linterAdapter.getDiagnosticCode(editor, diagnostic.range, diagnostic.text);
+            if (code != null) {
+              converted.code = code;
+            }
+          }
+          return converted;
+        }),
+      },
+    });
+    return commands.map(command => ({
+      async apply() {
+        await connection.executeCommand({
+          command: command.command,
+          arguments: command.arguments,
+        });
+      },
+      getTitle() {
+        return Promise.resolve(command.title);
+      },
+      dispose() {},
+    }));
+  }
+}

--- a/lib/adapters/code-format-adapter.js
+++ b/lib/adapters/code-format-adapter.js
@@ -6,7 +6,6 @@ import {
   type DocumentRangeFormattingParams,
   type FormattingOptions,
   type ServerCapabilities,
-  type TextEdit,
 } from '../languageclient';
 import Convert from '../convert';
 
@@ -67,7 +66,7 @@ export default class CodeFormatAdapter {
     editor: atom$TextEditor,
   ): Promise<Array<atomIde$TextEdit>> {
     const edits = await connection.documentFormatting(CodeFormatAdapter.createDocumentFormattingParams(editor));
-    return CodeFormatAdapter.convertLsTextEdits(edits);
+    return Convert.convertLsTextEdits(edits);
   }
 
   // Public: Create {DocumentFormattingParams} to be sent to the language server when requesting an
@@ -100,7 +99,7 @@ export default class CodeFormatAdapter {
     const edits = await connection.documentRangeFormatting(
       CodeFormatAdapter.createDocumentRangeFormattingParams(editor, range),
     );
-    return CodeFormatAdapter.convertLsTextEdits(edits);
+    return Convert.convertLsTextEdits(edits);
   }
 
   // Public: Create {DocumentRangeFormattingParams} to be sent to the language server when requesting an
@@ -136,29 +135,6 @@ export default class CodeFormatAdapter {
     return {
       tabSize: editor.getTabLength(),
       insertSpaces: editor.getSoftTabs(),
-    };
-  }
-
-  // Public: Convert an array of language server protocol {TextEdit} objects to an
-  // equivalent array of Atom {TextEdit} objects.
-  //
-  // * `textEdits` The language server protocol {TextEdit} objects to convert.
-  //
-  // Returns an {Array} of Atom {TextEdit} objects.
-  static convertLsTextEdits(textEdits: Array<TextEdit>): Array<atomIde$TextEdit> {
-    return (textEdits || []).map(CodeFormatAdapter.convertLsTextEdit);
-  }
-
-  // Public: Convert a language server protocol {TextEdit} object to the
-  // Atom equivalent {TextEdit}.
-  //
-  // * `textEdits` The language server protocol {TextEdit} objects to convert.
-  //
-  // Returns an Atom {TextEdit} object.
-  static convertLsTextEdit(textEdit: TextEdit): atomIde$TextEdit {
-    return {
-      oldRange: Convert.lsRangeToAtomRange(textEdit.range),
-      newText: textEdit.newText,
     };
   }
 }

--- a/lib/adapters/document-sync-adapter.js
+++ b/lib/adapters/document-sync-adapter.js
@@ -249,7 +249,10 @@ class TextEditorSyncAdapter {
 
   _isPrimaryAdapter(): boolean {
     const lowestIdForBuffer = Math.min(
-      ...atom.workspace.getTextEditors().filter(t => t.getBuffer() === this._editor.getBuffer()).map(t => t.id),
+      ...atom.workspace
+        .getTextEditors()
+        .filter(t => t.getBuffer() === this._editor.getBuffer())
+        .map(t => t.id),
     );
     return lowestIdForBuffer === this._editor.id;
   }

--- a/lib/adapters/linter-push-v2-adapter.js
+++ b/lib/adapters/linter-push-v2-adapter.js
@@ -4,6 +4,7 @@ import {
   DiagnosticSeverity,
   LanguageClientConnection,
   type Diagnostic,
+  type DiagnosticCode,
   type PublishDiagnosticsParams,
 } from '../languageclient';
 import Convert from '../convert';
@@ -12,6 +13,7 @@ import Convert from '../convert';
 // to the user by way of the Linter Push (Indie) v2 API supported by Atom IDE UI.
 export default class LinterPushV2Adapter {
   _diagnosticMap: Map<string, Array<linter$V2Message>> = new Map();
+  _diagnosticCodes: Map<string, Map<string, ?DiagnosticCode>> = new Map();
   _indies: Set<linter$V2IndieDelegate> = new Set();
 
   // Public: Create a new {LinterPushV2Adapter} that will listen for diagnostics
@@ -48,8 +50,14 @@ export default class LinterPushV2Adapter {
   //            be captured and forwarded on to any attached {V2IndieDelegate}s.
   captureDiagnostics(params: PublishDiagnosticsParams): void {
     const path = Convert.uriToPath(params.uri);
-    const messages = params.diagnostics.map(d => this.diagnosticToV2Message(path, d));
+    const codeMap = new Map();
+    const messages = params.diagnostics.map(d => {
+      const linterMessage = this.diagnosticToV2Message(path, d);
+      codeMap.set(getCodeKey(linterMessage.location.position, d.message), d.code);
+      return linterMessage;
+    });
     this._diagnosticMap.set(path, messages);
+    this._diagnosticCodes.set(path, codeMap);
     this._indies.forEach(i => i.setMessages(path, messages));
   }
 
@@ -90,4 +98,23 @@ export default class LinterPushV2Adapter {
         return 'info';
     }
   }
+
+  // Private: Get the recorded diagnostic code for a range/message.
+  // Diagnostic codes are tricky because there's no suitable place in the Linter API for them.
+  // For now, we'll record the original code for each range/message combination and retrieve it
+  // when needed (e.g. for passing back into code actions)
+  getDiagnosticCode(editor: atom$TextEditor, range: atom$Range, text: string): ?(number | string) {
+    const path = editor.getPath();
+    if (path != null) {
+      const diagnosticCodes = this._diagnosticCodes.get(path);
+      if (diagnosticCodes != null) {
+        return diagnosticCodes.get(getCodeKey(range, text));
+      }
+    }
+    return null;
+  }
+}
+
+function getCodeKey(range: atom$Range, text: string): string {
+  return [].concat(...range.serialize(), text).join(',');
 }

--- a/lib/auto-languageclient.js
+++ b/lib/auto-languageclient.js
@@ -208,7 +208,9 @@ export default class AutoLanguageClient {
   // Autocomplete+ via LS completion---------------------------------------
   provideAutocomplete(): atom$AutocompleteProvider {
     return {
-      selector: this.getGrammarScopes().map(g => '.' + g).join(', '),
+      selector: this.getGrammarScopes()
+        .map(g => '.' + g)
+        .join(', '),
       excludeLowerPriority: false,
       getSuggestions: this.getSuggestions.bind(this),
     };

--- a/lib/auto-languageclient.js
+++ b/lib/auto-languageclient.js
@@ -7,6 +7,7 @@ import {CompositeDisposable} from 'atom';
 import {ConsoleLogger, NullLogger, type Logger} from './logger';
 import {ServerManager, type ActiveServer} from './server-manager.js';
 
+import ApplyEditAdapter from './adapters/apply-edit-adapter';
 import AutocompleteAdapter from './adapters/autocomplete-adapter';
 import CodeActionAdapter from './adapters/code-action-adapter';
 import CodeFormatAdapter from './adapters/code-format-adapter';
@@ -183,6 +184,7 @@ export default class AutoLanguageClient {
 
   // Start adapters that are not shared between servers
   startExclusiveAdapters(server: ActiveServer): void {
+    ApplyEditAdapter.attach(server.connection);
     NotificationsAdapter.attach(server.connection, this.name);
 
     if (DocumentSyncAdapter.canAdapt(server.capabilities)) {

--- a/lib/auto-languageclient.js
+++ b/lib/auto-languageclient.js
@@ -8,6 +8,7 @@ import {ConsoleLogger, NullLogger, type Logger} from './logger';
 import {ServerManager, type ActiveServer} from './server-manager.js';
 
 import AutocompleteAdapter from './adapters/autocomplete-adapter';
+import CodeActionAdapter from './adapters/code-action-adapter';
 import CodeFormatAdapter from './adapters/code-format-adapter';
 import CodeHighlightAdapter from './adapters/code-highlight-adapter';
 import DatatipAdapter from './adapters/datatip-adapter';
@@ -364,5 +365,31 @@ export default class AutoLanguageClient {
     }
 
     return CodeHighlightAdapter.highlight(server.connection, server.capabilities, editor, position);
+  }
+
+  provideCodeActions(): atomIde$CodeActionProvider {
+    return {
+      grammarScopes: this.getGrammarScopes(),
+      priority: 1,
+      getCodeActions: (editor, range, diagnostics) => {
+        return this.getCodeActions(editor, range, diagnostics);
+      },
+    };
+  }
+
+  async getCodeActions(editor: atom$TextEditor, range: atom$Range, diagnostics: Array<atomIde$Diagnostic>) {
+    const server = await this._serverManager.getServer(editor);
+    if (server == null || !CodeActionAdapter.canAdapt(server.capabilities)) {
+      return null;
+    }
+
+    return CodeActionAdapter.getCodeActions(
+      server.connection,
+      server.capabilities,
+      server.linterPushV2,
+      editor,
+      range,
+      diagnostics,
+    );
   }
 }

--- a/lib/convert.js
+++ b/lib/convert.js
@@ -171,4 +171,27 @@ export default class Convert {
         return [];
     }
   }
+
+  static atomIdeDiagnosticToLSDiagnostic(diagnostic: atomIde$Diagnostic): ls.Diagnostic {
+    return {
+      range: Convert.atomRangeToLSRange(diagnostic.range),
+      severity: Convert.diagnosticTypeToLSSeverity(diagnostic.type),
+      source: diagnostic.providerName,
+      message: diagnostic.text || '',
+    };
+  }
+
+  static diagnosticTypeToLSSeverity(type: atomIde$DiagnosticType): $Values<typeof ls.DiagnosticSeverity> {
+    switch (type) {
+      case 'Error':
+        return ls.DiagnosticSeverity.Error;
+      case 'Warning':
+        return ls.DiagnosticSeverity.Warning;
+      case 'Info':
+        return ls.DiagnosticSeverity.Information;
+      default:
+        (type: empty);
+        throw Error(`Unexpected diagnostic type ${type}`);
+    }
+  }
 }

--- a/lib/convert.js
+++ b/lib/convert.js
@@ -194,4 +194,27 @@ export default class Convert {
         throw Error(`Unexpected diagnostic type ${type}`);
     }
   }
+
+  // Public: Convert an array of language server protocol {TextEdit} objects to an
+  // equivalent array of Atom {TextEdit} objects.
+  //
+  // * `textEdits` The language server protocol {TextEdit} objects to convert.
+  //
+  // Returns an {Array} of Atom {TextEdit} objects.
+  static convertLsTextEdits(textEdits: ?Array<ls.TextEdit>): Array<atomIde$TextEdit> {
+    return (textEdits || []).map(Convert.convertLsTextEdit);
+  }
+
+  // Public: Convert a language server protocol {TextEdit} object to the
+  // Atom equivalent {TextEdit}.
+  //
+  // * `textEdits` The language server protocol {TextEdit} objects to convert.
+  //
+  // Returns an Atom {TextEdit} object.
+  static convertLsTextEdit(textEdit: ls.TextEdit): atomIde$TextEdit {
+    return {
+      oldRange: Convert.lsRangeToAtomRange(textEdit.range),
+      newText: textEdit.newText,
+    };
+  }
 }

--- a/lib/languageclient.js
+++ b/lib/languageclient.js
@@ -204,6 +204,10 @@ export class LanguageClientConnection {
     return this._sendRequest('textDocument/rename', params);
   }
 
+  executeCommand(params: ExecuteCommandParams): Promise<any> {
+    return this._sendRequest('workspace/executeCommand', params);
+  }
+
   _onRequest(type: {method: string}, callback: Object => Promise<any>): void {
     this._rpc.onRequest(type, value => {
       this._log.debug(`rpc.onRequest ${type.method}`, value);
@@ -261,6 +265,8 @@ export type Location = {
   range: Range,
 };
 
+export type DiagnosticCode = number | string;
+
 export type Diagnostic = {
   // The range at which the message applies.
   range: Range,
@@ -268,7 +274,7 @@ export type Diagnostic = {
   // client to interpret diagnostics as error, warning, info or hint.
   severity?: number,
   // The diagnostic's code. Can be omitted.
-  code?: number | string,
+  code?: DiagnosticCode,
   // A human-readable string describing the source of this
   // diagnostic, e.g. 'typescript' or 'super lint'.
   source?: string,
@@ -790,6 +796,12 @@ export type RenameParams = {
   // request must return a [ResponseError](#ResponseError) with an
   // appropriate message set.
   newName: string,
+};
+
+// Public: Parameters to send with a workspace/executeCommand request.
+export type ExecuteCommandParams = {
+  command: string,
+  arguments?: Array<any>,
 };
 
 // Window

--- a/lib/languageclient.js
+++ b/lib/languageclient.js
@@ -96,6 +96,15 @@ export class LanguageClientConnection {
     this._onNotification({method: 'telemetry/event'}, callback);
   }
 
+  // Public: Register a callback for the 'workspace/applyEdit' message.
+  //
+  // * `callback` The function to be called when the 'workspace/applyEdit' message is
+  //              received with 'ApplyWorkspaceEditParams' being passed as an object.
+  //              Should return a 'ApplyWorkspaceEditResponse' message.
+  onApplyEdit(callback: ApplyWorkspaceEditParams => Promise<ApplyWorkspaceEditResponse>): void {
+    this._onRequest({method: 'workspace/applyEdit'}, callback);
+  }
+
   // Public: Register a callback for the 'workspace/didChangeConfiguration' message.
   //
   // * `callback` The function to be called when the 'workspace/didChangeConfiguration' message is
@@ -798,12 +807,6 @@ export type RenameParams = {
   newName: string,
 };
 
-// Public: Parameters to send with a workspace/executeCommand request.
-export type ExecuteCommandParams = {
-  command: string,
-  arguments?: Array<any>,
-};
-
 // Window
 
 // Public: Details of a message to be shown to the user.
@@ -923,4 +926,20 @@ export type FileEvent = {
   uri: string,
   // Public: The type of change as specified by {FileChangeType}
   type: number,
+};
+
+// Public: Parameters to send with a workspace/executeCommand request.
+export type ExecuteCommandParams = {
+  command: string,
+  arguments?: Array<any>,
+};
+
+// Public: Parameters to receive with a workspace/applyEdit request.
+export type ApplyWorkspaceEditParams = {
+  edit: WorkspaceEdit,
+};
+
+// Public: Parameters to send with a workspace/applyEdit response.
+export type ApplyWorkspaceEditResponse = {
+  applied: boolean,
 };

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "clean": "rm -rf build",
     "compile": "babel lib --out-dir build/lib && babel test --out-dir build/test",
     "flow": "flow",
-    "lint": "eslint lib test",
+    "lint": "eslint lib test --max-warnings 0",
     "prepublish": "npm run clean && npm run compile",
     "test": "npm run compile && npm run lint && atom --test build/test",
     "watch": "babel lib --out-dir build/lib -w"

--- a/test/adapters/apply-edit-adapter.test.js
+++ b/test/adapters/apply-edit-adapter.test.js
@@ -1,0 +1,142 @@
+// @flow
+
+import {expect} from 'chai';
+import path from 'path';
+import sinon from 'sinon';
+import ApplyEditAdapter from '../../lib/adapters/apply-edit-adapter';
+import Convert from '../../lib/convert';
+
+const TEST_PATH1 = path.join(__dirname, 'test.txt');
+const TEST_PATH2 = path.join(__dirname, 'test2.txt');
+const TEST_PATH3 = path.join(__dirname, 'test3.txt');
+const TEST_PATH4 = path.join(__dirname, 'test4.txt');
+
+describe('ApplyEditAdapter', () => {
+  describe('onApplyEdit', () => {
+    beforeEach(() => {
+      sinon.spy(atom.notifications, 'addError');
+    });
+
+    afterEach(() => {
+      atom.notifications.addError.restore();
+    });
+
+    it('works for open files', async () => {
+      const editor = await atom.workspace.open(TEST_PATH1);
+      editor.setText('abc\ndef\n');
+
+      const result = await ApplyEditAdapter.onApplyEdit({
+        edit: {
+          changes: {
+            [Convert.pathToUri(TEST_PATH1)]: [
+              {
+                range: {
+                  start: {line: 0, character: 0},
+                  end: {line: 0, character: 3},
+                },
+                newText: 'def',
+              },
+              {
+                range: {
+                  start: {line: 1, character: 0},
+                  end: {line: 1, character: 3},
+                },
+                newText: 'ghi',
+              },
+            ],
+          },
+        },
+      });
+
+      expect(result.applied).to.equal(true);
+      expect(editor.getText()).to.equal('def\nghi\n');
+
+      // Undo should be atomic.
+      editor.getBuffer().undo();
+      expect(editor.getText()).to.equal('abc\ndef\n');
+    });
+
+    it('opens files that are not already open', async () => {
+      const result = await ApplyEditAdapter.onApplyEdit({
+        edit: {
+          changes: {
+            [TEST_PATH2]: [
+              {
+                range: {
+                  start: {line: 0, character: 0},
+                  end: {line: 0, character: 0},
+                },
+                newText: 'abc',
+              },
+            ],
+          },
+        },
+      });
+
+      expect(result.applied).to.equal(true);
+      const editor = await atom.workspace.open(TEST_PATH2);
+      expect(editor.getText()).to.equal('abc');
+    });
+
+    it('fails with overlapping edits', async () => {
+      const editor = await atom.workspace.open(TEST_PATH3);
+      editor.setText('abcdef\n');
+
+      const result = await ApplyEditAdapter.onApplyEdit({
+        edit: {
+          changes: {
+            [TEST_PATH3]: [
+              {
+                range: {
+                  start: {line: 0, character: 0},
+                  end: {line: 0, character: 3},
+                },
+                newText: 'def',
+              },
+              {
+                range: {
+                  start: {line: 0, character: 2},
+                  end: {line: 0, character: 4},
+                },
+                newText: 'ghi',
+              },
+            ],
+          },
+        },
+      });
+
+      expect(result.applied).to.equal(false);
+      expect(
+        atom.notifications.addError.calledWith('workspace/applyEdits failed', {
+          description: 'Failed to apply edits.',
+          detail: `Found overlapping edit ranges in ${TEST_PATH3}`,
+        }),
+      ).to.equal(true);
+      // No changes.
+      expect(editor.getText()).to.equal('abcdef\n');
+    });
+
+    it('fails with out-of-range edits', async () => {
+      const result = await ApplyEditAdapter.onApplyEdit({
+        edit: {
+          changes: {
+            [TEST_PATH4]: [
+              {
+                range: {
+                  start: {line: 0, character: 1},
+                  end: {line: 0, character: 2},
+                },
+                newText: 'def',
+              },
+            ],
+          },
+        },
+      });
+
+      expect(result.applied).to.equal(false);
+      const errorCalls = atom.notifications.addError.getCalls();
+      expect(errorCalls.length).to.equal(1);
+      expect(errorCalls[0].args[1].detail).to.equal(`Out of range edit on ${TEST_PATH4}:1:2`);
+    });
+  });
+});

--- a/test/adapters/code-action-adapter.test.js
+++ b/test/adapters/code-action-adapter.test.js
@@ -1,0 +1,93 @@
+// @flow
+
+import {Range} from 'atom';
+import {expect} from 'chai';
+import sinon from 'sinon';
+import * as ls from '../../lib/languageclient';
+import CodeActionAdapter from '../../lib/adapters/code-action-adapter';
+import LinterPushV2Adapter from '../../lib/adapters/linter-push-v2-adapter';
+import {createSpyConnection, createFakeEditor} from '../helpers.js';
+
+describe('CodeActionAdapter', () => {
+  describe('canAdapt', () => {
+    it('returns true if range formatting is supported', () => {
+      const result = CodeActionAdapter.canAdapt({
+        codeActionProvider: true,
+      });
+      expect(result).to.be.true;
+    });
+
+    it('returns false it no formatting supported', () => {
+      const result = CodeActionAdapter.canAdapt({});
+      expect(result).to.be.false;
+    });
+  });
+
+  describe('getCodeActions', () => {
+    it('fetches code actions from the connection', async () => {
+      const connection = createSpyConnection();
+      const languageClient = new ls.LanguageClientConnection(connection);
+      const testCommand: ls.Command = {
+        command: 'testCommand',
+        title: 'Test Command',
+        arguments: ['a', 'b'],
+      };
+      sinon.stub(languageClient, 'codeAction').returns(Promise.resolve([testCommand]));
+      sinon.spy(languageClient, 'executeCommand');
+
+      const linterAdapter = new LinterPushV2Adapter(languageClient);
+      sinon.stub(linterAdapter, 'getDiagnosticCode').returns('test code');
+
+      const testPath = '/test.txt';
+      const actions = await CodeActionAdapter.getCodeActions(
+        languageClient,
+        {codeActionProvider: true},
+        linterAdapter,
+        createFakeEditor(testPath),
+        new Range([1, 2], [3, 4]),
+        [
+          {
+            filePath: testPath,
+            type: 'Error',
+            text: 'test message',
+            range: new Range([1, 2], [3, 3]),
+            providerName: 'test linter',
+          },
+        ],
+      );
+
+      expect(languageClient.codeAction.called).to.be.true;
+      const args = languageClient.codeAction.getCalls()[0].args;
+      const params: ls.CodeActionParams = args[0];
+      expect(params.textDocument.uri).to.equal('file://' + testPath);
+      expect(params.range).to.deep.equal({
+        start: {line: 1, character: 2},
+        end: {line: 3, character: 4},
+      });
+      expect(params.context.diagnostics).to.deep.equal([
+        {
+          range: {
+            start: {line: 1, character: 2},
+            end: {line: 3, character: 3},
+          },
+          severity: ls.DiagnosticSeverity.Error,
+          code: 'test code',
+          source: 'test linter',
+          message: 'test message',
+        },
+      ]);
+
+      expect(actions.length).to.equal(1);
+      const codeAction = actions[0];
+      expect(await codeAction.getTitle()).to.equal('Test Command');
+      await codeAction.apply();
+      expect(languageClient.executeCommand.called).to.be.true;
+      expect(languageClient.executeCommand.getCalls()[0].args).to.deep.equal([
+        {
+          command: 'testCommand',
+          arguments: ['a', 'b'],
+        },
+      ]);
+    });
+  });
+});

--- a/test/adapters/code-format-adapter.test.js
+++ b/test/adapters/code-format-adapter.test.js
@@ -3,6 +3,7 @@
 import {Range} from 'atom';
 import {expect} from 'chai';
 import sinon from 'sinon';
+import Convert from '../../lib/convert';
 import * as ls from '../../lib/languageclient';
 import CodeFormatAdapter from '../../lib/adapters/code-format-adapter';
 import {createSpyConnection, createFakeEditor} from '../helpers.js';
@@ -182,7 +183,7 @@ describe('CodeFormatAdapter', () => {
         },
         newText: 'abc-def',
       };
-      const actual = CodeFormatAdapter.convertLsTextEdit(textEdit);
+      const actual = Convert.convertLsTextEdit(textEdit);
       expect(actual.oldRange).to.eql(new Range([1, 0], [2, 3]));
       expect(actual.newText).to.equal('abc-def');
     });

--- a/test/adapters/document-sync-adapter.test.js
+++ b/test/adapters/document-sync-adapter.test.js
@@ -51,7 +51,7 @@ describe('DocumentSyncAdapter', () => {
 
   describe('constructor', () => {
     function create(textDocumentSync) {
-      return new DocumentSyncAdapter((null: any), textDocumentSync, (null: any));
+      return new DocumentSyncAdapter((null: any), textDocumentSync, () => false);
     }
 
     it('sets _documentSyncKind correctly Incremental for v2 capabilities', () => {

--- a/test/adapters/linter-push-v2-adapter.test.js
+++ b/test/adapters/linter-push-v2-adapter.test.js
@@ -1,11 +1,13 @@
 // @flow
 
 import LinterPushV2Adapter from '../../lib/adapters/linter-push-v2-adapter';
+import Convert from '../../lib/convert';
 import * as ls from '../../lib/languageclient';
+import path from 'path';
 import sinon from 'sinon';
 import {expect} from 'chai';
 import {Point, Range} from 'atom';
-import {createSpyConnection} from '../helpers.js';
+import {createSpyConnection, createFakeEditor} from '../helpers.js';
 
 describe('LinterPushV2Adapter', () => {
   beforeEach(() => {
@@ -70,6 +72,35 @@ describe('LinterPushV2Adapter', () => {
     it('converts DiagnosticSeverity.Hint to "info"', () => {
       const severity = LinterPushV2Adapter.diagnosticSeverityToSeverity(ls.DiagnosticSeverity.Hint);
       expect(severity).equals('info');
+    });
+  });
+
+  describe('captureDiagnostics', () => {
+    it('stores diagnostic codes and allows their retrival', () => {
+      const languageClient = new ls.LanguageClientConnection(createSpyConnection());
+      const adapter = new LinterPushV2Adapter(languageClient);
+      const testPath = path.join(__dirname, 'test.txt');
+      adapter.captureDiagnostics({
+        uri: Convert.pathToUri(testPath),
+        diagnostics: [
+          {
+            message: 'Test message',
+            range: {
+              start: {line: 1, character: 2},
+              end: {line: 3, character: 4},
+            },
+            source: 'source',
+            code: 'test code',
+            severity: ls.DiagnosticSeverity.Information,
+            type: ls.DiagnosticSeverity.Information,
+          },
+        ],
+      });
+
+      const mockEditor = createFakeEditor(testPath);
+      expect(adapter.getDiagnosticCode(mockEditor, new Range([1, 2], [3, 4]), 'Test message')).to.equal('test code');
+      expect(adapter.getDiagnosticCode(mockEditor, new Range([1, 2], [3, 4]), 'Test message2')).to.not.exist;
+      expect(adapter.getDiagnosticCode(mockEditor, new Range([1, 2], [3, 5]), 'Test message')).to.not.exist;
     });
   });
 });


### PR DESCRIPTION
This is a fairly large change... I tried to break it up into reasonably-sized commits.

This hooks up code actions with `atom-ide-code-actions` from the Atom IDE UI package.
This video provides a better demonstration that I can describe:

[![Video](https://media.giphy.com/media/e2xptPGmMVWM0/giphy.gif)](https://media.giphy.com/media/e2xptPGmMVWM0/source.mp4)

There are two ways to trigger code actions, currently:
1. Hover over a diagnostic with a code action to reveal the code actions in the diagnostic UI.
2. Hit Alt-A (`diagnostics:show-actions-at-position`) to reveal a keyboard-friendly context menu.

Atom IDE UI's Code Actions API has been designed to mimic the LSP's API as closely as possible, and `getCodeActions` is only called when triggered as described above.

I've tested this with many of the actions available in the `ide-typescript` package. The video demonstrates two simple ones: adding a missing `this.` and adding a missing declaration for a new property.

The only tricky part about this API is that the Linter/Nuclide APIs have no way to provide a "code" for a diagnostic. In VSCode this isn't really surfaced anywhere either, so it's a very specific implementation detail... and unfortunately it seems like `ide-typescript` (and likely others) depend on this to provide code actions.

As a workaround I'm having `LinterPushV2Adapter` store codes for all the diagnostics it receives.. which is pretty gross, but I can't think of anything better. This obviously won't work for cross-language-server diagnostic/code action interactions, which is an intended use case, but in those cases I imagine relying on `code` is a bit less common.

It's kinda hard to make sure we get a consistent lookup between the diagnostics we provide and what we get back from the code actions API - I've decided to use the range + text as a lookup key. I don't imagine you'd have two diagnostics with the same message *and* same range.

cc @wbinnssmith, @seansegal

Closes #23.

Contributed under CC0.