### PR TITLE
Add configuration watching to send `workspace/didChangeConfiguration`

### DIFF
--- a/lib/auto-languageclient.js
+++ b/lib/auto-languageclient.js
@@ -178,6 +178,16 @@ export default class AutoLanguageClient {
     return this.socket != null ? 'socket' : 'stdio';
   }
 
+  // Return the name of your root configuration key
+  getRootConfigurationKey(): string {
+    return '';
+  }
+
+  // Optionally transform the configuration object before it is sent to the server
+  mapConfigurationObject(configuration: any): any {
+    return configuration;
+  }
+
   // Default implementation of the rest of the AutoLanguageClient
   // ---------------------------------------------------------------------------
 
@@ -251,6 +261,20 @@ export default class AutoLanguageClient {
     };
     this.postInitialization(newServer);
     connection.initialized();
+
+    const configurationKey = this.getRootConfigurationKey();
+    if (configurationKey) {
+      this._disposable.add(
+        atom.config.observe(configurationKey, config => {
+          const mappedConfig = this.mapConfigurationObject(config || {});
+          if (mappedConfig) {
+            connection.didChangeConfiguration({
+              settings: mappedConfig,
+            });
+          }
+        }));
+    }
+
     this.startExclusiveAdapters(newServer);
     return newServer;
   }


### PR DESCRIPTION
This change adds logic to AutoLanguageClient so that a language package can opt-in to having a specific configuration section watched for changes so that workspace/didChangeConfiguration notifications are sent to the language server.  Language packages can opt-in by implementing the `getRootConfigurationKey` method and optionally the `filterConfigurationObject` method to manipulate the configuration object before it gets sent to the language server.