### PR TITLE
Allow client didChangeWatchedFiles filtering

### DIFF
--- a/lib/auto-languageclient.js
+++ b/lib/auto-languageclient.js
@@ -106,7 +106,12 @@ export default class AutoLanguageClient {
   activate(): void {
     this.name = `${this.getLanguageName()} (${this.getServerName()})`;
     this.logger = this.getLogger();
-    this._serverManager = new ServerManager(p => this.startServer(p), this.logger, e => this.shouldStartForEditor(e));
+    this._serverManager = new ServerManager(
+      p => this.startServer(p),
+      this.logger,
+      e => this.shouldStartForEditor(e),
+      path => this.filterChangeWatchedFiles(path),
+    );
     this._serverManager.startListening();
     process.on('exit', () => this.exitCleanup.bind(this));
   }
@@ -437,5 +442,14 @@ export default class AutoLanguageClient {
     return new Disposable(() => {
       this._signatureHelpRegistry = null;
     });
+  }
+
+  /**
+   * `didChangeWatchedFiles` message filtering, override for custom logic.
+   * @param filePath path of a file that has changed in the project path
+   * @return false => message will not be sent to the language server
+   */
+  filterChangeWatchedFiles(filePath: string): boolean {
+    return true;
   }
 }

--- a/lib/server-manager.js
+++ b/lib/server-manager.js
@@ -34,16 +34,19 @@ export class ServerManager {
   _normalizedProjectPaths: Array<string> = [];
   _startForEditor: (editor: atom$TextEditor) => boolean;
   _startServer: (projectPath: string) => Promise<ActiveServer>;
+  _changeWatchedFileFilter: (filePath: string) => boolean;
 
   constructor(
     startServer: (projectPath: string) => Promise<ActiveServer>,
     logger: Logger,
     startForEditor: (editor: atom$TextEditor) => boolean,
+    changeWatchedFileFilter: (filePath: string) => boolean,
   ) {
     this._startServer = startServer;
     this._logger = logger;
     this._startForEditor = startForEditor;
     this.updateNormalizedProjectPaths();
+    this._changeWatchedFileFilter = changeWatchedFileFilter;
   }
 
   startListening(): void {
@@ -228,6 +231,10 @@ export class ServerManager {
     for (const activeServer of this._activeServers) {
       const changes = [];
       for (const fileEvent of fileEvents) {
+        if (this._changeWatchedFileFilter(fileEvent.path) === false) {
+          continue;
+        }
+
         if (fileEvent.path.startsWith(activeServer.projectPath)) {
           changes.push(Convert.atomFileEventToLSFileEvents(fileEvent)[0]);
         }


### PR DESCRIPTION
This change will allow clients to help address #125. Even when ignored server side this can produce a lot of message churn when the language server is spamming files somewhere in the project, ie rls.

Here's a screen just to show you the possible magnitude. This is _with_ my patch having the rls ignore these btw.
![debug-no-filter](https://user-images.githubusercontent.com/2331607/32118780-d4fd6718-bb4a-11e7-9128-fac192fd43ca.png)

With this patch and *ide-rust* popping a filter into the equation the situation is improved.
```js
// ide-rust
class RustLanguageClient extends AutoLanguageClient {
  ...
  filterChangeWatchedFiles(filePath) {
    return !filePath.includes('/.git/') && !filePath.includes('/target/rls/')
  }
}
```

![screenshot from 2017-10-27 19-08-49](https://user-images.githubusercontent.com/2331607/32118903-57e31484-bb4b-11e7-896b-4da3a95751ac.png)
