### PR TITLE
Changed to using rimraf instead of rm -rf for cross-platform support

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "license": "MIT",
   "main": "./build/lib/main",
   "scripts": {
-    "clean": "rm -rf build",
+    "clean": "rimraf build",
     "compile": "babel lib --out-dir build/lib && babel test --out-dir build/test",
     "flow": "flow",
     "lint": "eslint lib test --max-warnings 0",
@@ -50,6 +50,7 @@
     "mocha": "^3.2.0",
     "mocha-appveyor-reporter": "^0.4.0",
     "prettier": "^1.7.4",
+    "rimraf": "^2.6.2",
     "sinon": "^2.0.0"
   }
 }


### PR DESCRIPTION
As title suggests. `rm -rf` is unix-based. this pr switches it's change to `rimraf` package.