### PR TITLE
Fixed file URI parsing

### DIFF
--- a/lib/convert.js
+++ b/lib/convert.js
@@ -24,15 +24,15 @@ export default class Convert {
   // * `uri` A Uri to convert to a file path.
   //
   // Returns a file path corresponding to the Uri. e.g. /a/b/c.txt
-  // If the Uri does not begin file:// then it is returned as-is to allow Atom
+  // If the Uri does not begin file: then it is returned as-is to allow Atom
   // to deal with http/https sources in the future.
   static uriToPath(uri: string): string {
-    let filePath = decodeURIComponent(uri);
-    if (!filePath.startsWith('file://')) {
+    const url = require('url').parse(uri);
+    if (url.protocol !== 'file:') {
       return uri;
     }
 
-    filePath = filePath.substr(7);
+    let filePath = decodeURIComponent(url.path);
     if (process.platform === 'win32') {
       // Deal with Windows drive names
       if (filePath[0] === '/') {

--- a/lib/convert.js
+++ b/lib/convert.js
@@ -2,6 +2,7 @@
 
 import * as ls from './languageclient';
 import {Point, Range} from 'atom';
+import URL from 'url';
 
 // Public: Class that contains a number of helper methods for general conversions
 // between the language server protocol and Atom/Atom packages.
@@ -27,8 +28,8 @@ export default class Convert {
   // If the Uri does not begin file: then it is returned as-is to allow Atom
   // to deal with http/https sources in the future.
   static uriToPath(uri: string): string {
-    const url = require('url').parse(uri);
-    if (url.protocol !== 'file:') {
+    const url = URL.parse(uri);
+    if (url.protocol !== 'file:' || url.path === undefined) {
       return uri;
     }
 

--- a/test/convert.test.js
+++ b/test/convert.test.js
@@ -80,6 +80,11 @@ describe('Convert', () => {
       setProcessPlatform('darwin');
       expect(Convert.uriToPath('file:/a/b/c/d.txt')).equals('/a/b/c/d.txt');
     });
+
+    it('parses URI without double slash in the beginning on Windows', () => {
+      setProcessPlatform('win32');
+      expect(Convert.uriToPath('file:/x:/a/b/c/d.txt')).equals('x:\\a\\b\\c\\d.txt');
+    });
   });
 
   describe('pointToPosition', () => {

--- a/test/convert.test.js
+++ b/test/convert.test.js
@@ -75,6 +75,10 @@ describe('Convert', () => {
       setProcessPlatform('darwin');
       expect(Convert.uriToPath('file:///a/sp%20ace/do$lar')).equals('/a/sp ace/do$lar');
     });
+
+    it('parses URI without double slash in the beginning', () => {
+      expect(Convert.uriToPath('file:/a/b/c/d.txt')).equals('/a/b/c/d.txt');
+    });
   });
 
   describe('pointToPosition', () => {

--- a/test/convert.test.js
+++ b/test/convert.test.js
@@ -77,6 +77,7 @@ describe('Convert', () => {
     });
 
     it('parses URI without double slash in the beginning', () => {
+      setProcessPlatform('darwin');
       expect(Convert.uriToPath('file:/a/b/c/d.txt')).equals('/a/b/c/d.txt');
     });
   });


### PR DESCRIPTION
Double slash after the `file:` protocol name is optional and shouldn't be required. See for example this [SO answer](https://stackoverflow.com/a/44725349/736957) with references to the [URI specification](https://tools.ietf.org/html/rfc3986#section-3).

I discovered this problem when the server (for which I'm writing a plugin) sent `publishDiagnostic` with URI like `file:/root/path/file.foo`. Atom treated this as a relative path, so it became `/root/path/file:/root/path/file.foo`.

I'm totally new to Electron, JavaScript, etc. So this may be not the best solution. Tell me if I need to change it.