### PR TITLE
Add language server restart API and auto-restart behavior

### DIFF
--- a/lib/adapters/linter-push-v2-adapter.js
+++ b/lib/adapters/linter-push-v2-adapter.js
@@ -24,6 +24,11 @@ export default class LinterPushV2Adapter {
     connection.onPublishDiagnostics(this.captureDiagnostics.bind(this));
   }
 
+  // Dispose this adapter ensuring any resources are freed and events unhooked.
+  dispose(): void {
+    this.detachAll();
+  }
+
   // Public: Attach this {LinterPushV2Adapter} to a given {V2IndieDelegate} registry.
   //
   // * `indie` A {V2IndieDelegate} that wants to receive messages.

--- a/lib/auto-languageclient.js
+++ b/lib/auto-languageclient.js
@@ -35,6 +35,7 @@ export default class AutoLanguageClient {
   _linterDelegate: linter$V2IndieDelegate;
   _signatureHelpRegistry: ?atomIde$SignatureHelpRegistry;
   _lastAutocompleteRequest: ?atom$AutocompleteRequest;
+  _isDeactivating: boolean;
 
   // Available if consumeBusySignal is setup
   busySignalService: ?atomIde$BusySignalService;
@@ -227,6 +228,7 @@ export default class AutoLanguageClient {
 
   // Deactivate disposes the resources we're using
   async deactivate(): Promise<any> {
+    this._isDeactivating = true;
     this._disposable.dispose();
     this._serverManager.stopListening();
     await this._serverManager.stopAllServers();
@@ -275,7 +277,18 @@ export default class AutoLanguageClient {
     };
     this.postInitialization(newServer);
     connection.initialized();
-    connection.on('close', () => this._serverManager.stopServer(newServer));
+    connection.on('close', () => {
+      if (!this.isDeactivating) {
+        this._serverManager.stopServer(newServer);
+        if (!this._serverManager.hasServerReachedRestartLimit(newServer)) {
+          this.logger.debug(`Restarting language server for project '${newServer.projectPath}'`);
+          this._serverManager.startServer(projectPath);
+        } else {
+          this.logger.warn(`Language server has exceeded auto-restart limit for project '${newServer.projectPath}'`);
+          atom.notifications.addError(`The ${this.name} language server has exited and exceeded the restart limit for project '${newServer.projectPath}'`);
+        }
+      }
+    });
 
     const configurationKey = this.getRootConfigurationKey();
     if (configurationKey) {

--- a/lib/auto-languageclient.js
+++ b/lib/auto-languageclient.js
@@ -188,10 +188,18 @@ export default class AutoLanguageClient {
     return configuration;
   }
 
+  // Helper methods that are useful for implementors
+  // ---------------------------------------------------------------------------
+
   // Gets a LanguageClientConnection for a given TextEditor
   async getConnectionForEditor(editor: atom$TextEditor): Promise<?ls.LanguageClientConnection> {
     const server = await this._serverManager.getServer(editor);
     return server ? server.connection : null;
+  }
+
+  // Restart all active language servers for this language client in the workspace
+  async restartAllServers() {
+    await this._serverManager.restartAllServers();
   }
 
   // Default implementation of the rest of the AutoLanguageClient

--- a/lib/auto-languageclient.js
+++ b/lib/auto-languageclient.js
@@ -374,12 +374,14 @@ export default class AutoLanguageClient {
     if (this._linterDelegate != null) {
       server.linterPushV2.attach(this._linterDelegate);
     }
+    server.disposable.add(server.linterPushV2);
 
     if (SignatureHelpAdapter.canAdapt(server.capabilities)) {
       server.signatureHelpAdapter = new SignatureHelpAdapter(server, this.getGrammarScopes());
       if (this._signatureHelpRegistry != null) {
         server.signatureHelpAdapter.attach(this._signatureHelpRegistry);
       }
+      server.disposable.add(server.signatureHelpAdapter);
     }
   }
 

--- a/lib/server-manager.js
+++ b/lib/server-manager.js
@@ -70,6 +70,7 @@ export class ServerManager {
   stopListening(): void {
     if (this._isStarted) {
       this._disposable.dispose();
+      this._isStarted = false;
     }
   }
 
@@ -172,6 +173,13 @@ export class ServerManager {
 
   async stopAllServers(): Promise<void> {
     await Promise.all(this._activeServers.map(s => this.stopServer(s)));
+  }
+
+  async restartAllServers(): Promise<void> {
+    this.stopListening();
+    await this.stopAllServers();
+    this._editorToServer = new Map();
+    this.startListening();
   }
 
   async stopServer(server: ActiveServer): Promise<void> {

--- a/lib/server-manager.js
+++ b/lib/server-manager.js
@@ -22,11 +22,17 @@ export type ActiveServer = {
   signatureHelpAdapter?: SignatureHelpAdapter,
 };
 
+type RestartCounter = {
+  restarts: number;
+  timerId: number;
+};
+
 // Manages the language server lifecycles and their associated objects necessary
 // for adapting them to Atom IDE.
 export class ServerManager {
   _activeServers: Array<ActiveServer> = [];
   _startingServerPromises: Map<string, Promise<ActiveServer>> = new Map();
+  _restartCounterPerProject: Map<string, RestartCounter> = new Map();
   _stoppingServers: Array<ActiveServer> = [];
   _disposable: CompositeDisposable = new CompositeDisposable();
   _editorToServer: Map<atom$TextEditor, ActiveServer> = new Map();
@@ -172,6 +178,11 @@ export class ServerManager {
   }
 
   async stopAllServers(): Promise<void> {
+    for (const [projectPath, restartCounter] of this._restartCounterPerProject) {
+      clearTimeout(restartCounter.timerId);
+      this._restartCounterPerProject.delete(projectPath);
+    }
+
     await Promise.all(this._activeServers.map(s => this.stopServer(s)));
   }
 
@@ -180,6 +191,23 @@ export class ServerManager {
     await this.stopAllServers();
     this._editorToServer = new Map();
     this.startListening();
+  }
+
+  hasServerReachedRestartLimit(server: ActiveServer) {
+    let restartCounter = this._restartCounterPerProject.get(server.projectPath);
+
+    if (!restartCounter) {
+      restartCounter = {
+        restarts: 0,
+        timerId: setTimeout(() => {
+          this._restartCounterPerProject.delete(server.projectPath);
+        }, 3 * 60 * 1000 /* 3 minutes */),
+      };
+
+      this._restartCounterPerProject.set(server.projectPath, restartCounter);
+    }
+
+    return ++restartCounter.restarts > 5;
   }
 
   async stopServer(server: ActiveServer): Promise<void> {
@@ -196,6 +224,12 @@ export class ServerManager {
       server.disposable.dispose();
       if (server.connection.isConnected) {
         await server.connection.shutdown();
+      }
+
+      for (const [editor, mappedServer] of this._editorToServer) {
+        if (mappedServer === server) {
+          this._editorToServer.delete(editor);
+        }
       }
 
       if (server.linterPushV2 != null) {

--- a/lib/server-manager.js
+++ b/lib/server-manager.js
@@ -232,14 +232,6 @@ export class ServerManager {
         }
       }
 
-      if (server.linterPushV2 != null) {
-        server.linterPushV2.detachAll();
-      }
-
-      if (server.signatureHelpAdapter != null) {
-        server.signatureHelpAdapter.dispose();
-      }
-
       this.exitServer(server);
       this._stoppingServers.splice(this._stoppingServers.indexOf(server), 1);
     } finally {


### PR DESCRIPTION
**Add AutoLanguageClient.restartServers API**

This change adds a new restartServers() API to AutoLanguageClient so
that implementors of the class can easily restart all active language
servers for their client in the workspace.

**Add language server auto-restart**

This change adds language server auto-restart behavior when a
language server exits or crashes unexpectedly.  The restart logic
allows a language server to be restarted up to 5 times within 3
minutes and then stops auto-restarting after reaching that limit.
