### PR TITLE
Add `handleServerStderr` method + default logging

### DIFF
--- a/lib/auto-languageclient.js
+++ b/lib/auto-languageclient.js
@@ -232,7 +232,7 @@ export default class AutoLanguageClient {
     } finally {
       startingSignal && startingSignal.dispose();
     }
-
+    this.captureServerErrors(process, projectPath);
     const connection = new ls.LanguageClientConnection(this.createRpcConnection(process), this.logger);
     this.preInitialization(connection);
     const initializeParams = this.getInitializeParams(projectPath, process);
@@ -255,13 +255,13 @@ export default class AutoLanguageClient {
     return newServer;
   }
 
-  captureServerErrors(childProcess: child_process$ChildProcess): void {
+  captureServerErrors(childProcess: child_process$ChildProcess, projectPath: string): void {
     childProcess.on('error', err => this.handleSpawnFailure(err));
-    childProcess.on('exit', (code, signal) => this.logger.debug(`exited code ${code}`));
+    childProcess.on('exit', (code, signal) => code !== null && this.logger.debug(`exit code: ${code}`));
     childProcess.stderr.setEncoding('utf8');
     childProcess.stderr.on('data', (chunk: Buffer) => {
       const errorString = chunk.toString();
-      this.logger.warn('stderr', errorString);
+      this.handleServerStderr(errorString, projectPath);
       // Keep the last 5 lines for packages to use in messages
       this.processStdErr = (this.processStdErr + errorString)
         .split('\n')
@@ -571,5 +571,13 @@ export default class AutoLanguageClient {
    */
   filterChangeWatchedFiles(filePath: string): boolean {
     return true;
+  }
+
+  /**
+   * Called on language server stderr output.
+   * @param stderr a chunk of stderr from a language server instance
+   */
+  handleServerStderr(stderr: string, projectPath: string) {
+    stderr.split('\n').filter(l => l).forEach(line => this.logger.warn(`stderr ${line}`));
   }
 }


### PR DESCRIPTION
As discussed a little in #157 this PR adds stderr handling to a new public method:
```js
/**
 * Called on language server stderr output.
 * @param stderr a chunk of stderr from a language server instance
 */
handleServerStderr(stderr: string, projectPath: string) {
  stderr.split('\n').filter(l => l).forEach(line => this.logger.warn(`stderr ${line}`));
}
```

* Restored stderr / childProcess error handling code.
* Sends stderr chunks to new method, default impl warns per line

Resolves #157