### PR TITLE
Add busy-signals for server start, initialize & stop

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ node_modules
 npm-debug.log
 build/
 flow-typed/
+package-lock.json
+yarn.lock

--- a/lib/auto-languageclient.js
+++ b/lib/auto-languageclient.js
@@ -3,6 +3,7 @@
 import * as cp from 'child_process';
 import * as ls from './languageclient';
 import * as rpc from 'vscode-jsonrpc';
+import path from 'path';
 import {CompositeDisposable, Disposable} from 'atom';
 import {ConsoleLogger, NullLogger, type Logger} from './logger';
 import {ServerManager, type ActiveServer} from './server-manager.js';
@@ -33,6 +34,16 @@ export default class AutoLanguageClient {
   _serverManager: ServerManager;
   _linterDelegate: linter$V2IndieDelegate;
   _signatureHelpRegistry: ?atomIde$SignatureHelpRegistry;
+
+  /**
+   * Available if consumeBusySignal is called, ie the client package.json includes:
+   * ```json
+   * "consumedServices": {
+   *   "atom-ide-busy-signal": { "versions": { "0.1.0": "consumeBusySignal" } }
+   * }
+   * ```
+   */
+  busySignalService: ?atomIde$BusySignalService;
 
   processStdErr: string = '';
   logger: Logger;
@@ -65,7 +76,7 @@ export default class AutoLanguageClient {
   }
 
   // Start your server process
-  startServerProcess(projectPath: string): child_process$ChildProcess {
+  startServerProcess(projectPath: string): child_process$ChildProcess | Promise<child_process$ChildProcess> {
     throw Error('Must override startServerProcess to start language server process when extending AutoLanguageClient');
   }
 
@@ -182,10 +193,12 @@ export default class AutoLanguageClient {
     this.name = `${this.getLanguageName()} (${this.getServerName()})`;
     this.logger = this.getLogger();
     this._serverManager = new ServerManager(
+      this.getServerName(),
       p => this.startServer(p),
       this.logger,
       e => this.shouldStartForEditor(e),
-      path => this.filterChangeWatchedFiles(path),
+      filepath => this.filterChangeWatchedFiles(filepath),
+      () => this.busySignalService,
     );
     this._serverManager.startListening();
     process.on('exit', () => this.exitCleanup.bind(this));
@@ -217,11 +230,25 @@ export default class AutoLanguageClient {
 
   // Starts the server by starting the process, then initializing the language server and starting adapters
   async startServer(projectPath: string): Promise<ActiveServer> {
-    const process = await this.startServerProcess(projectPath);
+    const startingSignal = this.busySignalService && this.busySignalService.reportBusy(
+      `Starting ${this.getServerName()} for ${path.basename(projectPath)}`,
+    );
+    let process;
+    try {
+      process = await this.startServerProcess(projectPath);
+    } finally {
+      startingSignal && startingSignal.dispose();
+    }
+
     const connection = new ls.LanguageClientConnection(this.createRpcConnection(process), this.logger);
     this.preInitialization(connection);
     const initializeParams = this.getInitializeParams(projectPath, process);
-    const initializeResponse = await connection.initialize(initializeParams);
+    const initialization = connection.initialize(initializeParams);
+    this.busySignalService && this.busySignalService.reportBusyWhile(
+      `${this.getServerName()} initializing for ${path.basename(projectPath)}`,
+      () => initialization,
+    );
+    const initializeResponse = await initialization;
     const newServer = {
       projectPath,
       process,
@@ -518,6 +545,11 @@ export default class AutoLanguageClient {
     return new Disposable(() => {
       this._signatureHelpRegistry = null;
     });
+  }
+
+  consumeBusySignal(service: atomIde$BusySignalService): IDisposable {
+    this.busySignalService = service;
+    return new Disposable(() => delete this.busySignalService);
   }
 
   /**

--- a/lib/auto-languageclient.js
+++ b/lib/auto-languageclient.js
@@ -35,14 +35,7 @@ export default class AutoLanguageClient {
   _linterDelegate: linter$V2IndieDelegate;
   _signatureHelpRegistry: ?atomIde$SignatureHelpRegistry;
 
-  /**
-   * Available if consumeBusySignal is called, ie the client package.json includes:
-   * ```json
-   * "consumedServices": {
-   *   "atom-ide-busy-signal": { "versions": { "0.1.0": "consumeBusySignal" } }
-   * }
-   * ```
-   */
+  // Available if consumeBusySignal is setup
   busySignalService: ?atomIde$BusySignalService;
 
   processStdErr: string = '';
@@ -193,12 +186,12 @@ export default class AutoLanguageClient {
     this.name = `${this.getLanguageName()} (${this.getServerName()})`;
     this.logger = this.getLogger();
     this._serverManager = new ServerManager(
-      this.getServerName(),
       p => this.startServer(p),
       this.logger,
       e => this.shouldStartForEditor(e),
       filepath => this.filterChangeWatchedFiles(filepath),
       () => this.busySignalService,
+      this.getServerName(),
     );
     this._serverManager.startListening();
     process.on('exit', () => this.exitCleanup.bind(this));

--- a/lib/server-manager.js
+++ b/lib/server-manager.js
@@ -40,12 +40,12 @@ export class ServerManager {
   _isStarted = false;
 
   constructor(
-    languageServerName: string,
     startServer: (projectPath: string) => Promise<ActiveServer>,
     logger: Logger,
     startForEditor: (editor: atom$TextEditor) => boolean,
     changeWatchedFileFilter: (filePath: string) => boolean,
     busySignalServiceGetter: () => ?atomIde$BusySignalService,
+    languageServerName: string,
   ) {
     this._languageServerName = languageServerName;
     this._startServer = startServer;

--- a/lib/server-manager.js
+++ b/lib/server-manager.js
@@ -35,19 +35,25 @@ export class ServerManager {
   _startForEditor: (editor: atom$TextEditor) => boolean;
   _startServer: (projectPath: string) => Promise<ActiveServer>;
   _changeWatchedFileFilter: (filePath: string) => boolean;
+  _getBusySignalService: () => ?atomIde$BusySignalService;
+  _languageServerName: string;
   _isStarted = false;
 
   constructor(
+    languageServerName: string,
     startServer: (projectPath: string) => Promise<ActiveServer>,
     logger: Logger,
     startForEditor: (editor: atom$TextEditor) => boolean,
     changeWatchedFileFilter: (filePath: string) => boolean,
+    busySignalServiceGetter: () => ?atomIde$BusySignalService,
   ) {
+    this._languageServerName = languageServerName;
     this._startServer = startServer;
     this._logger = logger;
     this._startForEditor = startForEditor;
     this.updateNormalizedProjectPaths();
     this._changeWatchedFileFilter = changeWatchedFileFilter;
+    this._getBusySignalService = busySignalServiceGetter;
   }
 
   startListening(): void {
@@ -169,24 +175,32 @@ export class ServerManager {
   }
 
   async stopServer(server: ActiveServer): Promise<void> {
-    this._logger.debug(`Server stopping "${server.projectPath}"`);
-    // Immediately remove the server to prevent further usage.
-    // If we re-open the file after this point, we'll get a new server.
-    this._activeServers.splice(this._activeServers.indexOf(server), 1);
-    this._stoppingServers.push(server);
-    server.disposable.dispose();
-    await server.connection.shutdown();
+    const busySignalService = this._getBusySignalService();
+    const signal = busySignalService && busySignalService.reportBusy(
+      `Stopping ${this._languageServerName} for ${path.basename(server.projectPath)}`,
+    );
+    try {
+      this._logger.debug(`Server stopping "${server.projectPath}"`);
+      // Immediately remove the server to prevent further usage.
+      // If we re-open the file after this point, we'll get a new server.
+      this._activeServers.splice(this._activeServers.indexOf(server), 1);
+      this._stoppingServers.push(server);
+      server.disposable.dispose();
+      await server.connection.shutdown();
 
-    if (server.linterPushV2 != null) {
-      server.linterPushV2.detachAll();
+      if (server.linterPushV2 != null) {
+        server.linterPushV2.detachAll();
+      }
+
+      if (server.signatureHelpAdapter != null) {
+        server.signatureHelpAdapter.dispose();
+      }
+
+      this.exitServer(server);
+      this._stoppingServers.splice(this._stoppingServers.indexOf(server), 1);
+    } finally {
+      signal && signal.dispose();
     }
-
-    if (server.signatureHelpAdapter != null) {
-      server.signatureHelpAdapter.dispose();
-    }
-
-    this.exitServer(server);
-    this._stoppingServers.splice(this._stoppingServers.indexOf(server), 1);
   }
 
   exitServer(server: ActiveServer): void {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "watch": "babel lib --out-dir build/lib -w"
   },
   "dependencies": {
-    "vscode-jsonrpc": "^3.4.1"
+    "vscode-jsonrpc": "^3.5.0"
   },
   "atomTestRunner": "./test/runner",
   "atomTranspilers": [
@@ -32,7 +32,7 @@
   ],
   "devDependencies": {
     "atom-babel6-transpiler": "1.1.2",
-    "atom-mocha-test-runner": "^1.0.0",
+    "atom-mocha-test-runner": "^1.2.0",
     "babel-cli": "^6.26.0",
     "babel-core": "6.26.0",
     "babel-plugin-add-module-exports": "0.2.1",
@@ -41,7 +41,7 @@
     "babel-plugin-transform-flow-strip-types": "6.22.0",
     "babel-plugin-transform-object-rest-spread": "6.26.0",
     "chai": "^3.5.0",
-    "eslint": "^4.9.0",
+    "eslint": "^4.11.0",
     "eslint-config-fbjs-opensource": "^1.0.0",
     "eslint-plugin-flowtype": "^2.39.1",
     "flow-bin": "^0.59.0",


### PR DESCRIPTION
* Add support for consuming `BusySignalService`
* Add busy signal `Starting ${this.getServerName()} for ${path.basename(projectPath)}`
* Add busy signal `${this.getServerName()} initializing for ${path.basename(projectPath)}`
* Add busy signal `Stopping ${this.getServerName()} for ${path.basename(projectPath)}`

Note: Having public _busySignalService_ in `AutoLanguageClient` is intended as this service can be useful to the subclass clients _(and they have to add the package.json declaration anyway)_. For example, we'll use the service to show we're installing Rls.

![atom-languageclient-busy-signal](https://user-images.githubusercontent.com/2331607/33209302-150eac04-d10d-11e7-8818-09c80dc94685.png)

Resolves #105
