### PR TITLE
Autocomplete: Take priority over the default provider

### DIFF
--- a/lib/auto-languageclient.js
+++ b/lib/auto-languageclient.js
@@ -233,6 +233,8 @@ export default class AutoLanguageClient {
       selector: this.getGrammarScopes()
         .map(g => '.' + g)
         .join(', '),
+      inclusionPriority: 1,
+      suggestionPriority: 2,
       excludeLowerPriority: false,
       getSuggestions: this.getSuggestions.bind(this),
     };


### PR DESCRIPTION
The autocompletions provided by the language server are usually more relevant than the default provider.

This PR increases the priority in order to display the completions above the default provider.

## Example
### master
<img width="594" alt="master" src="https://user-images.githubusercontent.com/13285808/30767795-52b693fc-a000-11e7-9d1f-12ed9448ff92.png">

### PR 
<img width="635" alt="PR" src="https://user-images.githubusercontent.com/13285808/30767796-5810618e-a000-11e7-9f1e-acf2e41f74bf.png">

Original issue: https://github.com/lgeiger/ide-python/issues/16#issuecomment-331579161
