### PR TITLE
Add Language Server Protocol v3 support

### DIFF
--- a/lib/adapters/apply-edit-adapter.js
+++ b/lib/adapters/apply-edit-adapter.js
@@ -15,8 +15,18 @@ export default class ApplyEditAdapter {
   }
 
   static async onApplyEdit(params: ApplyWorkspaceEditParams): Promise<ApplyWorkspaceEditResponse> {
-    // TODO(protocol v3.0): Handle versioned documentChanges
-    const {changes} = params.edit;
+
+    let changes = params.edit.changes || {};
+
+    if (params.edit.documentChanges) {
+      changes = {};
+      params.edit.documentChanges.forEach(change => {
+        if (change && change.textDocument) {
+          changes[change.textDocument.uri] = change.edits;
+        }
+      });
+    }
+
     const uris = Object.keys(changes);
     const paths = uris.map(Convert.uriToPath);
     const editors = await Promise.all(

--- a/lib/adapters/document-sync-adapter.js
+++ b/lib/adapters/document-sync-adapter.js
@@ -3,6 +3,7 @@
 import {
   LanguageClientConnection,
   FileChangeType,
+  TextDocumentSaveReason,
   TextDocumentSyncKind,
   TextDocumentSyncOptions,
   type TextDocumentContentChangeEvent,
@@ -160,6 +161,7 @@ class TextEditorSyncAdapter {
     }
 
     this._disposable.add(
+      editor.getBuffer().onWillSave(this.willSave.bind(this)),
       editor.onDidSave(this.didSave.bind(this)),
       editor.onDidDestroy(this.didClose.bind(this)),
       editor.onDidChangePath(this.didRename.bind(this)),
@@ -296,6 +298,18 @@ class TextEditorSyncAdapter {
     }
 
     this._connection.didCloseTextDocument({textDocument: {uri: this.getEditorUri()}});
+  }
+
+  // Called just before the {TextEditor} saves and sends the 'willSaveTextDocument' notification to
+  // the connected language server.
+  willSave(): void {
+    if (!this._isPrimaryAdapter()) return;
+
+    const uri = this.getEditorUri();
+    this._connection.willSaveTextDocument({
+      textDocument: {uri},
+      reason: TextDocumentSaveReason.Manual
+    });
   }
 
   // Called when the {TextEditor} saves and sends the 'didSaveTextDocument' notification to

--- a/lib/auto-languageclient.js
+++ b/lib/auto-languageclient.js
@@ -81,7 +81,82 @@ export default class AutoLanguageClient {
   getInitializeParams(projectPath: string, process: child_process$ChildProcess): ls.InitializeParams {
     return {
       processId: process.pid,
-      capabilities: {},
+      capabilities: {
+        workspace: {
+          applyEdit: true,
+          workspaceEdit: {
+            documentChanges: true
+          },
+          didChangeConfiguration: {
+            dynamicRegistration: false
+          },
+          didChangeWatchedFiles: {
+            dynamicRegistration: false
+          },
+          symbol: {
+            dynamicRegistration: false
+          },
+          executeCommand: {
+            dynamicRegistration: false
+          }
+        },
+        textDocument: {
+          synchronization: {
+            dynamicRegistration: false,
+            willSave: true,
+            willSaveWaitUntil: false,
+            didSave: true
+          },
+          completion: {
+            dynamicRegistration: false,
+            completionItem: {
+              snippetSupport: true,
+              commitCharactersSupport: false
+            },
+            contextSupport: false
+          },
+          hover: {
+            dynamicRegistration: false
+          },
+          signatureHelp: {
+            dynamicRegistration: false
+          },
+          references: {
+            dynamicRegistration: false
+          },
+          documentHighlight: {
+            dynamicRegistration: false
+          },
+          documentSymbol: {
+            dynamicRegistration: false
+          },
+          formatting: {
+            dynamicRegistration: false
+          },
+          rangeFormatting: {
+            dynamicRegistration: false
+          },
+          onTypeFormatting: {
+            dynamicRegistration: false
+          },
+          definition: {
+            dynamicRegistration: false
+          },
+          codeAction: {
+            dynamicRegistration: false
+          },
+          codeLens: {
+            dynamicRegistration: false
+          },
+          documentLink: {
+            dynamicRegistration: false
+          },
+          rename: {
+            dynamicRegistration: false
+          }
+        },
+        experimental: {}
+      },
       rootPath: projectPath,
       rootUri: Convert.pathToUri(projectPath),
     };
@@ -155,6 +230,7 @@ export default class AutoLanguageClient {
       disposable: new CompositeDisposable(),
     };
     this.postInitialization(newServer);
+    connection.initialized();
     this.startExclusiveAdapters(newServer);
     return newServer;
   }

--- a/lib/languageclient.js
+++ b/lib/languageclient.js
@@ -3,8 +3,8 @@
 import * as jsonrpc from 'vscode-jsonrpc';
 import {NullLogger, type Logger} from './logger';
 
-// Flow-typed wrapper around JSONRPC to implement Microsoft Language Server Protocol v2
-// https://github.com/Microsoft/language-server-protocol/blob/master/versions/protocol-2-x.md
+// Flow-typed wrapper around JSONRPC to implement Microsoft Language Server Protocol v3
+// https://github.com/Microsoft/language-server-protocol/blob/master/protocol.md
 export class LanguageClientConnection {
   _rpc: jsonrpc.connection;
   _log: Logger;
@@ -41,6 +41,11 @@ export class LanguageClientConnection {
   // capabilities.
   initialize(params: InitializeParams): Promise<InitializeResult> {
     return this._sendRequest('initialize', params);
+  }
+
+  // Public: Send an 'initialized' event to the language server.
+  initialized(): void {
+    this._sendNotification('initialized');
   }
 
   // Public: Shut down the language server.
@@ -127,6 +132,10 @@ export class LanguageClientConnection {
 
   didCloseTextDocument(params: DidCloseTextDocumentParams): void {
     this._sendNotification('textDocument/didClose', params);
+  }
+
+  willSaveTextDocument(params: WillSaveTextDocumentParams): void {
+    this._sendNotification('textDocument/willSave', params);
   }
 
   didSaveTextDocument(params: DidSaveTextDocumentParams): void {
@@ -321,7 +330,21 @@ export type TextEdit = {
 
 export type WorkspaceEdit = {
   // Holds changes to existing resources.
-  changes: {[uri: string]: TextEdit[]},
+  changes?: {[uri: string]: TextEdit[]};
+
+  // An array of `TextDocumentEdit`s to express changes to n different text documents
+  // where each text document edit addresses a specific version of a text document.
+  // Whether a client supports versioned document edits is expressed via
+  // `WorkspaceClientCapabilities.workspaceEdit.documentChanges`.
+  documentChanges?: TextDocumentEdit[];
+};
+
+export type TextDocumentEdit = {
+  // The text document to change.
+  textDocument: VersionedTextDocumentIdentifier;
+
+  // The edits to be applied.
+  edits: TextEdit[];
 };
 
 export type TextDocumentIdentifier = {
@@ -353,6 +376,19 @@ export type TextDocumentPositionParams = {
   position: Position,
 };
 
+export type DocumentFilter = {
+  // A language id, like `typescript`.
+  language?: string;
+
+  // A Uri [scheme](#Uri.scheme), like `file` or `untitled`.
+  scheme?: string;
+
+  // A glob pattern, like `*.{ts,js}`.
+  pattern?: string;
+};
+
+export type DocumentSelector = DocumentFilter[];
+
 // General
 
 export type InitializeParams = {
@@ -374,7 +410,246 @@ export type InitializeParams = {
   trace?: 'off' | 'messages' | 'verbose',
 };
 
-export type ClientCapabilities = {};
+export type ClientCapabilities = {
+  // Workspace specific client capabilities.
+  workspace?: WorkspaceClientCapabilities,
+
+  // Text document specific client capabilities.
+  textDocument?: TextDocumentClientCapabilities,
+
+  // Experimental client capabilities.
+  experimental?: any;
+};
+
+export type WorkspaceClientCapabilities = {
+  /**
+   * The client supports applying batch edits to the workspace by supporting
+   * the request 'workspace/applyEdit'
+   */
+  applyEdit?: boolean;
+
+  /**
+   * Capabilities specific to `WorkspaceEdit`s
+   */
+  workspaceEdit?: {
+  /**
+   * The client supports versioned document changes in `WorkspaceEdit`s
+   */
+  documentChanges?: boolean;
+  };
+
+  /**
+   * Capabilities specific to the `workspace/didChangeConfiguration` notification.
+   */
+  didChangeConfiguration?: {
+  /**
+   * Did change configuration notification supports dynamic registration.
+   */
+  dynamicRegistration?: boolean;
+  };
+
+  /**
+   * Capabilities specific to the `workspace/didChangeWatchedFiles` notification.
+   */
+  didChangeWatchedFiles?: {
+  /**
+   * Did change watched files notification supports dynamic registration.
+   */
+  dynamicRegistration?: boolean;
+  };
+
+  /**
+   * Capabilities specific to the `workspace/symbol` request.
+   */
+  symbol?: {
+  /**
+   * Symbol request supports dynamic registration.
+   */
+  dynamicRegistration?: boolean;
+  };
+
+  /**
+   * Capabilities specific to the `workspace/executeCommand` request.
+   */
+  executeCommand?: {
+  /**
+   * Execute command supports dynamic registration.
+   */
+  dynamicRegistration?: boolean;
+  };
+};
+
+export type TextDocumentClientCapabilities = {
+  synchronization?: {
+  // Whether text document synchronization supports dynamic registration.
+  dynamicRegistration?: boolean;
+
+  // The client supports sending will save notifications.
+  willSave?: boolean;
+
+  // The client supports sending a will save request and
+  // waits for a response providing text edits which will
+  // be applied to the document before it is saved.
+  willSaveWaitUntil?: boolean;
+
+  // The client supports did save notifications.
+  didSave?: boolean;
+  },
+
+  // Capabilities specific to the `textDocument/completion`
+  completion?: {
+  /**
+   * Whether completion supports dynamic registration.
+   */
+  dynamicRegistration?: boolean;
+
+  /**
+   * The client supports the following `CompletionItem` specific
+   * capabilities.
+   */
+  completionItem?: {
+  /**
+   * Client supports snippets as insert text.
+   *
+   * A snippet can define tab stops and placeholders with `$1`, `$2`
+   * and `${3:foo}`. `$0` defines the final tab stop, it defaults to
+   * the end of the snippet. Placeholders with equal identifiers are linked,
+   * that is typing in one will update others too.
+   */
+  snippetSupport?: boolean;
+  };
+  };
+
+  /**
+   * Capabilities specific to the `textDocument/hover`
+   */
+  hover?: {
+  /**
+   * Whether hover supports dynamic registration.
+   */
+  dynamicRegistration?: boolean;
+  };
+
+  /**
+   * Capabilities specific to the `textDocument/signatureHelp`
+   */
+  signatureHelp?: {
+  /**
+   * Whether signature help supports dynamic registration.
+   */
+  dynamicRegistration?: boolean;
+  };
+
+  /**
+   * Capabilities specific to the `textDocument/references`
+   */
+  references?: {
+  /**
+   * Whether references supports dynamic registration.
+   */
+  dynamicRegistration?: boolean;
+  };
+
+  /**
+   * Capabilities specific to the `textDocument/documentHighlight`
+   */
+  documentHighlight?: {
+  /**
+   * Whether document highlight supports dynamic registration.
+   */
+  dynamicRegistration?: boolean;
+  };
+
+  /**
+   * Capabilities specific to the `textDocument/documentSymbol`
+   */
+  documentSymbol?: {
+  /**
+   * Whether document symbol supports dynamic registration.
+   */
+  dynamicRegistration?: boolean;
+  };
+
+  /**
+   * Capabilities specific to the `textDocument/formatting`
+   */
+  formatting?: {
+  /**
+   * Whether formatting supports dynamic registration.
+   */
+  dynamicRegistration?: boolean;
+  };
+
+  /**
+   * Capabilities specific to the `textDocument/rangeFormatting`
+   */
+  rangeFormatting?: {
+  /**
+   * Whether range formatting supports dynamic registration.
+   */
+  dynamicRegistration?: boolean;
+  };
+
+  /**
+   * Capabilities specific to the `textDocument/onTypeFormatting`
+   */
+  onTypeFormatting?: {
+  /**
+   * Whether on type formatting supports dynamic registration.
+   */
+  dynamicRegistration?: boolean;
+  };
+
+  /**
+   * Capabilities specific to the `textDocument/definition`
+   */
+  definition?: {
+  /**
+   * Whether definition supports dynamic registration.
+   */
+  dynamicRegistration?: boolean;
+  };
+
+  /**
+   * Capabilities specific to the `textDocument/codeAction`
+   */
+  codeAction?: {
+  /**
+   * Whether code action supports dynamic registration.
+   */
+  dynamicRegistration?: boolean;
+  };
+
+  /**
+   * Capabilities specific to the `textDocument/codeLens`
+   */
+  codeLens?: {
+  /**
+   * Whether code lens supports dynamic registration.
+   */
+  dynamicRegistration?: boolean;
+  };
+
+  /**
+   * Capabilities specific to the `textDocument/documentLink`
+   */
+  documentLink?: {
+  /**
+   * Whether document link supports dynamic registration.
+   */
+  dynamicRegistration?: boolean;
+  };
+
+  /**
+   * Capabilities specific to the `textDocument/rename`
+   */
+  rename?: {
+  /**
+   * Whether rename supports dynamic registration.
+   */
+  dynamicRegistration?: boolean;
+  };
+};
 
 export type InitializeResult = {
   //  The capabilities the language server provides.
@@ -430,6 +705,43 @@ export interface TextDocumentSyncOptions {
   save?: SaveOptions;
 }
 
+/**
+ * The parameters send in a will save text document notification.
+ */
+export interface WillSaveTextDocumentParams {
+  /**
+   * The document that will be saved.
+   */
+  textDocument: TextDocumentIdentifier;
+
+  /**
+   * The 'TextDocumentSaveReason'.
+   */
+  reason: number;
+};
+
+/**
+ * Represents reasons why a text document is saved.
+ */
+export const TextDocumentSaveReason = {
+
+  /**
+   * Manually triggered, e.g. by the user pressing save, by starting debugging,
+   * or by an API call.
+   */
+  Manual: 1,
+
+  /**
+   * Automatic after a delay.
+   */
+  AfterDelay: 2,
+
+  /**
+   * When the editor lost focus.
+   */
+  FocusOut: 3,
+};
+
 // Completion options.
 export type CompletionOptions = {
   // The server provides support to resolve additional information for a completion item.
@@ -456,6 +768,18 @@ export type DocumentOnTypeFormattingOptions = {
   firstTriggerCharacter: string,
   // More trigger characters.
   moreTriggerCharacter?: string[],
+};
+
+// Document link options
+export interface DocumentLinkOptions {
+  // Document links have a resolve provider as well.
+  resolveProvider?: boolean;
+};
+
+// Execute command options.
+export interface ExecuteCommandOptions {
+  // The commands to be executed on the server
+  commands: string[];
 };
 
 export type ServerCapabilities = {
@@ -489,6 +813,35 @@ export type ServerCapabilities = {
   documentOnTypeFormattingProvider?: DocumentOnTypeFormattingOptions,
   // The server provides rename support.
   renameProvider?: boolean,
+  // The server provides document link support.
+  documentLinkProvider?: DocumentLinkOptions,
+  // The server provides execute command support.
+  executeCommandProvider?: ExecuteCommandOptions,
+  // Experimental server capabilities.
+  experimental?: any;
+};
+
+// General parameters to register for a capability.
+export type Registration = {
+  // The id used to register the request. The id can be used to deregister
+  // the request again.
+  id: string,
+
+  // The method / capability to register for.
+  method: string,
+
+  // Options necessary for the registration.
+  registerOptions?: any,
+};
+
+export type RegistrationParams = {
+  registrations: Registration[],
+};
+
+export type TextDocumentRegistrationOptions = {
+  // A document selector to identify the scope of the registration. If set to null
+  // the document selector provided on the client side will be used.
+  documentSelector: DocumentSelector | null,
 };
 
 // Document

--- a/test/adapters/apply-edit-adapter.test.js
+++ b/test/adapters/apply-edit-adapter.test.js
@@ -56,6 +56,45 @@ describe('ApplyEditAdapter', () => {
       expect(editor.getText()).to.equal('abc\ndef\n');
     });
 
+    it('works with TextDocumentEdits', async () => {
+      const editor = await atom.workspace.open(TEST_PATH1);
+      editor.setText('abc\ndef\n');
+
+      const result = await ApplyEditAdapter.onApplyEdit({
+        edit: {
+          documentChanges: [{
+            textDocument: {
+                version: 1,
+                uri: Convert.pathToUri(TEST_PATH1)
+            },
+            edits: [
+              {
+                range: {
+                  start: {line: 0, character: 0},
+                  end: {line: 0, character: 3},
+                },
+                newText: 'def',
+              },
+              {
+                range: {
+                  start: {line: 1, character: 0},
+                  end: {line: 1, character: 3},
+                },
+                newText: 'ghi',
+              },
+            ]
+          }],
+        }
+      });
+
+      expect(result.applied).to.equal(true);
+      expect(editor.getText()).to.equal('def\nghi\n');
+
+      // Undo should be atomic.
+      editor.getBuffer().undo();
+      expect(editor.getText()).to.equal('abc\ndef\n');
+    });
+
     it('opens files that are not already open', async () => {
       const result = await ApplyEditAdapter.onApplyEdit({
         edit: {


### PR DESCRIPTION
This change updates our LSP types and client interface to conform to LSP v3.  I've also added support for sending the `textDocument/willSave` event and applying `TextDocumentEdits` if those are sent in an `workspace/applyEdit` request.

I haven't yet added version checking to the code that applies TextDocumentEdits, planning to do that a bit later when I'm back home.  Will add a test or two for that also.

**Questions for reviewers**

1. For the LSP message types, should we keep the same ordering as what they have in the protocol.md file just to make it easier to spot-check protocol changes in the future?
2. Looks like there's some comment block inconsistency in the LSP types, probably due to copy/pasting types from the LSP spec over time.  Should I clean those up to be consistent?
3. Any other tests you think I should add?