### PR TITLE
Add ide-python to community packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,7 @@ Right now we have the following experimental Atom LSP packages in development. T
 * [ide-reason](https://github.com/zaaack/atom-ide-reason) provides OCaml and Reason support using [OCaml Language Server](https://github.com/freebroccolo/ocaml-language-server)
 * [ide-rust](https://github.com/mehcode/atom-ide-rust) provides Rust support using [Rust Language Server](https://github.com/rust-lang-nursery/rls)
 * [ide-vue](https://github.com/rwatts3/atom-ide-vue) provides Vue language support using the [Vue Language Server](https://www.npmjs.com/package/vue-language-server)
+* [ide-python](https://github.com/lgeiger/ide-python) provides Python support via [Python Language Server](https://github.com/palantir/python-language-server)
 
 ### Other language servers
 


### PR DESCRIPTION
This adds [`ide-python`](https://github.com/lgeiger/ide-python) to the list of community packages.