### PR TITLE
Add AutoLanguageClient.getConnectionForEditor

### DIFF
--- a/lib/auto-languageclient.js
+++ b/lib/auto-languageclient.js
@@ -188,6 +188,12 @@ export default class AutoLanguageClient {
     return configuration;
   }
 
+  // Gets a LanguageClientConnection for a given TextEditor
+  async getConnectionForEditor(editor: atom$TextEditor): Promise<?ls.LanguageClientConnection> {
+    const server = await this._serverManager.getServer(editor);
+    return server ? server.connection : null;
+  }
+
   // Default implementation of the rest of the AutoLanguageClient
   // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
This change adds a getConnectionForEditor method to AutoLanguageClient
so that implementors can send custom requests and notifications to the
language server associated with a TextEditor.