### PR TITLE
Reorganize LSP message types, add missing registration types

### DIFF
--- a/lib/languageclient.js
+++ b/lib/languageclient.js
@@ -605,7 +605,12 @@ export type TextDocumentClientCapabilities = {
       // the end of the snippet. Placeholders with equal identifiers are linked,
       // that is typing in one will update others too.
       snippetSupport?: boolean;
+      // Client supports commit characters on a completion item.
+      commitCharactersSupport?: boolean;
     };
+    // The client supports to send additional context information for a
+    // `textDocument/completion` requestion.
+    contextSupport?: boolean;
   };
   // Capabilities specific to the `textDocument/hover`
   hover?: {
@@ -692,6 +697,7 @@ export type InitializeResult = {
   capabilities: ServerCapabilities,
 };
 
+// Public: Initialization error details.
 export type InitializeError = {
   // Indicates whether the client should retry to send the
   // initilize request after showing the message provided
@@ -699,7 +705,7 @@ export type InitializeError = {
   retry: boolean,
 };
 
-// Defines how the host (editor) should sync document changes to the language server.
+// Public: Defines how the host (editor) should sync document changes to the language server.
 export const TextDocumentSyncKind = {
   // Documents should not be synced at all.
   None: 0,
@@ -710,11 +716,53 @@ export const TextDocumentSyncKind = {
   Incremental: 2,
 };
 
+// Public: Completion options.
+export type CompletionOptions = {
+  // The server provides support to resolve additional information for a completion item.
+  resolveProvider?: boolean,
+  // The characters that trigger completion automatically.
+  triggerCharacters?: string[],
+};
+
+// Public: Signature Help options.
+export type SignatureHelpOptions = {
+  // The characters that trigger signature help automatically.
+  triggerCharacters?: string[],
+};
+
+// Public: Code Lens options.
+export type CodeLensOptions = {
+  // Code lens has a resolve provider as well.
+  resolveProvider?: boolean,
+};
+
+// Public: Format Document on type options
+export type DocumentOnTypeFormattingOptions = {
+  // A character on which formatting should be triggered, like `};`.
+  firstTriggerCharacter: string,
+  // More trigger characters.
+  moreTriggerCharacter?: string[],
+};
+
+// Public: Document Link options
+export interface DocumentLinkOptions {
+  // Document links have a resolve provider as well.
+  resolveProvider?: boolean;
+}
+
+// Public: Execute Command options.
+export interface ExecuteCommandOptions {
+  // The commands to be executed on the server
+  commands: string[];
+}
+
+// Public: Document save options.
 export interface SaveOptions {
   // The client is supposed to include the content on save.
   includeText?: boolean;
 }
 
+// Public: Text document synchronization options.
 export interface TextDocumentSyncOptions {
   // Open and close notifications are sent to the server.
   openClose?: boolean;
@@ -729,67 +777,7 @@ export interface TextDocumentSyncOptions {
   save?: SaveOptions;
 }
 
-// The parameters send in a will save text document notification.
-export interface WillSaveTextDocumentParams {
-  // The document that will be saved.
-  textDocument: TextDocumentIdentifier;
-  // The 'TextDocumentSaveReason'.
-  reason: number;
-}
-
-// Represents reasons why a text document is saved.
-export const TextDocumentSaveReason = {
-  // Manually triggered, e.g. by the user pressing save, by starting debugging,
-  // or by an API call.
-  Manual: 1,
-
-  // Automatic after a delay.
-  AfterDelay: 2,
-
-  // When the editor lost focus.
-  FocusOut: 3,
-};
-
-// Completion options.
-export type CompletionOptions = {
-  // The server provides support to resolve additional information for a completion item.
-  resolveProvider?: boolean,
-  // The characters that trigger completion automatically.
-  triggerCharacters?: string[],
-};
-
-// Signature Help options.
-export type SignatureHelpOptions = {
-  // The characters that trigger signature help automatically.
-  triggerCharacters?: string[],
-};
-
-// Code Lens options.
-export type CodeLensOptions = {
-  // Code lens has a resolve provider as well.
-  resolveProvider?: boolean,
-};
-
-// Format Document on type options
-export type DocumentOnTypeFormattingOptions = {
-  // A character on which formatting should be triggered, like `};`.
-  firstTriggerCharacter: string,
-  // More trigger characters.
-  moreTriggerCharacter?: string[],
-};
-
-// Document Link options
-export interface DocumentLinkOptions {
-  // Document links have a resolve provider as well.
-  resolveProvider?: boolean;
-}
-
-// Execute Command options.
-export interface ExecuteCommandOptions {
-  // The commands to be executed on the server
-  commands: string[];
-}
-
+// Public: Defines capabilities that will be returned by the server.
 export type ServerCapabilities = {
   // Defines how text documents are synced.
   textDocumentSync?: TextDocumentSyncOptions | number,
@@ -827,361 +815,6 @@ export type ServerCapabilities = {
   executeCommandProvider?: ExecuteCommandOptions,
   // Experimental server capabilities.
   experimental?: any;
-};
-
-// General parameters to register for a capability.
-export type Registration = {
-  // The id used to register the request. The id can be used to deregister
-  // the request again.
-  id: string,
-
-  // The method / capability to register for.
-  method: string,
-
-  // Options necessary for the registration.
-  registerOptions?: any,
-};
-
-export type RegistrationParams = {
-  registrations: Registration[],
-};
-
-export type TextDocumentRegistrationOptions = {
-  // A document selector to identify the scope of the registration. If set to null
-  // the document selector provided on the client side will be used.
-  documentSelector: DocumentSelector | null,
-};
-
-export type PublishDiagnosticsParams = {
-  // The URI for which diagnostic information is reported.
-  uri: string,
-  // An array of diagnostic information items.
-  diagnostics: Diagnostic[],
-};
-
-export type CompletionParams = TextDocumentPositionParams & {
-  // The completion context. This is only available it the client specifies
-  // to send this using `ClientCapabilities.textDocument.completion.contextSupport === true`
-  context?: CompletionContext;
-};
-
-// How a completion was triggered
-export const CompletionTriggerKind = {
-  // Completion was triggered by typing an identifier (24x7 code
-  // complete), manual invocation (e.g Ctrl+Space) or via API.
-  Invoked: 1,
-
-  // Completion was triggered by a trigger character specified by
-  // the `triggerCharacters` properties of the `CompletionRegistrationOptions`.
-  TriggerCharacter: 2,
-};
-
-// Contains additional information about the context in which a completion request is triggered.
-export interface CompletionContext {
-  // How the completion was triggered.
-  triggerKind: number,
-
-  // The trigger character (a single character) that has trigger code complete.
-  // Is undefined if `triggerKind !== CompletionTriggerKind.TriggerCharacter`
-  triggerCharacter?: string,
-}
-
-// Represents a collection of [completion items](#CompletionItem) to be presented in the editor.
-export type CompletionList = {
-  // This list it not complete. Further typing should result in recomputing this list.
-  isIncomplete: boolean,
-  // The completion items.
-  items: CompletionItem[],
-};
-
-export type CompletionItem = {
-  //  The label of this completion item. By default
-  //  also the text that is inserted when selecting
-  //  this completion.
-  label: string,
-  // The kind of this completion item. Based of the kind an icon is chosen by the editor.
-  kind?: number,
-  // A human-readable string with additional information
-  // about this item, like type or symbol information.
-  detail?: string,
-  // A human-readable string that represents a doc-comment.
-  documentation?: string,
-  //  A string that shoud be used when comparing this item
-  //  with other items. When `falsy` the label is used.
-  sortText?: string,
-  //  A string that should be used when filtering a set of
-  //  completion items. When `falsy` the label is used.
-  filterText?: string,
-  //  A string that should be inserted a document when selecting
-  //  this completion. When `falsy` the label is used.
-  insertText?: string,
-  //  An edit which is applied to a document when selecting
-  //  this completion. When an edit is provided the value of
-  //  insertText is ignored.
-  textEdit?: TextEdit,
-  //  An optional array of additional text edits that are applied when
-  //  selecting this completion. Edits must not overlap with the main edit
-  //  nor with themselves.
-  additionalTextEdits?: TextEdit[],
-  //  An optional command that is executed *after* inserting this completion. *Note* that
-  //  additional modifications to the current document should be described with the
-  //  additionalTextEdits-property.
-  command?: Command,
-  //  An data entry field that is preserved on a completion item between
-  //  a completion and a completion resolve request.
-  data?: any,
-};
-
-// The kind of a completion entry.
-export const CompletionItemKind = {
-  Text: 1,
-  Method: 2,
-  Function: 3,
-  Constructor: 4,
-  Field: 5,
-  Variable: 6,
-  Class: 7,
-  Interface: 8,
-  Module: 9,
-  Property: 10,
-  Unit: 11,
-  Value: 12,
-  Enum: 13,
-  Keyword: 14,
-  Snippet: 15,
-  Color: 16,
-  File: 17,
-  Reference: 18,
-};
-
-// The result of a hover request.
-export type Hover = {
-  // The hover's content
-  contents: MarkedString | MarkedString[],
-  // An optional range is a range inside a text document
-  // that is used to visualize a hover, e.g. by changing the background color.
-  range?: Range,
-};
-
-
-// The marked string is rendered:
-// - as markdown if it is represented as a string
-// - as code block of the given langauge if it is represented as a pair of a language and a value
-//
-// The pair of a language and a value is an equivalent to markdown:
-// ```${language};
-// ${value};
-// ```
-export type MarkedString = string | {language: string, value: string};
-
-// Signature help represents the signature of something
-// callable. There can be multiple signature but only one
-// active and only one active parameter.
-export type SignatureHelp = {
-  // One or more signatures.
-  signatures: SignatureInformation[],
-  // The active signature.
-  activeSignature?: number,
-  // The active parameter of the active signature.
-  activeParameter?: number,
-};
-
-// Represents the signature of something callable. A signature
-// can have a label, like a function-name, a doc-comment, and
-// a set of parameters.
-export type SignatureInformation = {
-  // The label of this signature. Will be shown in the UI.
-  label: string,
-  //  The human-readable doc-comment of this signature. Will be shown in the UI but can be omitted.
-  documentation?: string,
-  // The parameters of this signature.
-  parameters?: ParameterInformation[],
-};
-
-// Represents a parameter of a callable-signature. A parameter can
-// have a label and a doc-comment.
-export type ParameterInformation = {
-  // The label of this parameter. Will be shown in the UI.
-  label: string,
-  // The human-readable doc-comment of this parameter. Will be shown in the UI but can be omitted.
-  documentation?: string,
-};
-
-export type ReferenceParams = TextDocumentPositionParams & {
-  context: ReferenceContext,
-};
-
-export type ReferenceContext = {
-  // Include the declaration of the current symbol.
-  includeDeclaration: boolean,
-};
-
-// A document highlight is a range inside a text document which deserves
-// special attention. Usually a document highlight is visualized by changing
-// the background color of its range.
-export type DocumentHighlight = {
-  // The range this highlight applies to.
-  range: Range,
-  // The highlight kind, default is DocumentHighlightKind.Text.
-  kind?: number,
-};
-
-export const DocumentHighlightKind = {
-  // A textual occurrance.
-  Text: 1,
-  // Read-access of a symbol, like reading a variable.
-  Read: 2,
-  // Write-access of a symbol, like writing to a variable.
-  Write: 3,
-};
-
-export type DocumentSymbolParams = {
-  // The text document.
-  textDocument: TextDocumentIdentifier,
-};
-
-// Represents information about programming constructs like variables, classes,
-// interfaces etc.
-export type SymbolInformation = {
-  // The name of this symbol.
-  name: string,
-  // The kind of this symbol.
-  kind: number,
-  // The location of this symbol.
-  location: Location,
-  // The name of the symbol containing this symbol.
-  containerName?: string,
-};
-
-export const SymbolKind = {
-  File: 1,
-  Module: 2,
-  Namespace: 3,
-  Package: 4,
-  Class: 5,
-  Method: 6,
-  Property: 7,
-  Field: 8,
-  Constructor: 9,
-  Enum: 10,
-  Interface: 11,
-  Function: 12,
-  Variable: 13,
-  Constant: 14,
-  String: 15,
-  Number: 16,
-  Boolean: 17,
-  Array: 18,
-};
-
-// The parameters of a Workspace Symbol Request.
-export type WorkspaceSymbolParams = {
-  // A non-empty query string.
-  query: string,
-};
-
-// Params for the CodeActionRequest
-export type CodeActionParams = {
-  // The document in which the command was invoked.
-  textDocument: TextDocumentIdentifier,
-  // The range for which the command was invoked.
-  range: Range,
-  // Context carrying additional information.
-  context: CodeActionContext,
-};
-
-// Contains additional diagnostic information about the context in which a code action is run.
-export type CodeActionContext = {
-  // An array of diagnostics.
-  diagnostics: Diagnostic[],
-};
-
-export type CodeLensParams = {
-  // The document to request code lens for.
-  textDocument: TextDocumentIdentifier,
-};
-
-// A code lens represents a command that should be shown along with
-// source text, like the number of references, a way to run tests, etc.
-//
-// A code lens is _unresolved_ when no command is associated to it. For performance
-// reasons the creation of a code lens and resolving should be done in two stages.
-export type CodeLens = {
-  // The range in which this code lens is valid. Should only span a single line.
-  range: Range,
-  // The command this code lens represents.
-  command?: Command,
-  // A data entry field that is preserved on a code lens item between a code lens
-  // and a code lens resolve request.
-  data?: any,
-};
-
-export type DocumentLinkParams = {
-  // The document to provide document links for.
-  textDocument: TextDocumentIdentifier,
-};
-
-// A document link is a range in a text document that links to an internal or
-// external resource, like another
-// text document or a web site.
-export type DocumentLink = {
-  // The range this link applies to.
-  range: Range,
-  // The uri this link points to.
-  target: string,
-};
-
-// Public: Parameters to be send with a DocumentFormatting request.
-export type DocumentFormattingParams = {
-  // The document to format.
-  textDocument: TextDocumentIdentifier,
-  // The format options.
-  options: FormattingOptions,
-};
-
-// Public: Value-object describing what options formatting should use.
-export type FormattingOptions = {
-  // Size of a tab in spaces.
-  tabSize: number,
-  // Prefer spaces over tabs.
-  insertSpaces: boolean,
-  // Signature for further properties.
-  [key: string]: boolean | number | string,
-};
-
-// Public: Parameters to be send with a DocumentRangeFormatting request.
-export type DocumentRangeFormattingParams = {
-  // The document to format.
-  textDocument: TextDocumentIdentifier,
-  // The range to format.
-  range: Range,
-  // The format options.
-  options: FormattingOptions,
-};
-
-// Public: Parameters to be send with a DocumentOnTypeFormatting request.
-export type DocumentOnTypeFormattingParams = {
-  // Public: The {TextDocumentIdentifier} of the document to format.
-  textDocument: TextDocumentIdentifier,
-  // Public: The {Position} of the text cursor at this point in time.
-  position: Position,
-  // Public: The character that has been typed.
-  ch: string,
-  // Public: The {FormattingOptions} relating to this document.
-  options: FormattingOptions,
-};
-
-// Public: Parameters to send with a Rename request.
-export type RenameParams = {
-  // Public: The {TextDocumentIdentifier} containing the item being renamed.
-  textDocument: TextDocumentIdentifier,
-  // Public: The position at which the symbol being renamed exists within the
-  // text document.
-  position: Position,
-  // Public: The new name of this symbol.  If the given name is not valid the
-  // request must return a [ResponseError](#ResponseError) with an
-  // appropriate message set.
-  newName: string,
 };
 
 // Public: Details of a message to be shown to the user.
@@ -1230,10 +863,133 @@ export type LogMessageParams = {
   message: string,
 };
 
+// Public: General parameters to register for a capability.
+export type Registration = {
+  // The id used to register the request. The id can be used to deregister
+  // the request again.
+  id: string,
+  // The method / capability to register for.
+  method: string,
+  // Options necessary for the registration.
+  registerOptions?: any,
+};
+
+// Public: Capability registration parameters.
+export type RegistrationParams = {
+  registrations: Registration[],
+};
+
+// Public: Text document registration options.
+export type TextDocumentRegistrationOptions = {
+  // A document selector to identify the scope of the registration. If set to null
+  // the document selector provided on the client side will be used.
+  documentSelector: DocumentSelector | null,
+};
+
+// Public: General parameters to unregister a capability.
+export interface Unregistration {
+   // The id used to unregister the request or notification. Usually an id
+   // provided during the register request.
+  id: string,
+  // The method / capability to unregister for.
+  method: string,
+}
+
+// Public: General parameters to unregister a capability.
+export interface UnregistrationParams {
+  unregisterations: Unregistration[],
+}
+
 // Public: Details of a configuration change that has occured.
 export type DidChangeConfigurationParams = {
   // Public: The complete settings after the change has been applied.
   settings: any,
+};
+
+// Public: Details of file activities on files that are being watched.
+export type DidChangeWatchedFilesParams = {
+  // Public: The {Array} of {FileEvent}s that have occured.
+  changes: FileEvent[],
+};
+
+// Public: An event describing a file change.
+export type FileEvent = {
+  // Public: The file's Uri.
+  uri: string,
+  // Public: The type of change as specified by {FileChangeType}
+  type: number,
+};
+
+// Public: The type of file changes that may occur.
+export const FileChangeType = {
+  // Public: The file was created.
+  Created: 1,
+  // Public: The file was changed.
+  Changed: 2,
+  // Public: The file was deleted.
+  Deleted: 3,
+};
+
+// Public: Describe options to be used when registered for text document change events.
+export interface DidChangeWatchedFilesRegistrationOptions {
+  // The watchers to register.
+  watchers: FileSystemWatcher[],
+}
+
+// Public: Parameters for a file system watcher.
+export interface FileSystemWatcher {
+  // The glob pattern to watch
+  globPattern: string,
+  // The kind of events of interest. If omitted it defaults
+  // to WatchKind.Create | WatchKind.Change | WatchKind.Delete
+  // which is 7.
+  kind?: number,
+}
+
+// Public: The kind of file system to event to watch.
+export const WatchKind = {
+  // Interested in create events.
+  Create: 1,
+  // Interested in change events
+  Change: 2,
+  // Interested in delete events
+  Delete: 4,
+};
+
+// Public: The parameters of a Workspace Symbol Request.
+export type WorkspaceSymbolParams = {
+  // A non-empty query string.
+  query: string,
+};
+
+// Public: Parameters to send with a workspace/executeCommand request.
+export type ExecuteCommandParams = {
+  // The identifier of the actual command handler.
+  command: string,
+  // Arguments that the command should be invoked with.
+  arguments?: Array<any>,
+};
+
+// Public: Execute command registration options.
+export interface ExecuteCommandRegistrationOptions {
+  // The commands to be executed on the server
+  commands: string[],
+}
+
+// Public: Parameters to receive with a workspace/applyEdit request.
+export type ApplyWorkspaceEditParams = {
+  // An optional label of the workspace edit. This label is
+  // presented in the user interface for example on an undo
+  // stack to undo the workspace edit.
+  label?: string,
+  // The edits to apply.
+  edit: WorkspaceEdit,
+};
+
+// Public: Parameters to send with a workspace/applyEdit response.
+export type ApplyWorkspaceEditResponse = {
+  // Indicates whether the edit was applied or not.
+  applied: boolean,
 };
 
 // Public: Details of a text document that has been opened.
@@ -1265,56 +1021,448 @@ export type TextDocumentContentChangeEvent = {
   text: string,
 };
 
-// Public: Details of text documents that has been closed.
-export type DidCloseTextDocumentParams = {
-  // Public: The {TextDocumentIdentifier} of the file that was closed.
+// Public: Describe options to be used when registered for text document change events.
+export interface TextDocumentChangeRegistrationOptions extends TextDocumentRegistrationOptions {
+  // How documents are synced to the server. See TextDocumentSyncKind.Full
+  // and TextDocumentSyncKindIncremental.
+  syncKind: number,
+}
+
+// Public: The parameters send in a will save text document notification.
+export interface WillSaveTextDocumentParams {
+  // The document that will be saved.
   textDocument: TextDocumentIdentifier,
+  // The 'TextDocumentSaveReason'.
+  reason: number,
+}
+
+// Public: Represents reasons why a text document is saved.
+export const TextDocumentSaveReason = {
+  // Manually triggered, e.g. by the user pressing save, by starting debugging,
+  // or by an API call.
+  Manual: 1,
+  // Automatic after a delay.
+  AfterDelay: 2,
+  // When the editor lost focus.
+  FocusOut: 3,
 };
 
 // Public: Details of a text document that has been saved.
 export type DidSaveTextDocumentParams = {
   // Public: The {TextDocumentIdentifier} of the file that was saved.
   textDocument: TextDocumentIdentifier,
+  // Optional the content when saved. Depends on the includeText value
+  // when the save notifcation was requested.
+  text?: string,
 };
 
-// Public: Details of file activities on files that are being watched.
-export type DidChangeWatchedFilesParams = {
-  // Public: The {Array} of {FileEvent}s that have occured.
-  changes: FileEvent[],
+// Public: Registration options for text document save events.
+export interface TextDocumentSaveRegistrationOptions extends TextDocumentRegistrationOptions {
+  // The client is supposed to include the content on save.
+  includeText?: boolean,
+}
+
+// Public: Details of text documents that has been closed.
+export type DidCloseTextDocumentParams = {
+  // Public: The {TextDocumentIdentifier} of the file that was closed.
+  textDocument: TextDocumentIdentifier,
 };
 
-// Public: The type of file changes that may occur.
-export const FileChangeType = {
-  // Public: The file was created.
-  Created: 1,
-  // Public: The file was changed.
-  Changed: 2,
-  // Public: The file was deleted.
-  Deleted: 3,
-};
-
-// Public: An event describing a file change.
-export type FileEvent = {
-  // Public: The file's Uri.
+// Public: Parameters for textDocument/publishDiagnostics events.
+export type PublishDiagnosticsParams = {
+  // The URI for which diagnostic information is reported.
   uri: string,
-  // Public: The type of change as specified by {FileChangeType}
-  type: number,
+  // An array of diagnostic information items.
+  diagnostics: Diagnostic[],
 };
 
-// Public: Parameters to send with a workspace/executeCommand request.
-export type ExecuteCommandParams = {
-  command: string,
-  arguments?: Array<any>,
+// Public: Parameters for completion requests.
+export type CompletionParams = TextDocumentPositionParams & {
+  // The completion context. This is only available it the client specifies
+  // to send this using `ClientCapabilities.textDocument.completion.contextSupport === true`
+  context?: CompletionContext;
 };
 
-// Public: Parameters to receive with a workspace/applyEdit request.
-export type ApplyWorkspaceEditParams = {
-  edit: WorkspaceEdit,
+// Public: How a completion was triggered
+export const CompletionTriggerKind = {
+  // Completion was triggered by typing an identifier (24x7 code
+  // complete), manual invocation (e.g Ctrl+Space) or via API.
+  Invoked: 1,
+  // Completion was triggered by a trigger character specified by
+  // the `triggerCharacters` properties of the `CompletionRegistrationOptions`.
+  TriggerCharacter: 2,
 };
 
-// Public: Parameters to send with a workspace/applyEdit response.
-export type ApplyWorkspaceEditResponse = {
-  applied: boolean,
+// Public: Contains additional information about the context in which a completion request is triggered.
+export interface CompletionContext {
+  // How the completion was triggered.
+  triggerKind: number,
+  // The trigger character (a single character) that has trigger code complete.
+  // Is undefined if `triggerKind !== CompletionTriggerKind.TriggerCharacter`
+  triggerCharacter?: string,
+}
+
+// Public: Represents a collection of [completion items](#CompletionItem) to be presented in the editor.
+export type CompletionList = {
+  // This list it not complete. Further typing should result in recomputing this list.
+  isIncomplete: boolean,
+  // The completion items.
+  items: CompletionItem[],
+};
+
+// Public: Defines whether the insert text in a completion item should be interpreted as
+// plain text or a snippet.
+export const InsertTextFormat = {
+  // The primary text to be inserted is treated as a plain string.
+  PlainText: 1,
+  // The primary text to be inserted is treated as a snippet.
+  //
+  // A snippet can define tab stops and placeholders with `$1`, `$2`
+  // and `${3:foo}`. `$0` defines the final tab stop, it defaults to
+  // the end of the snippet. Placeholders with equal identifiers are linked,
+  // that is typing in one will update others too.
+  Snippet: 2,
+};
+
+// Public: CompletionItem details.
+export type CompletionItem = {
+  //  The label of this completion item. By default
+  //  also the text that is inserted when selecting
+  //  this completion.
+  label: string,
+  // The kind of this completion item. Based of the kind an icon is chosen by the editor.
+  kind?: number,
+  // A human-readable string with additional information
+  // about this item, like type or symbol information.
+  detail?: string,
+  // A human-readable string that represents a doc-comment.
+  documentation?: string,
+  //  A string that shoud be used when comparing this item
+  //  with other items. When `falsy` the label is used.
+  sortText?: string,
+  //  A string that should be used when filtering a set of
+  //  completion items. When `falsy` the label is used.
+  filterText?: string,
+  //  A string that should be inserted a document when selecting
+  //  this completion. When `falsy` the label is used.
+  insertText?: string,
+  // The format of the insert text. The format applies to both the `insertText` property
+  // and the `newText` property of a provided `textEdit`.
+  insertTextFormat?: number,
+  //  An edit which is applied to a document when selecting
+  //  this completion. When an edit is provided the value of
+  //  insertText is ignored.
+  textEdit?: TextEdit,
+  //  An optional array of additional text edits that are applied when
+  //  selecting this completion. Edits must not overlap with the main edit
+  //  nor with themselves.
+  additionalTextEdits?: TextEdit[],
+  // An optional set of characters that when pressed while this completion is active will accept it first and
+  // then type that character. *Note* that all commit characters should have `length=1` and that superfluous
+  // characters will be ignored.
+  commitCharacters?: string[],
+  //  An optional command that is executed *after* inserting this completion. *Note* that
+  //  additional modifications to the current document should be described with the
+  //  additionalTextEdits-property.
+  command?: Command,
+  //  An data entry field that is preserved on a completion item between
+  //  a completion and a completion resolve request.
+  data?: any,
+};
+
+// Public: The kind of a completion entry.
+export const CompletionItemKind = {
+  Text: 1,
+  Method: 2,
+  Function: 3,
+  Constructor: 4,
+  Field: 5,
+  Variable: 6,
+  Class: 7,
+  Interface: 8,
+  Module: 9,
+  Property: 10,
+  Unit: 11,
+  Value: 12,
+  Enum: 13,
+  Keyword: 14,
+  Snippet: 15,
+  Color: 16,
+  File: 17,
+  Reference: 18,
+};
+
+// Public: Registration options for the completions capability.
+export interface CompletionRegistrationOptions extends TextDocumentRegistrationOptions {
+  // Most tools trigger completion request automatically without explicitly requesting
+  // it using a keyboard shortcut (e.g. Ctrl+Space). Typically they do so when the user
+  // starts to type an identifier. For example if the user types `c` in a JavaScript file
+  // code complete will automatically pop up present `console` besides others as a
+  // completion item. Characters that make up identifiers don't need to be listed here.
+  //
+  // If code complete should automatically be trigger on characters not being valid inside
+  // an identifier (for example `.` in JavaScript) list them in `triggerCharacters`.
+  triggerCharacters?: string[],
+  // The server provides support to resolve additional
+  // information for a completion item.
+  resolveProvider?: boolean,
+}
+
+// Public: The result of a hover request.
+export type Hover = {
+  // The hover's content
+  contents: MarkedString | MarkedString[],
+  // An optional range is a range inside a text document
+  // that is used to visualize a hover, e.g. by changing the background color.
+  range?: Range,
+};
+
+// Public: The marked string is rendered:
+// - as markdown if it is represented as a string
+// - as code block of the given langauge if it is represented as a pair of a language and a value
+//
+// The pair of a language and a value is an equivalent to markdown:
+// ```${language};
+// ${value};
+// ```
+export type MarkedString = string | {language: string, value: string};
+
+// Public: Signature help represents the signature of something
+// callable. There can be multiple signature but only one
+// active and only one active parameter.
+export type SignatureHelp = {
+  // One or more signatures.
+  signatures: SignatureInformation[],
+  // The active signature.
+  activeSignature?: number,
+  // The active parameter of the active signature.
+  activeParameter?: number,
+};
+
+// Public: Represents the signature of something callable. A signature
+// can have a label, like a function-name, a doc-comment, and
+// a set of parameters.
+export type SignatureInformation = {
+  // The label of this signature. Will be shown in the UI.
+  label: string,
+  //  The human-readable doc-comment of this signature. Will be shown in the UI but can be omitted.
+  documentation?: string,
+  // The parameters of this signature.
+  parameters?: ParameterInformation[],
+};
+
+// Public: Represents a parameter of a callable-signature. A parameter can
+// have a label and a doc-comment.
+export type ParameterInformation = {
+  // The label of this parameter. Will be shown in the UI.
+  label: string,
+  // The human-readable doc-comment of this parameter. Will be shown in the UI but can be omitted.
+  documentation?: string,
+};
+
+// Public: Registration options for the signature help capability.
+export interface SignatureHelpRegistrationOptions extends TextDocumentRegistrationOptions {
+  // The characters that trigger signature help
+  // automatically.
+  triggerCharacters?: string[],
+}
+
+// Public: Parameters for the references request.
+export type ReferenceParams = TextDocumentPositionParams & {
+  context: ReferenceContext,
+};
+
+// Public: The context of a references request.
+export type ReferenceContext = {
+  // Include the declaration of the current symbol.
+  includeDeclaration: boolean,
+};
+
+// Public: A document highlight is a range inside a text document which deserves
+// special attention. Usually a document highlight is visualized by changing
+// the background color of its range.
+export type DocumentHighlight = {
+  // The range this highlight applies to.
+  range: Range,
+  // The highlight kind, default is DocumentHighlightKind.Text.
+  kind?: number,
+};
+
+// Public: The kind of a {DocumentHighlight}.
+export const DocumentHighlightKind = {
+  // A textual occurrance.
+  Text: 1,
+  // Read-access of a symbol, like reading a variable.
+  Read: 2,
+  // Write-access of a symbol, like writing to a variable.
+  Write: 3,
+};
+
+// Public: Parameters for a document symbol request.
+export type DocumentSymbolParams = {
+  // The text document.
+  textDocument: TextDocumentIdentifier,
+};
+
+// Public: Represents information about programming constructs like variables, classes,
+// interfaces etc.
+export type SymbolInformation = {
+  // The name of this symbol.
+  name: string,
+  // The kind of this symbol.
+  kind: number,
+  // The location of this symbol.
+  location: Location,
+  // The name of the symbol containing this symbol.
+  containerName?: string,
+};
+
+// Public: The kind of a symbol.
+export const SymbolKind = {
+  File: 1,
+  Module: 2,
+  Namespace: 3,
+  Package: 4,
+  Class: 5,
+  Method: 6,
+  Property: 7,
+  Field: 8,
+  Constructor: 9,
+  Enum: 10,
+  Interface: 11,
+  Function: 12,
+  Variable: 13,
+  Constant: 14,
+  String: 15,
+  Number: 16,
+  Boolean: 17,
+  Array: 18,
+};
+
+// Public: Params for the CodeActionRequest
+export type CodeActionParams = {
+  // The document in which the command was invoked.
+  textDocument: TextDocumentIdentifier,
+  // The range for which the command was invoked.
+  range: Range,
+  // Context carrying additional information.
+  context: CodeActionContext,
+};
+
+// Public: Contains additional diagnostic information about the context in which a code action is run.
+export type CodeActionContext = {
+  // An array of diagnostics.
+  diagnostics: Diagnostic[],
+};
+
+// Public: Parameters for the CodeLens request.
+export type CodeLensParams = {
+  // The document to request code lens for.
+  textDocument: TextDocumentIdentifier,
+};
+
+// Public: A code lens represents a command that should be shown along with
+// source text, like the number of references, a way to run tests, etc.
+//
+// A code lens is _unresolved_ when no command is associated to it. For performance
+// reasons the creation of a code lens and resolving should be done in two stages.
+export type CodeLens = {
+  // The range in which this code lens is valid. Should only span a single line.
+  range: Range,
+  // The command this code lens represents.
+  command?: Command,
+  // A data entry field that is preserved on a code lens item between a code lens
+  // and a code lens resolve request.
+  data?: any,
+};
+
+// Public: Registration options for the CodeLens capability.
+export interface CodeLensRegistrationOptions extends TextDocumentRegistrationOptions {
+  // Code lens has a resolve provider as well.
+  resolveProvider?: boolean,
+}
+
+// Public: Parameters for the DocumentLink request.
+export type DocumentLinkParams = {
+  // The document to provide document links for.
+  textDocument: TextDocumentIdentifier,
+};
+
+// Public: A document link is a range in a text document that links to an internal or
+// external resource, like another
+// text document or a web site.
+export type DocumentLink = {
+  // The range this link applies to.
+  range: Range,
+  // The uri this link points to.
+  target: string,
+};
+
+// Public: Registration options for the DocumentLink capability.
+export interface DocumentLinkRegistrationOptions extends TextDocumentRegistrationOptions {
+  // Document links have a resolve provider as well.
+  resolveProvider?: boolean,
+}
+
+// Public: Parameters to be send with a DocumentFormatting request.
+export type DocumentFormattingParams = {
+  // The document to format.
+  textDocument: TextDocumentIdentifier,
+  // The format options.
+  options: FormattingOptions,
+};
+
+// Public: Value-object describing what options formatting should use.
+export type FormattingOptions = {
+  // Size of a tab in spaces.
+  tabSize: number,
+  // Prefer spaces over tabs.
+  insertSpaces: boolean,
+  // Signature for further properties.
+  [key: string]: boolean | number | string,
+};
+
+// Public: Parameters to be send with a DocumentRangeFormatting request.
+export type DocumentRangeFormattingParams = {
+  // The document to format.
+  textDocument: TextDocumentIdentifier,
+  // The range to format.
+  range: Range,
+  // The format options.
+  options: FormattingOptions,
+};
+
+// Public: Parameters to be send with a DocumentOnTypeFormatting request.
+export type DocumentOnTypeFormattingParams = {
+  // Public: The {TextDocumentIdentifier} of the document to format.
+  textDocument: TextDocumentIdentifier,
+  // Public: The {Position} of the text cursor at this point in time.
+  position: Position,
+  // Public: The character that has been typed.
+  ch: string,
+  // Public: The {FormattingOptions} relating to this document.
+  options: FormattingOptions,
+};
+
+// Public: Registration options for the on-type document formatting capability.
+export interface DocumentOnTypeFormattingRegistrationOptions extends TextDocumentRegistrationOptions {
+  // A character on which formatting should be triggered, like `}`.
+  firstTriggerCharacter: string,
+  // More trigger characters.
+  moreTriggerCharacter?: string[],
+}
+
+// Public: Parameters to send with a Rename request.
+export type RenameParams = {
+  // Public: The {TextDocumentIdentifier} containing the item being renamed.
+  textDocument: TextDocumentIdentifier,
+  // Public: The position at which the symbol being renamed exists within the
+  // text document.
+  position: Position,
+  // Public: The new name of this symbol.  If the given name is not valid the
+  // request must return a [ResponseError](#ResponseError) with an
+  // appropriate message set.
+  newName: string,
 };
 
 type DocumentUri = string;


### PR DESCRIPTION
This change reorganizes the language server protocol Flow type definitions
so that they follow the order of the LSP spec for easier spot-checking.
It also adds some missing registration options types which currently
aren't being used.