### PR TITLE
Use `CompletionItem.textEdit` field for snippet content

### DIFF
--- a/lib/adapters/autocomplete-adapter.js
+++ b/lib/adapters/autocomplete-adapter.js
@@ -2,6 +2,7 @@
 
 import {
   CompletionItemKind,
+  InsertTextFormat,
   LanguageClientConnection,
   type CompletionItem,
   type CompletionList,
@@ -126,6 +127,7 @@ export default class AutocompleteAdapter {
   ): atom$AutocompleteSuggestion {
     AutocompleteAdapter.applyCompletionItemToSuggestion(item, suggestion);
     AutocompleteAdapter.applyTextEditToSuggestion(item.textEdit, request.editor, suggestion);
+    AutocompleteAdapter.applySnippetToSuggestion(item, suggestion);
     if (onDidConvertCompletionItem != null) {
       onDidConvertCompletionItem(item, suggestion, request);
     }
@@ -141,7 +143,6 @@ export default class AutocompleteAdapter {
   static applyCompletionItemToSuggestion(item: CompletionItem, suggestion: atom$AutocompleteSuggestion) {
     suggestion.text = item.insertText || item.label;
     suggestion.displayText = item.label;
-    suggestion.snippet = item.insertTextFormat === 2 ? item.insertText : undefined;
     suggestion.type = AutocompleteAdapter.completionKindToSuggestionType(item.kind);
     suggestion.rightLabel = item.detail;
     suggestion.description = item.documentation;
@@ -164,6 +165,19 @@ export default class AutocompleteAdapter {
       suggestion.text = textEdit.newText;
     }
   }
+
+  // Public: Adds a snippet to the suggestion if the CompletionItem contains
+  // snippet-formatted text
+  //
+  // * `item` An {CompletionItem} containing the completion items to be merged into.
+  // * `suggestion` The {atom$AutocompleteSuggestion} to merge the conversion into.
+  //
+  static applySnippetToSuggestion(item: CompletionItem, suggestion: atom$AutocompleteSuggestion): void {
+    if (item.insertTextFormat === InsertTextFormat.Snippet) {
+      suggestion.snippet = item.textEdit != null ? item.textEdit.newText : item.insertText;
+    }
+  }
+
 
   // Public: Obtain the textual suggestion type required by AutoComplete+ that
   // most closely maps to the numeric completion kind supplies by the language server.


### PR DESCRIPTION
The `CompletionItem.insertText` field is deprecated, so we give priority
to `textEdit` instead.  This is required for servers that no longer return
`insertText` in the completion items.