### PR TITLE
Don't retain failing server startup promises

### DIFF
--- a/lib/server-manager.js
+++ b/lib/server-manager.js
@@ -161,11 +161,16 @@ export class ServerManager {
     this._logger.debug(`Server starting "${projectPath}"`);
     const startingPromise = this._startServer(projectPath);
     this._startingServerPromises.set(projectPath, startingPromise);
-    const startedActiveServer = await startingPromise;
-    this._activeServers.push(startedActiveServer);
-    this._startingServerPromises.delete(projectPath);
-    this._logger.debug(`Server started "${projectPath}" (pid ${startedActiveServer.process.pid})`);
-    return startedActiveServer;
+    try {
+      const startedActiveServer = await startingPromise;
+      this._activeServers.push(startedActiveServer);
+      this._startingServerPromises.delete(projectPath);
+      this._logger.debug(`Server started "${projectPath}" (pid ${startedActiveServer.process.pid})`);
+      return startedActiveServer;
+    } catch (e) {
+      this._startingServerPromises.delete(projectPath);
+      throw e;
+    }
   }
 
   async stopUnusedServers(): Promise<void> {


### PR DESCRIPTION
This PR fixes a scenario where the lang-server's startup method returns a failing promise. In this case currently the `_startingServerPromises` map will retain hold of the failing promise and prevent the startup method from ever being re-run even after closing all project editors.