### PR TITLE
Gracefully handle unexpected server shutdown

### DIFF
--- a/lib/auto-languageclient.js
+++ b/lib/auto-languageclient.js
@@ -261,6 +261,7 @@ export default class AutoLanguageClient {
     };
     this.postInitialization(newServer);
     connection.initialized();
+    connection.on('close', () => this._serverManager.stopServer(newServer));
 
     const configurationKey = this.getRootConfigurationKey();
     if (configurationKey) {

--- a/lib/languageclient.js
+++ b/lib/languageclient.js
@@ -1,19 +1,29 @@
 // @flow
 
 import * as jsonrpc from 'vscode-jsonrpc';
+import EventEmitter from 'events';
 import {NullLogger, type Logger} from './logger';
 
 // Flow-typed wrapper around JSONRPC to implement Microsoft Language Server Protocol v3
 // https://github.com/Microsoft/language-server-protocol/blob/master/protocol.md
-export class LanguageClientConnection {
+export class LanguageClientConnection extends EventEmitter {
   _rpc: jsonrpc.connection;
   _log: Logger;
+  isConnected: boolean;
 
   constructor(rpc: jsonrpc.connection, logger: ?Logger) {
+    super();
     this._rpc = rpc;
     this._log = logger || new NullLogger();
     this.setupLogging();
     rpc.listen();
+
+    this.isConnected = true;
+    this._rpc.onClose(() => {
+      this.isConnected = false;
+      this._log.warn('rpc.onClose', 'The RPC connection closed unexpectedly');
+      this.emit('close');
+    });
   }
 
   setupLogging(): void {

--- a/lib/server-manager.js
+++ b/lib/server-manager.js
@@ -186,7 +186,9 @@ export class ServerManager {
       this._activeServers.splice(this._activeServers.indexOf(server), 1);
       this._stoppingServers.push(server);
       server.disposable.dispose();
-      await server.connection.shutdown();
+      if (server.connection.isConnected) {
+        await server.connection.shutdown();
+      }
 
       if (server.linterPushV2 != null) {
         server.linterPushV2.detachAll();
@@ -206,8 +208,10 @@ export class ServerManager {
   exitServer(server: ActiveServer): void {
     const pid = server.process.pid;
     try {
-      server.connection.exit();
-      server.connection.dispose();
+      if (server.connection.isConnected) {
+        server.connection.exit();
+        server.connection.dispose();
+      }
     } finally {
       server.process.kill();
     }

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -7,6 +7,7 @@ import * as rpc from 'vscode-jsonrpc';
 export function createSpyConnection(): rpc.connection {
   return {
     listen: sinon.spy(),
+    onClose: sinon.spy(),
     onError: sinon.spy(),
     onUnhandledNotification: sinon.spy(),
     onNotification: sinon.spy(),


### PR DESCRIPTION
This change adds some logic to gracefully handle sudden server shutdown
like when the language server process gets killed by the user in their
task manager.  The solution is to watch for the RPC connection to get
closed unexpectedly and then dispose of the server in ServerManager
so that no further requests are sent to it.