### PR TITLE
Handle the same file open in multiple editors

### DIFF
--- a/flow-libs/atom.js.flow
+++ b/flow-libs/atom.js.flow
@@ -906,6 +906,7 @@ declare class atom$TextEditor extends atom$Model {
   onDidConflict(callback: () => void): IDisposable,
   serialize: () => mixed,
   getNonWordCharacters: (scopes: atom$ScopeDescriptor) => string,
+  id: number,
 }
 
 /**

--- a/lib/adapters/document-sync-adapter.js
+++ b/lib/adapters/document-sync-adapter.js
@@ -223,6 +223,8 @@ class TextEditorSyncAdapter {
   // expects this in reverse.
   sendIncrementalChanges(event: atom$DidStopChangingEvent): void {
     if (event.changes.length > 0) {
+      if (!this._isPrimaryAdapter()) return; // Multiple editors, we are not first
+
       this._bumpVersion();
       this._connection.didChangeTextDocument({
         textDocument: this.getVersionedTextDocumentIdentifier(),
@@ -260,6 +262,7 @@ class TextEditorSyncAdapter {
   didOpen(): void {
     const filePath = this._editor.getPath();
     if (filePath == null) return; // Not yet saved
+
     if (!this._isPrimaryAdapter()) return; // Multiple editors, we are not first
 
     this._connection.didOpenTextDocument({

--- a/lib/adapters/document-sync-adapter.js
+++ b/lib/adapters/document-sync-adapter.js
@@ -21,6 +21,7 @@ export default class DocumentSyncAdapter {
   _documentSyncKind: number;
   _editors: WeakMap<atom$TextEditor, TextEditorSyncAdapter> = new WeakMap();
   _connection: LanguageClientConnection;
+  _versions: Map<string, number> = new Map();
 
   // Public: Determine whether this adapter can be used to adapt a language server
   // based on the serverCapabilities matrix textDocumentSync capability either being Full or
@@ -108,7 +109,7 @@ export default class DocumentSyncAdapter {
   }
 
   _handleNewEditor(editor: atom$TextEditor): void {
-    const sync = new TextEditorSyncAdapter(editor, this._connection, this._documentSyncKind);
+    const sync = new TextEditorSyncAdapter(editor, this._connection, this._documentSyncKind, this._versions);
     this._editors.set(editor, sync);
     this._disposable.add(sync);
     this._disposable.add(
@@ -134,17 +135,23 @@ class TextEditorSyncAdapter {
   _editor: atom$TextEditor;
   _currentUri: string;
   _connection: LanguageClientConnection;
-  _version = 1;
   _fakeDidChangeWatchedFiles: boolean;
+  _versions: Map<string, number>;
 
   // Public: Create a {TextEditorSyncAdapter} in sync with a given language server.
   //
   // * `editor` A {TextEditor} to keep in sync.
   // * `connection` A {LanguageClientConnection} to a language server to keep in sync.
   // * `documentSyncKind` Whether to use Full (1) or Incremental (2) when sending changes.
-  constructor(editor: atom$TextEditor, connection: LanguageClientConnection, documentSyncKind: number) {
+  constructor(
+    editor: atom$TextEditor,
+    connection: LanguageClientConnection,
+    documentSyncKind: number,
+    versions: Map<string, number>,
+  ) {
     this._editor = editor;
     this._connection = connection;
+    this._versions = versions;
     this._fakeDidChangeWatchedFiles = atom.project.onDidChangeFiles == null;
 
     const changeTracking = this.setupChangeTracking(documentSyncKind);
@@ -190,32 +197,16 @@ class TextEditorSyncAdapter {
   getVersionedTextDocumentIdentifier(): VersionedTextDocumentIdentifier {
     return {
       uri: this.getEditorUri(),
-      version: this._version,
+      version: this._getVersion(this._editor.getPath() || ''),
     };
-  }
-
-  // Ensure when the document is opened we send notification to the language server
-  // so it can load it in and keep track of diagnostics etc.
-  didOpen(): void {
-    const uri = this.getEditorUri();
-    if (uri === '') {
-      return; // Not yet saved
-    }
-
-    this._connection.didOpenTextDocument({
-      textDocument: {
-        uri,
-        languageId: this.getLanguageId().toLowerCase(),
-        version: this._version,
-        text: this._editor.getText(),
-      },
-    });
   }
 
   // Public: Send the entire document to the language server. This is used when
   // operating in Full (1) sync mode.
   sendFullChanges(): void {
-    this._version++;
+    if (!this._isPrimaryAdapter()) return; // Multiple editors, we are not first
+
+    this._bumpVersion();
     this._connection.didChangeTextDocument({
       textDocument: this.getVersionedTextDocumentIdentifier(),
       contentChanges: [{text: this._editor.getText()}],
@@ -232,7 +223,7 @@ class TextEditorSyncAdapter {
   // expects this in reverse.
   sendIncrementalChanges(event: atom$DidStopChangingEvent): void {
     if (event.changes.length > 0) {
-      this._version++;
+      this._bumpVersion();
       this._connection.didChangeTextDocument({
         textDocument: this.getVersionedTextDocumentIdentifier(),
         contentChanges: event.changes.map(TextEditorSyncAdapter.textEditToContentChange).reverse(),
@@ -254,21 +245,48 @@ class TextEditorSyncAdapter {
     };
   }
 
+  _isPrimaryAdapter(): boolean {
+    return atom.workspace.getTextEditors().filter(t => t.getBuffer() === this._editor.getBuffer())[0] === this._editor;
+  }
+
+  _bumpVersion(): void {
+    const filePath = this._editor.getPath();
+    if (filePath == null) return;
+    this._versions.set(filePath, this._getVersion(filePath) + 1);
+  }
+
+  // Ensure when the document is opened we send notification to the language server
+  // so it can load it in and keep track of diagnostics etc.
+  didOpen(): void {
+    const filePath = this._editor.getPath();
+    if (filePath == null) return; // Not yet saved
+    if (!this._isPrimaryAdapter()) return; // Multiple editors, we are not first
+
+    this._connection.didOpenTextDocument({
+      textDocument: {
+        uri: this.getEditorUri(),
+        languageId: this.getLanguageId().toLowerCase(),
+        version: this._getVersion(filePath),
+        text: this._editor.getText(),
+      },
+    });
+  }
+
+  _getVersion(filePath: string): number {
+    return this._versions.get(filePath) || 1;
+  }
+
   // Called when the {TextEditor} is closed and sends the 'didCloseTextDocument' notification to
   // the connected language server.
   didClose(): void {
-    const filePath = this._editor.getPath();
-    if (filePath == null) {
-      return; // Not yet saved
-    }
+    if (this._editor.getPath() == null) return; // Not yet saved
 
-    const fileStillOpen = atom.workspace.getTextEditors().find(t => t.getPath() === filePath);
+    const fileStillOpen = atom.workspace.getTextEditors().find(t => t.getBuffer() === this._editor.getBuffer());
     if (fileStillOpen) {
       return; // Other windows or editors still have this file open
     }
 
-    const uri = this.getEditorUri();
-    this._connection.didCloseTextDocument({textDocument: {uri}});
+    this._connection.didCloseTextDocument({textDocument: {uri: this.getEditorUri()}});
   }
 
   // Called when the {TextEditor} saves and sends the 'didSaveTextDocument' notification to
@@ -276,6 +294,8 @@ class TextEditorSyncAdapter {
   // Note: Right now this also sends the `didChangeWatchedFiles` notification as well but that
   // will be sent from elsewhere soon.
   didSave(): void {
+    if (!this._isPrimaryAdapter()) return;
+
     const uri = this.getEditorUri();
     this._connection.didSaveTextDocument({textDocument: {uri}});
     if (this._fakeDidChangeWatchedFiles) {
@@ -286,11 +306,12 @@ class TextEditorSyncAdapter {
   }
 
   didRename(): void {
+    if (!this._isPrimaryAdapter()) return;
+
     const oldUri = this._currentUri;
     this._currentUri = this.getEditorUri();
     if (!oldUri) {
-      // Didn't previously have a name
-      return;
+      return; // Didn't previously have a name
     }
 
     this._connection.didCloseTextDocument({

--- a/lib/adapters/document-sync-adapter.js
+++ b/lib/adapters/document-sync-adapter.js
@@ -248,7 +248,13 @@ class TextEditorSyncAdapter {
   }
 
   _isPrimaryAdapter(): boolean {
-    return atom.workspace.getTextEditors().filter(t => t.getBuffer() === this._editor.getBuffer())[0] === this._editor;
+    const lowestIdForBuffer = Math.min(
+      ...atom.workspace
+        .getTextEditors()
+        .filter(t => t.getBuffer() === this._editor.getBuffer())
+        .map(t => t.id),
+    );
+    return lowestIdForBuffer === this._editor.id;
   }
 
   _bumpVersion(): void {

--- a/lib/auto-languageclient.js
+++ b/lib/auto-languageclient.js
@@ -203,7 +203,9 @@ export default class AutoLanguageClient {
   // Autocomplete+ via LS completion---------------------------------------
   provideAutocomplete(): atom$AutocompleteProvider {
     return {
-      selector: this.getGrammarScopes().map(g => '.' + g).join(', '),
+      selector: this.getGrammarScopes()
+        .map(g => '.' + g)
+        .join(', '),
       excludeLowerPriority: false,
       getSuggestions: this.getSuggestions.bind(this),
     };


### PR DESCRIPTION
There were a few problems:

1. Close was send multiple times (addressed in https://github.com/atom/atom-languageclient/commit/2b3588374c048f054f530afb6ab7729dc763cad2)
2. Open was sent multiple times (fixed here)
3. Rename was sent multiple times (fixed here)
4. Change tracking happened multiple times with differing version numbers

Now we just sync the editor that occurs first in the list of editors for that file. We do however share the version id.