### PR TITLE
Send non-null `initialized` params

### DIFF
--- a/lib/languageclient.js
+++ b/lib/languageclient.js
@@ -45,7 +45,7 @@ export class LanguageClientConnection {
 
   // Public: Send an `initialized` notification to the language server.
   initialized(): void {
-    this._sendNotification('initialized');
+    this._sendNotification('initialized', {});
   }
 
   // Public: Send a `shutdown` request to the language server.
@@ -564,6 +564,10 @@ export type InitializeParams = {
   // The initial trace setting. If omitted trace is disabled ('off').
   trace?: 'off' | 'messages' | 'verbose',
 };
+
+// Public: Notification parameters sent to the server once after initialize
+// & before other requests
+export type InitializedParams = {};
 
 // Public: Defines capabilities the editor / tool provides on the workspace.
 export type WorkspaceClientCapabilities = {

--- a/test/languageclient.test.js
+++ b/test/languageclient.test.js
@@ -283,6 +283,15 @@ describe('LanguageClientConnection', () => {
       expect(lc._sendNotification.getCall(0).args.length).equals(1);
     });
 
+    it('initialized sends notification', () => {
+      lc.initialized();
+
+      expect(lc._sendNotification.called).equals(true);
+      expect(lc._sendNotification.getCall(0).args[0]).equals('initialized');
+      const expected: ls.InitializedParams = {};
+      expect(lc._sendNotification.getCall(0).args[1]).to.deep.equal(expected);
+    });
+
     it('didChangeConfiguration sends notification', () => {
       const params: ls.DidChangeConfigurationParams = {
         settings: {a: {b: 'c'}},


### PR DESCRIPTION
This pr sends non-null params with `initialized` notifications.

According to the [spec](https://github.com/Microsoft/language-server-protocol/blob/gh-pages/specification.md#initialized-notification-arrow_right) the _initialized_ parameters are not void _(although they are empty)_.  Sending `null`, as we currently do, has started to cause latest Rls code to crash parsing this notification.