### PR TITLE
Allow completion items to be modified easily

### DIFF
--- a/lib/adapters/autocomplete-adapter.js
+++ b/lib/adapters/autocomplete-adapter.js
@@ -23,17 +23,20 @@ export default class AutocompleteAdapter {
   //
   // * `connection` A {LanguageClientConnection} to the language server to query.
   // * `request` An {Object} with the AutoComplete+ request to satisfy.
+  // * `onDidConvertCompletionItem` A function that takes a {CompletionItem}, an {atom$AutocompleteSuggestion}
+  //   and a {atom$AutocompleteRequest} allowing you to adjust converted items.
   //
   // Returns a {Promise} of an {Array} of {Object}s containing the AutoComplete+
   // suggestions to display.
   async getSuggestions(
     connection: LanguageClientConnection,
     request: atom$AutocompleteRequest,
+    onDidConvertCompletionItem: (CompletionItem, atom$AutocompleteSuggestion, atom$AutocompleteRequest) => void,
   ): Promise<Array<atom$AutocompleteSuggestion>> {
     const completionItems = await connection.completion(
       AutocompleteAdapter.requestToTextDocumentPositionParams(request),
     );
-    return AutocompleteAdapter.completionItemsToSuggestions(completionItems, request);
+    return AutocompleteAdapter.completionItemsToSuggestions(completionItems, request, onDidConvertCompletionItem);
   }
 
   // Public: Create TextDocumentPositionParams to be sent to the language server
@@ -57,14 +60,17 @@ export default class AutocompleteAdapter {
   // * `completionItems` An {Array} of {CompletionItem} objects or a {CompletionList} containing completion
   //           items to be converted.
   // * `request` An {Object} with the AutoComplete+ request to use.
+  // * `onDidConvertCompletionItem` A function that takes a {CompletionItem}, an {atom$AutocompleteSuggestion}
+  //   and a {atom$AutocompleteRequest} allowing you to adjust converted items.
   //
   // Returns an {Array} of AutoComplete+ suggestions.
   static completionItemsToSuggestions(
     completionItems: Array<CompletionItem> | CompletionList,
     request: atom$AutocompleteRequest,
+    onDidConvertCompletionItem: (CompletionItem, atom$AutocompleteSuggestion, atom$AutocompleteRequest) => void,
   ): Array<atom$AutocompleteSuggestion> {
     return (Array.isArray(completionItems) ? completionItems : completionItems.items || []).map(s =>
-      AutocompleteAdapter.completionItemToSuggestion(s, request),
+      AutocompleteAdapter.completionItemToSuggestion(s, request, onDidConvertCompletionItem),
     );
   }
 
@@ -73,16 +79,18 @@ export default class AutocompleteAdapter {
   // * `item` An {Array} of {CompletionItem} objects or a {CompletionList} containing completion
   //             items to be converted.
   // * `request` An {Object} with the AutoComplete+ request to use.
+  // * `onDidConvertCompletionItem` A function that takes a {CompletionItem}, an {atom$AutocompleteSuggestion}
+  //   and a {atom$AutocompleteRequest} allowing you to adjust converted items.
   //
   // Returns an AutoComplete+ suggestion.
   static completionItemToSuggestion(
     item: CompletionItem,
     request: atom$AutocompleteRequest,
+    onDidConvertCompletionItem: (CompletionItem, atom$AutocompleteSuggestion, atom$AutocompleteRequest) => void,
   ): atom$AutocompleteSuggestion {
     const suggestion = AutocompleteAdapter.basicCompletionItemToSuggestion(item);
     AutocompleteAdapter.applyTextEditToSuggestion(item.textEdit, request.editor, suggestion);
-    // TODO: Snippets
-    return suggestion;
+    return onDidConvertCompletionItem != null ? onDidConvertCompletionItem(item, suggestion, request) : suggestion;
   }
 
   // Public: Convert the primary parts of a language server protocol CompletionItem to an AutoComplete+ suggestion.

--- a/lib/adapters/autocomplete-adapter.js
+++ b/lib/adapters/autocomplete-adapter.js
@@ -36,7 +36,8 @@ export default class AutocompleteAdapter {
     onDidConvertCompletionItem?: (CompletionItem, atom$AutocompleteSuggestion, atom$AutocompleteRequest) => void,
   ): Promise<Array<atom$AutocompleteSuggestion>> {
     const items = await connection.completion(AutocompleteAdapter.requestToTextDocumentPositionParams(request));
-    return this.completionItemsToSuggestions(items, request, onDidConvertCompletionItem);
+    this._lastSuggestions = this.completionItemsToSuggestions(items, request, onDidConvertCompletionItem);
+    return Array.from(this._lastSuggestions.keys());
   }
 
   // Public: Obtain a complete version of a suggestion with additional information
@@ -57,10 +58,7 @@ export default class AutocompleteAdapter {
     if (originalCompletionItem != null && originalCompletionItem[1] === false) {
       const resolveCompletionItem = await connection.completionItemResolve(originalCompletionItem[0]);
       if (resolveCompletionItem != null) {
-        const resolvedSuggestion = AutocompleteAdapter.completionItemToSuggestion(resolveCompletionItem, request, onDidConvertCompletionItem);
-        this._lastSuggestions.delete(suggestion);
-        this._lastSuggestions.set(resolvedSuggestion, [resolveCompletionItem, true]);
-        return resolvedSuggestion;
+        AutocompleteAdapter.completionItemToSuggestion(resolveCompletionItem, suggestion, request, onDidConvertCompletionItem);
       }
     }
 
@@ -91,16 +89,15 @@ export default class AutocompleteAdapter {
   // * `onDidConvertCompletionItem` A function that takes a {CompletionItem}, an {atom$AutocompleteSuggestion}
   //   and a {atom$AutocompleteRequest} allowing you to adjust converted items.
   //
-  // Returns an {Array} of AutoComplete+ suggestions ordered by the CompletionItems sortText.
+  // Returns a {Map} of AutoComplete+ suggestions ordered by the CompletionItems sortText.
   completionItemsToSuggestions(
     completionItems: Array<CompletionItem> | CompletionList,
     request: atom$AutocompleteRequest,
     onDidConvertCompletionItem?: (CompletionItem, atom$AutocompleteSuggestion, atom$AutocompleteRequest) => void,
-  ): Array<atom$AutocompleteSuggestion> {
-    this._lastSuggestions = new Map((Array.isArray(completionItems) ? completionItems : completionItems.items || [])
+  ): Map<atom$AutocompleteSuggestion, CompletionItem> {
+    return new Map((Array.isArray(completionItems) ? completionItems : completionItems.items || [])
       .sort((a, b) => (a.sortText || a.label).localeCompare(b.sortText || b.label))
-      .map(s => [AutocompleteAdapter.completionItemToSuggestion(s, request, onDidConvertCompletionItem), [s, false]]));
-    return Array.from(this._lastSuggestions.keys());
+      .map(s => [AutocompleteAdapter.completionItemToSuggestion(s, { /* TODO: FlowType */ }, request, onDidConvertCompletionItem), [s, false]]));
   }
 
   // Public: Convert a language server protocol CompletionItem to an AutoComplete+ suggestion.
@@ -114,10 +111,11 @@ export default class AutocompleteAdapter {
   // Returns an AutoComplete+ suggestion.
   static completionItemToSuggestion(
     item: CompletionItem,
+    suggestion: atom$AutocompleteSuggestion,
     request: atom$AutocompleteRequest,
-    onDidConvertCompletionItem?: (CompletionItem, atom$AutocompleteSuggestion, atom$AutocompleteRequest) => void,
+    onDidConvertCompletionItem?: (CompletionItem, atom$AutocompleteSuggestion, atom$AutocompleteRequest) => atom$AutocompleteSuggestion,
   ): atom$AutocompleteSuggestion {
-    const suggestion = AutocompleteAdapter.basicCompletionItemToSuggestion(item);
+    AutocompleteAdapter.applyCompletionItemToSuggestion(item, suggestion);
     AutocompleteAdapter.applyTextEditToSuggestion(item.textEdit, request.editor, suggestion);
     if (onDidConvertCompletionItem != null) {
       onDidConvertCompletionItem(item, suggestion, request);
@@ -131,17 +129,15 @@ export default class AutocompleteAdapter {
   //             items to be converted.
   //
   // Returns an {atom$AutocompleteSuggestion} created from the {CompletionItem}.
-  static basicCompletionItemToSuggestion(item: CompletionItem): atom$AutocompleteSuggestion {
-    return {
-      text: item.insertText || item.label,
-      displayText: item.label,
-      filterText: item.filterText || item.label,
-      snippet: item.insertTextFormat === 2 ? item.insertText : undefined,
-      type: AutocompleteAdapter.completionKindToSuggestionType(item.kind),
-      rightLabel: item.detail,
-      description: item.documentation,
-      descriptionMarkdown: item.documentation,
-    };
+  static applyCompletionItemToSuggestion(item: CompletionItem, suggestion: atom$AutocompleteSuggestion = { }) {
+    suggestion.text = item.insertText || item.label
+    suggestion.displayText = item.label
+    suggestion.filterText = item.filterText || item.label
+    suggestion.snippet = item.insertTextFormat === 2 ? item.insertText : undefined
+    suggestion.type = AutocompleteAdapter.completionKindToSuggestionType(item.kind)
+    suggestion.rightLabel = item.detail
+    suggestion.description = item.documentation
+    suggestion.descriptionMarkdown = item.documentation
   }
 
   // Public: Applies the textEdit part of a language server protocol CompletionItem to an

--- a/lib/adapters/autocomplete-adapter.js
+++ b/lib/adapters/autocomplete-adapter.js
@@ -130,13 +130,13 @@ export default class AutocompleteAdapter {
   //
   // Returns an {atom$AutocompleteSuggestion} created from the {CompletionItem}.
   static applyCompletionItemToSuggestion(item: CompletionItem, suggestion: atom$AutocompleteSuggestion) {
-    suggestion.text = item.insertText || item.label
-    suggestion.displayText = item.label
-    suggestion.snippet = item.insertTextFormat === 2 ? item.insertText : undefined
-    suggestion.type = AutocompleteAdapter.completionKindToSuggestionType(item.kind)
-    suggestion.rightLabel = item.detail
-    suggestion.description = item.documentation
-    suggestion.descriptionMarkdown = item.documentation
+    suggestion.text = item.insertText || item.label;
+    suggestion.displayText = item.label;
+    suggestion.snippet = item.insertTextFormat === 2 ? item.insertText : undefined;
+    suggestion.type = AutocompleteAdapter.completionKindToSuggestionType(item.kind);
+    suggestion.rightLabel = item.detail;
+    suggestion.description = item.documentation;
+    suggestion.descriptionMarkdown = item.documentation;
   }
 
   // Public: Applies the textEdit part of a language server protocol CompletionItem to an

--- a/lib/adapters/autocomplete-adapter.js
+++ b/lib/adapters/autocomplete-adapter.js
@@ -33,7 +33,7 @@ export default class AutocompleteAdapter {
   async getSuggestions(
     connection: LanguageClientConnection,
     request: atom$AutocompleteRequest,
-    onDidConvertCompletionItem: (CompletionItem, atom$AutocompleteSuggestion, atom$AutocompleteRequest) => void,
+    onDidConvertCompletionItem?: (CompletionItem, atom$AutocompleteSuggestion, atom$AutocompleteRequest) => void,
   ): Promise<Array<atom$AutocompleteSuggestion>> {
     const items = await connection.completion(AutocompleteAdapter.requestToTextDocumentPositionParams(request));
     return this.completionItemsToSuggestions(items, request, onDidConvertCompletionItem);
@@ -94,7 +94,7 @@ export default class AutocompleteAdapter {
   completionItemsToSuggestions(
     completionItems: Array<CompletionItem> | CompletionList,
     request: atom$AutocompleteRequest,
-    onDidConvertCompletionItem: (CompletionItem, atom$AutocompleteSuggestion, atom$AutocompleteRequest) => void,
+    onDidConvertCompletionItem?: (CompletionItem, atom$AutocompleteSuggestion, atom$AutocompleteRequest) => void,
   ): Array<atom$AutocompleteSuggestion> {
     this._lastSuggestions = new Map((Array.isArray(completionItems) ? completionItems : completionItems.items || [])
       .sort((a, b) => (a.sortText || a.label).localeCompare(b.sortText || b.label))
@@ -114,11 +114,14 @@ export default class AutocompleteAdapter {
   static completionItemToSuggestion(
     item: CompletionItem,
     request: atom$AutocompleteRequest,
-    onDidConvertCompletionItem: (CompletionItem, atom$AutocompleteSuggestion, atom$AutocompleteRequest) => void,
+    onDidConvertCompletionItem?: (CompletionItem, atom$AutocompleteSuggestion, atom$AutocompleteRequest) => void,
   ): atom$AutocompleteSuggestion {
     const suggestion = AutocompleteAdapter.basicCompletionItemToSuggestion(item);
     AutocompleteAdapter.applyTextEditToSuggestion(item.textEdit, request.editor, suggestion);
-    return onDidConvertCompletionItem != null ? onDidConvertCompletionItem(item, suggestion, request) : suggestion;
+    if (onDidConvertCompletionItem != null) {
+      onDidConvertCompletionItem(item, suggestion, request);
+    }
+    return suggestion;
   }
 
   // Public: Convert the primary parts of a language server protocol CompletionItem to an AutoComplete+ suggestion.

--- a/lib/adapters/autocomplete-adapter.js
+++ b/lib/adapters/autocomplete-adapter.js
@@ -94,26 +94,26 @@ export default class AutocompleteAdapter {
     completionItems: Array<CompletionItem> | CompletionList,
     request: atom$AutocompleteRequest,
     onDidConvertCompletionItem?: (CompletionItem, atom$AutocompleteSuggestion, atom$AutocompleteRequest) => void,
-  ): Map<atom$AutocompleteSuggestion, CompletionItem> {
+  ): Map<atom$AutocompleteSuggestion, [CompletionItem, boolean]> {
     return new Map((Array.isArray(completionItems) ? completionItems : completionItems.items || [])
       .sort((a, b) => (a.sortText || a.label).localeCompare(b.sortText || b.label))
-      .map(s => [AutocompleteAdapter.completionItemToSuggestion(s, { /* TODO: FlowType */ }, request, onDidConvertCompletionItem), [s, false]]));
+      .map(s => [AutocompleteAdapter.completionItemToSuggestion(s, { }, request, onDidConvertCompletionItem), [s, false]]));
   }
 
   // Public: Convert a language server protocol CompletionItem to an AutoComplete+ suggestion.
   //
-  // * `item` An {Array} of {CompletionItem} objects or a {CompletionList} containing completion
-  //             items to be converted.
+  // * `item` An {CompletionItem} containing a completion item to be converted.
+  // * `suggestion` A {atom$AutocompleteSuggestion} to have the conversion applied to.
   // * `request` The {atom$AutocompleteRequest} to satisfy.
   // * `onDidConvertCompletionItem` A function that takes a {CompletionItem}, an {atom$AutocompleteSuggestion}
   //   and a {atom$AutocompleteRequest} allowing you to adjust converted items.
   //
-  // Returns an AutoComplete+ suggestion.
+  // Returns the {atom$AutocompleteSuggestion} passed in as suggestion with the conversion applied.
   static completionItemToSuggestion(
     item: CompletionItem,
     suggestion: atom$AutocompleteSuggestion,
     request: atom$AutocompleteRequest,
-    onDidConvertCompletionItem?: (CompletionItem, atom$AutocompleteSuggestion, atom$AutocompleteRequest) => atom$AutocompleteSuggestion,
+    onDidConvertCompletionItem?: (CompletionItem, atom$AutocompleteSuggestion, atom$AutocompleteRequest) => void,
   ): atom$AutocompleteSuggestion {
     AutocompleteAdapter.applyCompletionItemToSuggestion(item, suggestion);
     AutocompleteAdapter.applyTextEditToSuggestion(item.textEdit, request.editor, suggestion);
@@ -125,14 +125,13 @@ export default class AutocompleteAdapter {
 
   // Public: Convert the primary parts of a language server protocol CompletionItem to an AutoComplete+ suggestion.
   //
-  // * `item` An {Array} of {CompletionItem} objects or a {CompletionList} containing completion
-  //             items to be converted.
+  // * `item` An {CompletionItem} containing the completion items to be merged into.
+  // * `suggestion` The {atom$AutocompleteSuggestion} to merge the conversion into.
   //
   // Returns an {atom$AutocompleteSuggestion} created from the {CompletionItem}.
-  static applyCompletionItemToSuggestion(item: CompletionItem, suggestion: atom$AutocompleteSuggestion = { }) {
+  static applyCompletionItemToSuggestion(item: CompletionItem, suggestion: atom$AutocompleteSuggestion) {
     suggestion.text = item.insertText || item.label
     suggestion.displayText = item.label
-    suggestion.filterText = item.filterText || item.label
     suggestion.snippet = item.insertTextFormat === 2 ? item.insertText : undefined
     suggestion.type = AutocompleteAdapter.completionKindToSuggestionType(item.kind)
     suggestion.rightLabel = item.detail

--- a/lib/adapters/autocomplete-adapter.js
+++ b/lib/adapters/autocomplete-adapter.js
@@ -24,7 +24,7 @@ export default class AutocompleteAdapter {
   // the `textDocument/completion` request.
   //
   // * `connection` A {LanguageClientConnection} to the language server to query.
-  // * `request` An {Object} with the AutoComplete+ request to satisfy.
+  // * `request` The {atom$AutocompleteRequest} to satisfy.
   // * `onDidConvertCompletionItem` A function that takes a {CompletionItem}, an {atom$AutocompleteSuggestion}
   //   and a {atom$AutocompleteRequest} allowing you to adjust converted items.
   //
@@ -69,9 +69,9 @@ export default class AutocompleteAdapter {
   // Public: Create TextDocumentPositionParams to be sent to the language server
   // based on the editor and position from the AutoCompleteRequest.
   //
-  // * `request` An {Object} with the AutoComplete+ request to use.
+  // * `request` The {atom$AutocompleteRequest} to satisfy.
   //
-  // Returns an {Object} containing the TextDocumentPositionParams object with the keys:
+  // Returns an {TextDocumentPositionParams} with the keys:
   //  * `textDocument` the language server protocol textDocument identification.
   //  * `position` the position within the text document to display completion request for.
   static requestToTextDocumentPositionParams(request: atom$AutocompleteRequest): TextDocumentPositionParams {
@@ -86,7 +86,7 @@ export default class AutocompleteAdapter {
   //
   // * `completionItems` An {Array} of {CompletionItem} objects or a {CompletionList} containing completion
   //           items to be converted.
-  // * `request` An {Object} with the AutoComplete+ request to use.
+  // * `request` The {atom$AutocompleteRequest} to satisfy.
   // * `onDidConvertCompletionItem` A function that takes a {CompletionItem}, an {atom$AutocompleteSuggestion}
   //   and a {atom$AutocompleteRequest} allowing you to adjust converted items.
   //
@@ -106,7 +106,7 @@ export default class AutocompleteAdapter {
   //
   // * `item` An {Array} of {CompletionItem} objects or a {CompletionList} containing completion
   //             items to be converted.
-  // * `request` An {Object} with the AutoComplete+ request to use.
+  // * `request` The {atom$AutocompleteRequest} to satisfy.
   // * `onDidConvertCompletionItem` A function that takes a {CompletionItem}, an {atom$AutocompleteSuggestion}
   //   and a {atom$AutocompleteRequest} allowing you to adjust converted items.
   //
@@ -126,7 +126,7 @@ export default class AutocompleteAdapter {
   // * `item` An {Array} of {CompletionItem} objects or a {CompletionList} containing completion
   //             items to be converted.
   //
-  // Returns an AutoComplete+ suggestion.
+  // Returns an {atom$AutocompleteSuggestion} created from the {CompletionItem}.
   static basicCompletionItemToSuggestion(item: CompletionItem): atom$AutocompleteSuggestion {
     return {
       text: item.insertText || item.label,
@@ -145,7 +145,7 @@ export default class AutocompleteAdapter {
   //
   // * `textEdit` A {TextEdit} from a CompletionItem to apply.
   // * `editor` An Atom {TextEditor} used to obtain the necessary text replacement.
-  // * `suggestion` An AutoComplete+ suggestion to set the replacementPrefix and text properties of.
+  // * `suggestion` An {atom$AutocompleteSuggestion} to set the replacementPrefix and text properties of.
   static applyTextEditToSuggestion(
     textEdit: ?TextEdit,
     editor: atom$TextEditor,

--- a/lib/adapters/autocomplete-adapter.js
+++ b/lib/adapters/autocomplete-adapter.js
@@ -51,12 +51,13 @@ export default class AutocompleteAdapter {
     connection: LanguageClientConnection,
     suggestion: atom$AutocompleteSuggestion,
     request: atom$AutocompleteRequest,
+    onDidConvertCompletionItem?: (CompletionItem, atom$AutocompleteSuggestion, atom$AutocompleteRequest) => void,
   ): Promise<atom$AutocompleteSuggestion> {
     const originalCompletionItem = this._lastSuggestions.get(suggestion);
     if (originalCompletionItem != null && originalCompletionItem[1] === false) {
       const resolveCompletionItem = await connection.completionItemResolve(originalCompletionItem[0]);
       if (resolveCompletionItem != null) {
-        const resolvedSuggestion = AutocompleteAdapter.completionItemToSuggestion(resolveCompletionItem, request);
+        const resolvedSuggestion = AutocompleteAdapter.completionItemToSuggestion(resolveCompletionItem, request, onDidConvertCompletionItem);
         this._lastSuggestions.delete(suggestion);
         this._lastSuggestions.set(resolvedSuggestion, [resolveCompletionItem, true]);
         return resolvedSuggestion;

--- a/lib/auto-languageclient.js
+++ b/lib/auto-languageclient.js
@@ -367,8 +367,8 @@ export default class AutoLanguageClient {
   onDidConvertAutocomplete(
     completionItem: ls.CompletionItem,
     suggestion: atom$AutocompleteSuggestion,
-  ): atom$AutocompleteSuggestion {
-    return suggestion;
+    request: atom$AutocompleteRequest,
+  ): void {
   }
 
   async getSuggestionDetailsOnSelect(suggestion: atom$AutocompleteSuggestion): Promise<?atom$AutocompleteSuggestion> {

--- a/lib/auto-languageclient.js
+++ b/lib/auto-languageclient.js
@@ -382,7 +382,7 @@ export default class AutoLanguageClient {
     }
 
     if (this._lastAutocompleteRequest != null && this.autoComplete != null) {
-      return this.autoComplete.completeSuggestion(server.connection, suggestion, this._lastAutocompleteRequest);
+      return this.autoComplete.completeSuggestion(server.connection, suggestion, this._lastAutocompleteRequest, this.onDidConvertAutocomplete);
     }
 
     return null;

--- a/lib/auto-languageclient.js
+++ b/lib/auto-languageclient.js
@@ -381,11 +381,7 @@ export default class AutoLanguageClient {
       return null;
     }
 
-    if (this._lastAutocompleteRequest != null && this.autoComplete != null) {
-      return this.autoComplete.completeSuggestion(server.connection, suggestion, this._lastAutocompleteRequest, this.onDidConvertAutocomplete);
-    }
-
-    return null;
+    return this.autoComplete.completeSuggestion(server.connection, suggestion, this._lastAutocompleteRequest, this.onDidConvertAutocomplete);
   }
 
   // Definitions via LS documentHighlight and gotoDefinition------------

--- a/lib/auto-languageclient.js
+++ b/lib/auto-languageclient.js
@@ -353,15 +353,27 @@ export default class AutoLanguageClient {
     };
   }
 
-  async getSuggestions(request: atom$AutocompleteRequest): Promise<Array<atom$AutocompleteSuggestion>> {
-    this._lastAutocompleteRequest = request;
+  async getSuggestions(
+    request: atom$AutocompleteRequest,
+  ): Promise<Array<atom$AutocompleteSuggestion>> {
     const server = await this._serverManager.getServer(request.editor);
     if (server == null || !AutocompleteAdapter.canAdapt(server.capabilities)) {
       return [];
     }
 
     this.autoComplete = this.autoComplete || new AutocompleteAdapter();
-    return this.autoComplete.getSuggestions(server.connection, request, this.onDidConvertAutocomplete);
+    this._lastAutocompleteRequest = request;
+    return this.autoComplete.getSuggestions(server.connection, request, this.onDidConvertAutocomplete, server.currentSuggestions);
+  }
+
+  async getSuggestionDetailsOnSelect(suggestion: atom$AutocompleteSuggestion): Promise<?atom$AutocompleteSuggestion> {
+    if (this._lastAutocompleteRequest == null) return;
+    const server = await this._serverManager.getServer(this._lastAutocompleteRequest.editor);
+    if (server == null || !AutocompleteAdapter.canAdapt(server.capabilities) || this.autoComplete == null) {
+      return null;
+    }
+
+    return this.autoComplete.completeSuggestion(server.connection, suggestion, this._lastAutocompleteRequest, this.onDidConvertAutocomplete, server.currentSuggestions);
   }
 
   onDidConvertAutocomplete(
@@ -369,19 +381,6 @@ export default class AutoLanguageClient {
     suggestion: atom$AutocompleteSuggestion,
     request: atom$AutocompleteRequest,
   ): void {
-  }
-
-  async getSuggestionDetailsOnSelect(suggestion: atom$AutocompleteSuggestion): Promise<?atom$AutocompleteSuggestion> {
-    if (this._lastAutocompleteRequest == null || this.autoComplete == null) {
-      return null;
-    }
-
-    const server = await this._serverManager.getServer(this._lastAutocompleteRequest.editor);
-    if (server == null || !AutocompleteAdapter.canAdapt(server.capabilities)) {
-      return null;
-    }
-
-    return this.autoComplete.completeSuggestion(server.connection, suggestion, this._lastAutocompleteRequest, this.onDidConvertAutocomplete);
   }
 
   // Definitions via LS documentHighlight and gotoDefinition------------

--- a/lib/auto-languageclient.js
+++ b/lib/auto-languageclient.js
@@ -263,7 +263,14 @@ export default class AutoLanguageClient {
     }
 
     this.autoComplete = this.autoComplete || new AutocompleteAdapter();
-    return this.autoComplete.getSuggestions(server.connection, request);
+    return this.autoComplete.getSuggestions(server.connection, request, this.onDidConvertAutocomplete);
+  }
+
+  onDidConvertAutocomplete(
+    completionItem: ls.CompletionItem,
+    suggestion: atom$AutocompleteSuggestion,
+  ): atom$AutocompleteSuggestion {
+    return suggestion;
   }
 
   // Definitions via LS documentHighlight and gotoDefinition------------

--- a/lib/auto-languageclient.js
+++ b/lib/auto-languageclient.js
@@ -363,17 +363,18 @@ export default class AutoLanguageClient {
 
     this.autoComplete = this.autoComplete || new AutocompleteAdapter();
     this._lastAutocompleteRequest = request;
-    return this.autoComplete.getSuggestions(server.connection, request, this.onDidConvertAutocomplete, server.currentSuggestions);
+    return this.autoComplete.getSuggestions(server.connection, request, this.onDidConvertAutocomplete);
   }
 
   async getSuggestionDetailsOnSelect(suggestion: atom$AutocompleteSuggestion): Promise<?atom$AutocompleteSuggestion> {
-    if (this._lastAutocompleteRequest == null) return;
-    const server = await this._serverManager.getServer(this._lastAutocompleteRequest.editor);
+    const request = this._lastAutocompleteRequest;
+    if (request == null) return;
+    const server = await this._serverManager.getServer(request.editor);
     if (server == null || !AutocompleteAdapter.canAdapt(server.capabilities) || this.autoComplete == null) {
       return null;
     }
 
-    return this.autoComplete.completeSuggestion(server.connection, suggestion, this._lastAutocompleteRequest, this.onDidConvertAutocomplete, server.currentSuggestions);
+    return this.autoComplete.completeSuggestion(server.connection, suggestion, request, this.onDidConvertAutocomplete);
   }
 
   onDidConvertAutocomplete(

--- a/lib/auto-languageclient.js
+++ b/lib/auto-languageclient.js
@@ -368,7 +368,7 @@ export default class AutoLanguageClient {
 
   async getSuggestionDetailsOnSelect(suggestion: atom$AutocompleteSuggestion): Promise<?atom$AutocompleteSuggestion> {
     const request = this._lastAutocompleteRequest;
-    if (request == null) return;
+    if (request == null) { return null; }
     const server = await this._serverManager.getServer(request.editor);
     if (server == null || !AutocompleteAdapter.canAdapt(server.capabilities) || this.autoComplete == null) {
       return null;

--- a/lib/languageclient.js
+++ b/lib/languageclient.js
@@ -401,32 +401,32 @@ export const TextDocumentSyncKind = {
 
 export interface SaveOptions {
   /**
-	 * The client is supposed to include the content on save.
-	 */
+   * The client is supposed to include the content on save.
+   */
   includeText?: boolean;
 }
 
 export interface TextDocumentSyncOptions {
   /**
-	 * Open and close notifications are sent to the server.
-	 */
+   * Open and close notifications are sent to the server.
+   */
   openClose?: boolean;
   /**
-	 * Change notificatins are sent to the server. See TextDocumentSyncKind.None, TextDocumentSyncKind.Full
-	 * and TextDocumentSyncKindIncremental.
-	 */
+   * Change notificatins are sent to the server. See TextDocumentSyncKind.None, TextDocumentSyncKind.Full
+   * and TextDocumentSyncKindIncremental.
+   */
   change?: number;
   /**
-	 * Will save notifications are sent to the server.
-	 */
+   * Will save notifications are sent to the server.
+   */
   willSave?: boolean;
   /**
-	 * Will save wait until requests are sent to the server.
-	 */
+   * Will save wait until requests are sent to the server.
+   */
   willSaveWaitUntil?: boolean;
   /**
-	 * Save notifications are sent to the server.
-	 */
+   * Save notifications are sent to the server.
+   */
   save?: SaveOptions;
 }
 
@@ -751,7 +751,7 @@ export type DocumentLinkParams = {
 
 /**
  * A document link is a range in a text document that links to an internal or
-* external resource, like another
+ * external resource, like another
  * text document or a web site.
  */
 export type DocumentLink = {

--- a/test/adapters/autocomplete-adapter.test.js
+++ b/test/adapters/autocomplete-adapter.test.js
@@ -151,7 +151,7 @@ describe('AutoCompleteAdapter', () => {
         detail: 'keyword',
         documentation: 'a truly useful keyword',
       };
-      const result = { }
+      const result = { };
       AutoCompleteAdapter.completionItemToSuggestion(completionItem, result, request);
       expect(result.text).equals('insert');
       expect(result.displayText).equals('label');
@@ -184,7 +184,7 @@ describe('AutoCompleteAdapter', () => {
         scopeDescriptor: 'some.scope',
       };
       sinon.stub(autocompleteRequest.editor, 'getTextInBufferRange').returns('replacementPrefix');
-      const result = { }
+      const result = { };
       AutoCompleteAdapter.completionItemToSuggestion(completionItem, result, autocompleteRequest);
       expect(result.displayText).equals('label');
       expect(result.type).equals('variable');
@@ -210,7 +210,7 @@ describe('AutoCompleteAdapter', () => {
         detail: 'detail',
         documentation: 'a very exciting keyword',
       };
-      const result = { }
+      const result = { };
       AutoCompleteAdapter.applyCompletionItemToSuggestion(completionItem, result);
       expect(result.text).equals('insert');
       expect(result.displayText).equals('label');
@@ -227,7 +227,7 @@ describe('AutoCompleteAdapter', () => {
         detail: 'detail',
         documentation: 'A very useful keyword',
       };
-      const result = { }
+      const result = { };
       AutoCompleteAdapter.applyCompletionItemToSuggestion(completionItem, result);
       expect(result.text).equals('label');
       expect(result.displayText).equals('label');

--- a/test/adapters/autocomplete-adapter.test.js
+++ b/test/adapters/autocomplete-adapter.test.js
@@ -106,25 +106,37 @@ describe('AutoCompleteAdapter', () => {
   describe('completionItemsToSuggestions', () => {
     it('converts LSP CompletionItem array to AutoComplete Suggestions array', () => {
       const autoCompleteAdapter = new AutoCompleteAdapter();
-      const results = autoCompleteAdapter.completionItemsToSuggestions(completionItems, request);
+      const results = Array.from(autoCompleteAdapter.completionItemsToSuggestions(completionItems, request));
       expect(results.length).equals(3);
-      expect(results[0].text).equals('label2');
-      expect(results[1].description).equals('a very exciting variable');
-      expect(results[2].type).equals('keyword');
+      expect(results[0][0].text).equals('label2');
+      expect(results[1][0].description).equals('a very exciting variable');
+      expect(results[2][0].type).equals('keyword');
     });
 
     it('converts LSP CompletionList to AutoComplete Suggestions array', () => {
       const completionList = {items: completionItems, isIncomplete: false};
       const autoCompleteAdapter = new AutoCompleteAdapter();
-      const results = autoCompleteAdapter.completionItemsToSuggestions(completionList, request);
+      const results = Array.from(autoCompleteAdapter.completionItemsToSuggestions(completionList, request));
       expect(results.length).equals(3);
-      expect(results[0].description).equals('a very exciting field');
-      expect(results[1].text).equals('label3');
+      expect(results[0][0].description).equals('a very exciting field');
+      expect(results[1][0].text).equals('label3');
+    });
+
+    it('converts LSP CompletionList to AutoComplete Suggestions array using the onDidConvertCompletionItem', () => {
+      const completionList = {items: completionItems, isIncomplete: false};
+      const autoCompleteAdapter = new AutoCompleteAdapter();
+      const results = Array.from(autoCompleteAdapter.completionItemsToSuggestions(completionList, request, (c, a, r) => {
+        a.text = c.label + ' ok';
+        a.displayText = r.scopeDescriptor;
+      }));
+      expect(results.length).equals(3);
+      expect(results[0][0].displayText).equals('some.scope');
+      expect(results[1][0].text).equals('label3 ok');
     });
 
     it('converts empty array into an empty AutoComplete Suggestions array', () => {
       const autoCompleteAdapter = new AutoCompleteAdapter();
-      const results = autoCompleteAdapter.completionItemsToSuggestions([], request);
+      const results = Array.from(autoCompleteAdapter.completionItemsToSuggestions([], request));
       expect(results.length).equals(0);
     });
   });
@@ -139,7 +151,8 @@ describe('AutoCompleteAdapter', () => {
         detail: 'keyword',
         documentation: 'a truly useful keyword',
       };
-      const result = AutoCompleteAdapter.completionItemToSuggestion(completionItem, request);
+      const result = { }
+      AutoCompleteAdapter.completionItemToSuggestion(completionItem, result, request);
       expect(result.text).equals('insert');
       expect(result.displayText).equals('label');
       expect(result.type).equals('keyword');
@@ -171,7 +184,8 @@ describe('AutoCompleteAdapter', () => {
         scopeDescriptor: 'some.scope',
       };
       sinon.stub(autocompleteRequest.editor, 'getTextInBufferRange').returns('replacementPrefix');
-      const result = AutoCompleteAdapter.completionItemToSuggestion(completionItem, autocompleteRequest);
+      const result = { }
+      AutoCompleteAdapter.completionItemToSuggestion(completionItem, result, autocompleteRequest);
       expect(result.displayText).equals('label');
       expect(result.type).equals('variable');
       expect(result.rightLabel).equals('number');
@@ -196,7 +210,8 @@ describe('AutoCompleteAdapter', () => {
         detail: 'detail',
         documentation: 'a very exciting keyword',
       };
-      const result = AutoCompleteAdapter.basicCompletionItemToSuggestion(completionItem);
+      const result = { }
+      AutoCompleteAdapter.applyCompletionItemToSuggestion(completionItem, result);
       expect(result.text).equals('insert');
       expect(result.displayText).equals('label');
       expect(result.type).equals('keyword');
@@ -212,7 +227,8 @@ describe('AutoCompleteAdapter', () => {
         detail: 'detail',
         documentation: 'A very useful keyword',
       };
-      const result = AutoCompleteAdapter.basicCompletionItemToSuggestion(completionItem);
+      const result = { }
+      AutoCompleteAdapter.applyCompletionItemToSuggestion(completionItem, result);
       expect(result.text).equals('label');
       expect(result.displayText).equals('label');
       expect(result.type).equals('keyword');


### PR DESCRIPTION
Provides a hook for easy modification of completion items for autocomplete. This is definitely an area people need to configure based on our experience with our own packages and right now it's a pain point.