### PR TITLE
Prevent showMessage spam + add projectPath to showMessage detail

### DIFF
--- a/lib/auto-languageclient.ts
+++ b/lib/auto-languageclient.ts
@@ -395,7 +395,7 @@ export default class AutoLanguageClient {
   // Start adapters that are not shared between servers
   private startExclusiveAdapters(server: ActiveServer): void {
     ApplyEditAdapter.attach(server.connection);
-    NotificationsAdapter.attach(server.connection, this.name);
+    NotificationsAdapter.attach(server.connection, this.name, server.projectPath);
 
     if (DocumentSyncAdapter.canAdapt(server.capabilities)) {
       server.docSyncAdapter =

--- a/typings/atom/index.d.ts
+++ b/typings/atom/index.d.ts
@@ -1,4 +1,4 @@
-import { Point, Range, TextBuffer, TextEditor as TextEditorCore, ScopeDescriptor } from 'atom';
+import { Point, Range, TextBuffer, TextEditor as TextEditorCore, ScopeDescriptor, Notification } from 'atom';
 
 declare module 'atom' {
   interface TextEditor {
@@ -80,5 +80,11 @@ declare module 'atom' {
     className?: string;
     onDidClick?(event: MouseEvent): void;
     text?: string;
+  }
+
+  // Non-public Notification api
+  interface NotificationExt extends Notification {
+    isDismissed?: () => boolean;
+    getOptions?: () => NotificationOptions | null;
   }
 }


### PR DESCRIPTION
This pr improves _window/showMessage_ -> notification handling. 

Servers can resend the same error message, in this case it isn't much help to repeat the notifications.  We also currently lack an indication of which project the notification relates to.

## Before
![](https://user-images.githubusercontent.com/2331607/36207390-afe6ff18-118d-11e8-92cc-0b40564efb8c.gif)

## After
![](https://user-images.githubusercontent.com/2331607/36207399-b721c7b8-118d-11e8-9eea-f42a611cd471.gif)

