### PR TITLE
Add support for CompletionItem.command

### DIFF
--- a/flow-libs/atom.js.flow
+++ b/flow-libs/atom.js.flow
@@ -1758,11 +1758,18 @@ type atom$AutocompleteRequest = {
   activatedManually?: boolean,
 };
 
+type atom$AutocompleteDidInsert = {
+  editor: TextEditor,
+  triggerPosition: atom$Point,
+  suggestion: atom$AutocompleteSuggestion
+}
+
 type atom$AutocompleteProvider = {
   selector: string,
   getSuggestions: (
     request: atom$AutocompleteRequest,
   ) => Promise<?Array<atom$AutocompleteSuggestion>>,
+  onDidInsertSuggestion?: (arg: atom$AutocompleteDidInsert) => void,
   disableForSelector?: string,
   inclusionPriority?: number,
   excludeLowerPriority?: boolean,

--- a/flow-libs/atom.js.flow
+++ b/flow-libs/atom.js.flow
@@ -1761,7 +1761,7 @@ type atom$AutocompleteRequest = {
 type atom$AutocompleteDidInsert = {
   editor: TextEditor,
   triggerPosition: atom$Point,
-  suggestion: atom$AutocompleteSuggestion
+  suggestion: atom$AutocompleteSuggestion,
 }
 
 type atom$AutocompleteProvider = {

--- a/lib/adapters/autocomplete-adapter.js
+++ b/lib/adapters/autocomplete-adapter.js
@@ -13,8 +13,6 @@ import {CancellationTokenSource} from 'vscode-jsonrpc';
 import Convert from '../convert';
 import Utils from '../utils';
 
-export type ExtendedAutocompleteSuggestion = atom$AutocompleteSuggestion & {_completionItem?: CompletionItem};
-
 // Public: Adapts the language server protocol "textDocument/completion" to the Atom
 // AutoComplete+ package.
 export default class AutocompleteAdapter {

--- a/lib/adapters/autocomplete-adapter.js
+++ b/lib/adapters/autocomplete-adapter.js
@@ -11,6 +11,8 @@ import {
 } from '../languageclient';
 import Convert from '../convert';
 
+export type ExtendedAutocompleteSuggestion = atom$AutocompleteSuggestion & {_completionItem?: CompletionItem};
+
 // Public: Adapts the language server protocol "textDocument/completion" to the Atom
 // AutoComplete+ package.
 export default class AutocompleteAdapter {
@@ -78,9 +80,10 @@ export default class AutocompleteAdapter {
   static completionItemToSuggestion(
     item: CompletionItem,
     request: atom$AutocompleteRequest,
-  ): atom$AutocompleteSuggestion {
+  ): ExtendedAutocompleteSuggestion {
     const suggestion = AutocompleteAdapter.basicCompletionItemToSuggestion(item);
     AutocompleteAdapter.applyTextEditToSuggestion(item.textEdit, request.editor, suggestion);
+    suggestion._completionItem = item;
     return suggestion;
   }
 
@@ -90,7 +93,7 @@ export default class AutocompleteAdapter {
   //             items to be converted.
   //
   // Returns an AutoComplete+ suggestion.
-  static basicCompletionItemToSuggestion(item: CompletionItem): atom$AutocompleteSuggestion {
+  static basicCompletionItemToSuggestion(item: CompletionItem): ExtendedAutocompleteSuggestion {
     return {
       text: item.insertText || item.label,
       displayText: item.label,

--- a/lib/auto-languageclient.js
+++ b/lib/auto-languageclient.js
@@ -9,7 +9,7 @@ import {ServerManager, type ActiveServer} from './server-manager.js';
 import Convert from './convert.js';
 
 import ApplyEditAdapter from './adapters/apply-edit-adapter';
-import AutocompleteAdapter from './adapters/autocomplete-adapter';
+import AutocompleteAdapter, {type ExtendedAutocompleteSuggestion} from './adapters/autocomplete-adapter';
 import CodeActionAdapter from './adapters/code-action-adapter';
 import CodeFormatAdapter from './adapters/code-format-adapter';
 import CodeHighlightAdapter from './adapters/code-highlight-adapter';
@@ -329,6 +329,10 @@ export default class AutoLanguageClient {
       suggestionPriority: 2,
       excludeLowerPriority: false,
       getSuggestions: this.getSuggestions.bind(this),
+      onDidInsertSuggestion: arg => {
+        const completionItem = ((arg.suggestion: any): ExtendedAutocompleteSuggestion)._completionItem;
+        this.onDidInsertSuggestion(arg, completionItem);
+      },
     };
   }
 
@@ -341,6 +345,8 @@ export default class AutoLanguageClient {
     this.autoComplete = this.autoComplete || new AutocompleteAdapter();
     return this.autoComplete.getSuggestions(server.connection, request);
   }
+
+  onDidInsertSuggestion(arg: atom$AutocompleteDidInsert, completionItem: ?ls.CompletionItem): void {}
 
   // Definitions via LS documentHighlight and gotoDefinition------------
   provideDefinitions(): atomIde$DefinitionProvider {

--- a/lib/auto-languageclient.js
+++ b/lib/auto-languageclient.js
@@ -10,7 +10,7 @@ import {ServerManager, type ActiveServer} from './server-manager.js';
 import Convert from './convert.js';
 
 import ApplyEditAdapter from './adapters/apply-edit-adapter';
-import AutocompleteAdapter, {type ExtendedAutocompleteSuggestion} from './adapters/autocomplete-adapter';
+import AutocompleteAdapter from './adapters/autocomplete-adapter';
 import CodeActionAdapter from './adapters/code-action-adapter';
 import CodeFormatAdapter from './adapters/code-format-adapter';
 import CodeHighlightAdapter from './adapters/code-highlight-adapter';


### PR DESCRIPTION
Maybe controversial smuggling extra data around with the completion item, which we get returned to us in `onDidInsertSuggestion`. Maybe there's a better way, also I have never used flow so this is probably not ideal.

I think the same strategy as for `command` can be used for additional text edits - i.e. on the didInsert callback the additional edits can be retrieved and applied to the document.

#114