### PR TITLE
Expect LanguageServerProcess from startServerProcess

### DIFF
--- a/lib/auto-languageclient.ts
+++ b/lib/auto-languageclient.ts
@@ -39,6 +39,21 @@ import SignatureHelpAdapter from './adapters/signature-help-adapter';
 
 export type ConnectionType = 'stdio' | 'socket' | 'ipc';
 
+// Public: Defines the minimum surface area for an object that resembles a
+// ChildProcess.  This is used so that language packages with alternative
+// language server process hosting strategies can return something compatible
+// with AutoLanguageClient.startServerProcess.
+export interface LanguageServerProcess extends EventEmitter {
+  stdin: stream.Writable;
+  stdout: stream.Readable;
+  stderr: stream.Readable;
+  pid: number;
+
+  kill(signal?: string): void;
+  on(event: 'error', listener: (err: Error) => void): this;
+  on(event: 'exit', listener: (code: number, signal: string) => void): this;
+}
+
 // Public: AutoLanguageClient provides a simple way to have all the supported
 // Atom-IDE services wired up entirely for you by just subclassing it and
 // implementing startServerProcess/getGrammarScopes/getLanguageName and
@@ -85,7 +100,7 @@ export default class AutoLanguageClient {
   }
 
   // Start your server process
-  protected startServerProcess(projectPath: string): cp.ChildProcess | Promise<cp.ChildProcess> {
+  protected startServerProcess(projectPath: string): LanguageServerProcess | Promise<LanguageServerProcess> {
     throw Error('Must override startServerProcess to start language server process when extending AutoLanguageClient');
   }
 


### PR DESCRIPTION
This change introduces a new LanguageServerProcess interface that
represents the minimum surface area of the ChildProcess class that
is used by atom-languageclient.  This is useful for language packages
which launch a language server by some means other than ChildProcess
and need a way to return a compatible wrapper.