### PR TITLE
Add CancellationToken support to LanguageClientConnection

### DIFF
--- a/flow-libs/jsonrpc.js.flow
+++ b/flow-libs/jsonrpc.js.flow
@@ -21,3 +21,24 @@ export type JsonRpcConnection = {
   onUnhandledNotification(callback: Object => void): void,
   onDispose(callback: () => void): void,
 };
+
+// https://github.com/Microsoft/vscode-languageserver-node/blob/master/jsonrpc/src/cancellation.ts
+export interface CancellationToken {
+	// Is `true` when the token has been cancelled, `false` otherwise.
+	+isCancellationRequested: boolean,
+
+	// An [event](#Event) which fires upon cancellation.
+	+onCancellationRequested: Event<any>,
+}
+
+export type MutableToken = {
+	cancel(): void,
+	isCancellationRequested(): boolean,
+	onCancellationRequested(): Event<any>,
+};
+
+export type CancellationTokenSource = {
+	token(): CancellationToken,
+	cancel(): void,
+	dispose(): void,
+};

--- a/lib/adapters/autocomplete-adapter.js
+++ b/lib/adapters/autocomplete-adapter.js
@@ -9,7 +9,9 @@ import {
   type TextEdit,
   type ServerCapabilities,
 } from '../languageclient';
+import {CancellationTokenSource} from 'vscode-jsonrpc';
 import Convert from '../convert';
+import Utils from '../utils';
 
 // Public: Adapts the language server protocol "textDocument/completion" to the Atom
 // AutoComplete+ package.
@@ -19,6 +21,7 @@ export default class AutocompleteAdapter {
   }
 
   _lastSuggestions: Map<atom$AutocompleteSuggestion, [CompletionItem, boolean]> = new Map();
+  _cancellationTokens: WeakMap<LanguageClientConnection, CancellationTokenSource> = new WeakMap();
 
   // Public: Obtain suggestion list for AutoComplete+ by querying the language server using
   // the `textDocument/completion` request.
@@ -35,7 +38,9 @@ export default class AutocompleteAdapter {
     request: atom$AutocompleteRequest,
     onDidConvertCompletionItem?: (CompletionItem, atom$AutocompleteSuggestion, atom$AutocompleteRequest) => void,
   ): Promise<Array<atom$AutocompleteSuggestion>> {
-    const items = await connection.completion(AutocompleteAdapter.requestToTextDocumentPositionParams(request));
+    const cancellationToken = Utils.cancelAndRefreshCancellationToken(connection, this._cancellationTokens);
+    const items = await connection.completion(AutocompleteAdapter.requestToTextDocumentPositionParams(request), cancellationToken);
+    this._cancellationTokens.delete(connection);
     this._lastSuggestions = this.completionItemsToSuggestions(items, request, onDidConvertCompletionItem);
     return Array.from(this._lastSuggestions.keys());
   }

--- a/lib/adapters/outline-view-adapter.js
+++ b/lib/adapters/outline-view-adapter.js
@@ -2,11 +2,16 @@
 
 import {LanguageClientConnection, SymbolKind, type ServerCapabilities, type SymbolInformation} from '../languageclient';
 import Convert from '../convert';
+import Utils from '../utils';
 import {Point} from 'atom';
+import {CancellationTokenSource} from 'vscode-jsonrpc';
 
 // Public: Adapts the documentSymbolProvider of the language server to the Outline View
 // supplied by Atom IDE UI.
 export default class OutlineViewAdapter {
+
+  _cancellationTokens: WeakMap<LanguageClientConnection, CancellationTokenSource> = new WeakMap();
+
   // Public: Determine whether this adapter can be used to adapt a language server
   // based on the serverCapabilities matrix containing a documentSymbolProvider.
   //
@@ -27,9 +32,12 @@ export default class OutlineViewAdapter {
   //
   // Returns a {Promise} containing the {Outline} of this document.
   async getOutline(connection: LanguageClientConnection, editor: atom$TextEditor): Promise<?atomIde$Outline> {
+    const cancellationToken = Utils.cancelAndRefreshCancellationToken(connection, this._cancellationTokens);
     const results = await connection.documentSymbol({
       textDocument: Convert.editorToTextDocumentIdentifier(editor),
-    });
+    }, cancellationToken);
+
+    this._cancellationTokens.delete(connection);
     results.sort(
       (a, b) =>
         (a.location.range.start.line === b.location.range.start.line

--- a/lib/languageclient.js
+++ b/lib/languageclient.js
@@ -171,10 +171,16 @@ export class LanguageClientConnection {
 
   // Public: Send a `textDocument/completion` request.
   //
-  // * `params` The {TextDocumentPositionParams} or {CompletionParams} for which {CompletionItem}s are desired.
+  // * `params`            The {TextDocumentPositionParams} or {CompletionParams} for which
+  //                       {CompletionItem}s are desired.
+  // * `cancellationToken` The {CancellationToken} that is used to cancel this request if
+  //                       necessary.
   // Returns a {Promise} containing either a {CompletionList} or an {Array} of {CompletionItem}s.
-  completion(params: TextDocumentPositionParams | CompletionParams): Promise<Array<CompletionItem> | CompletionList> {
-    return this._sendRequest('textDocument/completion', params);
+  completion(
+    params: TextDocumentPositionParams | CompletionParams,
+    cancellationToken?: jsonrpc.CancellationToken): Promise<Array<CompletionItem> | CompletionList> {
+    // Cancel prior request if necessary
+    return this._sendRequest('textDocument/completion', params, cancellationToken);
   }
 
   // Public: Send a `completionItem/resolve` request.
@@ -230,10 +236,13 @@ export class LanguageClientConnection {
 
   // Public: Send a `textDocument/documentSymbol` request.
   //
-  // * `params` The {DocumentSymbolParams} that identifies the document for which symbols are desired.
+  // * `params`            The {DocumentSymbolParams} that identifies the document for which
+  //                       symbols are desired.
+  // * `cancellationToken` The {CancellationToken} that is used to cancel this request if
+  //                       necessary.
   // Returns a {Promise} containing an {Array} of {SymbolInformation}s that can be used to
   // navigate this document.
-  documentSymbol(params: DocumentSymbolParams): Promise<Array<SymbolInformation>> {
+  documentSymbol(params: DocumentSymbolParams, cancellationToken?: jsonrpc.CancellationToken): Promise<Array<SymbolInformation>> {
     return this._sendRequest('textDocument/documentSymbol', params);
   }
 
@@ -359,11 +368,20 @@ export class LanguageClientConnection {
     this._rpc.sendNotification(method, args);
   }
 
-  async _sendRequest(method: string, args?: Object): Promise<any> {
+  async _sendRequest(method: string, args?: Object, cancellationToken?: jsonrpc.CancellationToken): Promise<any> {
     this._log.debug(`rpc.sendRequest ${method} sending`, args);
     try {
       const start = performance.now();
-      const result = await this._rpc.sendRequest(method, args);
+      let result = undefined;
+      if (cancellationToken) {
+        result = await this._rpc.sendRequest(method, args, cancellationToken);
+      } else {
+        // If cancellationToken is null or undefined, don't add the third
+        // argument otherwise vscode-jsonrpc will send an additional, null
+        // message parameter to the request
+        result = await this._rpc.sendRequest(method, args);
+      }
+
       const took = performance.now() - start;
       this._log.debug(`rpc.sendRequest ${method} received (${Math.floor(took)}ms)`, result);
       return result;

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,6 +1,10 @@
 // @flow
 
+import {
+  LanguageClientConnection,
+} from './languageclient';
 import {Range} from 'atom';
+import {CancellationTokenSource} from 'vscode-jsonrpc';
 
 export default class Utils {
   /**
@@ -48,5 +52,24 @@ export default class Utils {
       }
     });
     return matchData == null ? null : matchData.range;
+  }
+
+  /**
+   * For the given connection and cancellationTokens map, cancel the existing
+   * CancellationToken for that connection then create and store a new
+   * CancellationToken to be used for the current request.
+   */
+  static cancelAndRefreshCancellationToken(
+    connection: LanguageClientConnection,
+    cancellationTokens: WeakMap<LanguageClientConnection, CancellationTokenSource>): CancellationToken {
+
+    let cancellationToken = cancellationTokens.get(connection);
+    if (cancellationToken !== undefined) {
+      cancellationToken.cancel();
+    }
+
+    cancellationToken = new CancellationTokenSource();
+    cancellationTokens.set(connection, cancellationToken);
+    return cancellationToken.token;
   }
 }


### PR DESCRIPTION
This change adds and extra parameter to LanguageClientConnection._sendRequest which accepts the vscode-jsonrpc library's CancellationToken class which can be used to cancel active requests.  When a request is cancelled using one of these tokens, a `$/cancelRequest` notification will be sent to the language server to request a cancellation, but the server must implement cancellation behavior for this to be effective.

This change also adds auto-cancellation of previous requests in the AutocompleteAdapter and OutlineViewAdapter classes.

Related to #140.