### PR TITLE
Fix type exports for atom-ide and atom-linter.

### DIFF
--- a/lib/adapters/linter-push-v2-adapter.ts
+++ b/lib/adapters/linter-push-v2-adapter.ts
@@ -12,9 +12,9 @@ import Convert from '../convert';
 // Public: Listen to diagnostics messages from the language server and publish them
 // to the user by way of the Linter Push (Indie) v2 API supported by Atom IDE UI.
 export default class LinterPushV2Adapter {
-  private _diagnosticMap: Map<string, linter.V2Message[]> = new Map();
+  private _diagnosticMap: Map<string, linter.Message[]> = new Map();
   private _diagnosticCodes: Map<string, Map<string, DiagnosticCode | null>> = new Map();
-  private _indies: Set<linter.V2IndieDelegate> = new Set();
+  private _indies: Set<linter.IndieDelegate> = new Set();
 
   // Public: Create a new {LinterPushV2Adapter} that will listen for diagnostics
   // via the supplied {LanguageClientConnection}.
@@ -32,7 +32,7 @@ export default class LinterPushV2Adapter {
   // Public: Attach this {LinterPushV2Adapter} to a given {V2IndieDelegate} registry.
   //
   // * `indie` A {V2IndieDelegate} that wants to receive messages.
-  public attach(indie: linter.V2IndieDelegate): void {
+  public attach(indie: linter.IndieDelegate): void {
     this._indies.add(indie);
     this._diagnosticMap.forEach((value, key) => indie.setMessages(key, value));
     indie.onDidDestroy(() => {
@@ -73,7 +73,7 @@ export default class LinterPushV2Adapter {
   // * `diagnostics` A {Diagnostic} object received from the language server.
   //
   // Returns a {V2Message} equivalent to the {Diagnostic} object supplied by the language server.
-  public diagnosticToV2Message(path: string, diagnostic: Diagnostic): linter.V2Message {
+  public diagnosticToV2Message(path: string, diagnostic: Diagnostic): linter.Message {
     return {
       location: {
         file: path,

--- a/lib/auto-languageclient.ts
+++ b/lib/auto-languageclient.ts
@@ -47,7 +47,7 @@ export type ConnectionType = 'stdio' | 'socket' | 'ipc';
 export default class AutoLanguageClient {
   private _disposable = new CompositeDisposable();
   private _serverManager: ServerManager;
-  private _linterDelegate: linter.V2IndieDelegate;
+  private _linterDelegate: linter.IndieDelegate;
   private _signatureHelpRegistry: atomIde.SignatureHelpRegistry | null;
   private _lastAutocompleteRequest: AutocompleteRequest;
   private _isDeactivating: boolean;
@@ -514,7 +514,7 @@ export default class AutoLanguageClient {
   }
 
   // Linter push v2 API via LS publishDiagnostics
-  public consumeLinterV2(registerIndie: (params: {name: string}) => linter.V2IndieDelegate): void {
+  public consumeLinterV2(registerIndie: (params: {name: string}) => linter.IndieDelegate): void {
     this._linterDelegate = registerIndie({name: this.name});
     if (this._linterDelegate == null) {
       return;

--- a/lib/main.ts
+++ b/lib/main.ts
@@ -1,5 +1,8 @@
-// tslint:disable-next-line:no-reference
+// tslint:disable:no-reference
 /// <reference path="../typings/atom/index.d.ts"/>
+/// <reference path="../typings/atom-ide/index.d.ts"/>
+/// <reference path="../typings/atom-linter/index.d.ts"/>
+// tslint:enable:no-reference
 
 import AutoLanguageClient from './auto-languageclient';
 import Convert from './convert';

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "@types/node": "^8.0.41",
     "fuzzaldrin-plus": "^0.6.0",
     "vscode-jsonrpc": "^3.5.0",
-    "vscode-languageserver-protocol": "^3.6.0-next.1",
+    "vscode-languageserver-protocol": "3.6.0-next.5",
     "vscode-languageserver-types": "^3.6.0-next.1"
   },
   "atomTestRunner": "./build/test/runner",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,17 +9,10 @@
         "inlineSourceMap": true,
         "strictNullChecks": true,
         "noImplicitAny": true,
-        "baseUrl": "./",
-        "paths": {
-            "atom-ide": [
-                "./typings/atom-ide/index.d.ts"
-            ],
-            "atom-linter": [
-                "./typings/atom-linter/index.d.ts"
-            ]
-        }
+        "baseUrl": "./"
     },
     "include": [
+        "typings/**/*.ts",
         "lib/**/*.ts",
         "test/**/*.ts"
     ]

--- a/typings/atom-ide/index.d.ts
+++ b/typings/atom-ide/index.d.ts
@@ -1,266 +1,268 @@
-import { Disposable, Grammar, Point, Range, TextEditor } from 'atom';
+declare module 'atom-ide' {
+  import { Disposable, Grammar, Point, Range, TextEditor } from 'atom';
 
-export interface OutlineProvider {
-  name: string;
-  // If there are multiple providers for a given grammar, the one with the highest priority will be
-  // used.
-  priority: number;
-  grammarScopes: string[];
-  updateOnEdit?: boolean;
-  getOutline: (editor: TextEditor) => Promise<Outline | null>;
-}
+  export interface OutlineProvider {
+    name: string;
+    // If there are multiple providers for a given grammar, the one with the highest priority will be
+    // used.
+    priority: number;
+    grammarScopes: string[];
+    updateOnEdit?: boolean;
+    getOutline: (editor: TextEditor) => Promise<Outline | null>;
+  }
 
-export interface OutlineTree {
-  icon?: string; // from atom$Octicon | atom$OcticonsPrivate (types not allowed over rpc so we use string)
+  export interface OutlineTree {
+    icon?: string; // from atom$Octicon | atom$OcticonsPrivate (types not allowed over rpc so we use string)
 
-  // Must be one or the other. If both are present, tokenizedText is preferred.
-  plainText?: string;
-  tokenizedText?: TokenizedText;
-  representativeName?: string;
+    // Must be one or the other. If both are present, tokenizedText is preferred.
+    plainText?: string;
+    tokenizedText?: TokenizedText;
+    representativeName?: string;
 
-  startPosition: Point;
-  endPosition?: Point;
-  children: OutlineTree[];
-}
+    startPosition: Point;
+    endPosition?: Point;
+    children: OutlineTree[];
+  }
 
-export interface Outline {
-  outlineTrees: OutlineTree[];
-}
+  export interface Outline {
+    outlineTrees: OutlineTree[];
+  }
 
-export type TokenKind =
-  | 'keyword'
-  | 'class-name'
-  | 'constructor'
-  | 'method'
-  | 'param'
-  | 'string'
-  | 'whitespace'
-  | 'plain'
-  | 'type';
+  export type TokenKind =
+    | 'keyword'
+    | 'class-name'
+    | 'constructor'
+    | 'method'
+    | 'param'
+    | 'string'
+    | 'whitespace'
+    | 'plain'
+    | 'type';
 
-export interface TextToken {
-  kind: TokenKind;
-  value: string;
-}
+  export interface TextToken {
+    kind: TokenKind;
+    value: string;
+  }
 
-export type TokenizedText = TextToken[];
+  export type TokenizedText = TextToken[];
 
-export interface DefinitionProvider {
-  name: string;
-  priority: number;
-  grammarScopes: string[];
-  getDefinition: (editor: TextEditor, position: Point) => Promise<DefinitionQueryResult | null>;
-}
+  export interface DefinitionProvider {
+    name: string;
+    priority: number;
+    grammarScopes: string[];
+    getDefinition: (editor: TextEditor, position: Point) => Promise<DefinitionQueryResult | null>;
+  }
 
-export type IdeUri = string;
+  export type IdeUri = string;
 
-export interface Definition {
-  path: IdeUri;
-  position: Point;
-  range?: Range;
-  id?: string;
-  name?: string;
-  language: string;
-  projectRoot?: IdeUri;
-}
+  export interface Definition {
+    path: IdeUri;
+    position: Point;
+    range?: Range;
+    id?: string;
+    name?: string;
+    language: string;
+    projectRoot?: IdeUri;
+  }
 
-export interface DefinitionQueryResult {
-  queryRange: Range[];
-  definitions: Definition[];
-}
+  export interface DefinitionQueryResult {
+    queryRange: Range[];
+    definitions: Definition[];
+  }
 
-export interface FindReferencesProvider {
-  // Return true if your provider supports finding references for the provided TextEditor.
-  isEditorSupported(editor: TextEditor): boolean | Promise<boolean>;
+  export interface FindReferencesProvider {
+    // Return true if your provider supports finding references for the provided TextEditor.
+    isEditorSupported(editor: TextEditor): boolean | Promise<boolean>;
 
-  // `findReferences` will only be called if `isEditorSupported` previously returned true
-  // for the given TextEditor.
-  findReferences(editor: TextEditor, position: Point): Promise<FindReferencesReturn | null>;
-}
+    // `findReferences` will only be called if `isEditorSupported` previously returned true
+    // for the given TextEditor.
+    findReferences(editor: TextEditor, position: Point): Promise<FindReferencesReturn | null>;
+  }
 
-export interface Reference {
-  uri: IdeUri; // URI of the file path
-  name: string | null; // name of calling method/function/symbol
-  range: Range;
-}
+  export interface Reference {
+    uri: IdeUri; // URI of the file path
+    name: string | null; // name of calling method/function/symbol
+    range: Range;
+  }
 
-export interface FindReferencesData {
-  type: 'data';
-  baseUri: IdeUri;
-  referencedSymbolName: string;
-  references: Reference[];
-}
+  export interface FindReferencesData {
+    type: 'data';
+    baseUri: IdeUri;
+    referencedSymbolName: string;
+    references: Reference[];
+  }
 
-export interface FindReferencesError {
-  type: 'error';
-  message: string;
-}
+  export interface FindReferencesError {
+    type: 'error';
+    message: string;
+  }
 
-export type FindReferencesReturn = FindReferencesData | FindReferencesError;
+  export type FindReferencesReturn = FindReferencesData | FindReferencesError;
 
-export type MarkedString =
-  | {
-      type: 'markdown',
-      value: string,
-    }
-  | {
-      type: 'snippet',
-      grammar: Grammar,
-      value: string,
-    };
+  export type MarkedString =
+    | {
+        type: 'markdown',
+        value: string,
+      }
+    | {
+        type: 'snippet',
+        grammar: Grammar,
+        value: string,
+      };
 
-// This omits the React variant.
-export interface Datatip {
-  markedStrings: MarkedString[];
-  range: Range;
-  pinnable?: boolean;
-}
+  // This omits the React variant.
+  export interface Datatip {
+    markedStrings: MarkedString[];
+    range: Range;
+    pinnable?: boolean;
+  }
 
-export interface DatatipProvider {
-  datatip(
-    editor: TextEditor,
-    bufferPosition: Point,
-    // The mouse event that triggered the datatip.
-    // This is null for manually toggled datatips.
-    mouseEvent: MouseEvent | null,
-  ): Promise<Datatip>;
-  validForScope(scopeName: string): boolean;
-  // A unique name for the provider to be used for analytics.
-  // It is recommended that it be the name of the provider's package.
-  providerName: string;
-  priority: number;
-  grammarScopes: string[];
-}
+  export interface DatatipProvider {
+    datatip(
+      editor: TextEditor,
+      bufferPosition: Point,
+      // The mouse event that triggered the datatip.
+      // This is null for manually toggled datatips.
+      mouseEvent: MouseEvent | null,
+    ): Promise<Datatip>;
+    validForScope(scopeName: string): boolean;
+    // A unique name for the provider to be used for analytics.
+    // It is recommended that it be the name of the provider's package.
+    providerName: string;
+    priority: number;
+    grammarScopes: string[];
+  }
 
-export interface DatatipService {
-  addProvider(provider: DatatipProvider): Disposable;
-}
+  export interface DatatipService {
+    addProvider(provider: DatatipProvider): Disposable;
+  }
 
-export interface RangeCodeFormatProvider {
-  formatCode: (editor: TextEditor, range: Range) => Promise<TextEdit[]>;
-  priority: number;
-  grammarScopes: string[];
-}
+  export interface RangeCodeFormatProvider {
+    formatCode: (editor: TextEditor, range: Range) => Promise<TextEdit[]>;
+    priority: number;
+    grammarScopes: string[];
+  }
 
-export interface TextEdit {
-  oldRange: Range;
-  newText: string;
-  // If included, this will be used to verify that the edit still applies cleanly.
-  oldText?: string;
-}
+  export interface TextEdit {
+    oldRange: Range;
+    newText: string;
+    // If included, this will be used to verify that the edit still applies cleanly.
+    oldText?: string;
+  }
 
-export interface CodeHighlightProvider {
-  highlight(editor: TextEditor, bufferPosition: Point): Promise<Range[] | null>;
-  priority: number;
-  grammarScopes: string[];
-}
+  export interface CodeHighlightProvider {
+    highlight(editor: TextEditor, bufferPosition: Point): Promise<Range[] | null>;
+    priority: number;
+    grammarScopes: string[];
+  }
 
-export type DiagnosticType = 'Error' | 'Warning' | 'Info';
+  export type DiagnosticType = 'Error' | 'Warning' | 'Info';
 
-export interface Diagnostic {
-  providerName: string;
-  type: DiagnosticType;
-  filePath: string;
-  text?: string;
-  range: Range;
-}
+  export interface Diagnostic {
+    providerName: string;
+    type: DiagnosticType;
+    filePath: string;
+    text?: string;
+    range: Range;
+  }
 
-export interface CodeAction {
-  apply(): Promise<void>;
-  getTitle(): Promise<string>;
-  dispose(): void;
-}
+  export interface CodeAction {
+    apply(): Promise<void>;
+    getTitle(): Promise<string>;
+    dispose(): void;
+  }
 
-export interface CodeActionProvider {
-  grammarScopes: string[];
-  priority: number;
-  getCodeActions(
-    editor: TextEditor,
-    range: Range,
-    diagnostics: Diagnostic[],
-  ): Promise<CodeAction[] | null>;
-}
+  export interface CodeActionProvider {
+    grammarScopes: string[];
+    priority: number;
+    getCodeActions(
+      editor: TextEditor,
+      range: Range,
+      diagnostics: Diagnostic[],
+    ): Promise<CodeAction[] | null>;
+  }
 
-export interface BusySignalOptions {
-  // Can say that a busy signal will only appear when a given file is open.
-  // Default = null, meaning the busy signal applies to all files.
-  onlyForFile?: IdeUri;
-  // Is user waiting for computer to finish a task? (traditional busy spinner)
-  // or is the computer waiting for user to finish a task? (action required)
-  // Default = spinner.
-  waitingFor?: 'computer' | 'user';
-  // Debounce it? default = true for busy-signal, and false for action-required.
-  debounce?: boolean;
-  // If onClick is set, then the tooltip will be clickable. Default = null.
-  onDidClick?: () => void;
-}
+  export interface BusySignalOptions {
+    // Can say that a busy signal will only appear when a given file is open.
+    // Default = null, meaning the busy signal applies to all files.
+    onlyForFile?: IdeUri;
+    // Is user waiting for computer to finish a task? (traditional busy spinner)
+    // or is the computer waiting for user to finish a task? (action required)
+    // Default = spinner.
+    waitingFor?: 'computer' | 'user';
+    // Debounce it? default = true for busy-signal, and false for action-required.
+    debounce?: boolean;
+    // If onClick is set, then the tooltip will be clickable. Default = null.
+    onDidClick?: () => void;
+  }
 
-export interface BusySignalService {
-  // Activates the busy signal with the given title and returns the promise
-  // from the provided callback.
-  // The busy signal automatically deactivates when the returned promise
-  // either resolves or rejects.
-  reportBusyWhile<T>(
-    title: string,
-    f: () => Promise<T>,
-    options?: BusySignalOptions,
-  ): Promise<T>;
+  export interface BusySignalService {
+    // Activates the busy signal with the given title and returns the promise
+    // from the provided callback.
+    // The busy signal automatically deactivates when the returned promise
+    // either resolves or rejects.
+    reportBusyWhile<T>(
+      title: string,
+      f: () => Promise<T>,
+      options?: BusySignalOptions,
+    ): Promise<T>;
 
-  // Activates the busy signal. Set the title in the returned BusySignal
-  // object (you can update the title multiple times) and dispose it when done.
-  reportBusy(title: string, options?: BusySignalOptions): BusyMessage;
+    // Activates the busy signal. Set the title in the returned BusySignal
+    // object (you can update the title multiple times) and dispose it when done.
+    reportBusy(title: string, options?: BusySignalOptions): BusyMessage;
 
-  // This is a no-op. When someone consumes the busy service, they get back a
-  // reference to the single shared instance, so disposing of it would be wrong.
-  dispose(): void;
-}
+    // This is a no-op. When someone consumes the busy service, they get back a
+    // reference to the single shared instance, so disposing of it would be wrong.
+    dispose(): void;
+  }
 
-export interface BusyMessage {
-  // You can set/update the title.
-  setTitle(title: string): void;
-  // Dispose of the signal when done to make it go away.
-  dispose(): void;
-}
+  export interface BusyMessage {
+    // You can set/update the title.
+    setTitle(title: string): void;
+    // Dispose of the signal when done to make it go away.
+    dispose(): void;
+  }
 
-export type SignatureHelpRegistry = (provider: SignatureHelpProvider) => Disposable;
+  export type SignatureHelpRegistry = (provider: SignatureHelpProvider) => Disposable;
 
-/**
- * Signature help is activated when:
- * - upon keystroke, any provider with a matching grammar scope contains
- *   the pressed key inside its triggerCharacters set
- * - the signature-help:show command is manually activated
- *
- * Once signature help has been triggered, the provider will be queried immediately
- * with the current cursor position, and then repeatedly upon cursor movements
- * until a null/empty signature is returned.
- *
- * Returned signatures will be displayed in a small datatip at the current cursor.
- * The highest-priority provider with a non-null result will be used.
- */
-export interface SignatureHelpProvider {
-  priority: number;
-  grammarScopes: string[];
+  /**
+   * Signature help is activated when:
+   * - upon keystroke, any provider with a matching grammar scope contains
+   *   the pressed key inside its triggerCharacters set
+   * - the signature-help:show command is manually activated
+   *
+   * Once signature help has been triggered, the provider will be queried immediately
+   * with the current cursor position, and then repeatedly upon cursor movements
+   * until a null/empty signature is returned.
+   *
+   * Returned signatures will be displayed in a small datatip at the current cursor.
+   * The highest-priority provider with a non-null result will be used.
+   */
+  export interface SignatureHelpProvider {
+    priority: number;
+    grammarScopes: string[];
 
-  // A set of characters that will trigger signature help when typed.
-  // If a null/empty set is provided, only manual activation of the command works.
-  triggerCharacters?: Set<string>;
+    // A set of characters that will trigger signature help when typed.
+    // If a null/empty set is provided, only manual activation of the command works.
+    triggerCharacters?: Set<string>;
 
-  getSignatureHelp(editor: TextEditor, point: Point): Promise<SignatureHelp | null>;
-}
+    getSignatureHelp(editor: TextEditor, point: Point): Promise<SignatureHelp | null>;
+  }
 
-export interface SignatureHelp {
-  signatures: Signature[];
-  activeSignature?: number;
-  activeParameter?: number;
-}
+  export interface SignatureHelp {
+    signatures: Signature[];
+    activeSignature?: number;
+    activeParameter?: number;
+  }
 
-export interface Signature {
-  label: string;
-  documentation?: string;
-  parameters?: SignatureParameter[];
-}
+  export interface Signature {
+    label: string;
+    documentation?: string;
+    parameters?: SignatureParameter[];
+  }
 
-export interface SignatureParameter {
-  label: string;
-  documentation?: string;
+  export interface SignatureParameter {
+    label: string;
+    documentation?: string;
+  }
 }

--- a/typings/atom-linter/index.d.ts
+++ b/typings/atom-linter/index.d.ts
@@ -1,113 +1,115 @@
-import { Disposable, Grammar, Point, Range, TextEditor } from 'atom';
+declare module "atom-linter" {
+  import { Disposable, Grammar, Point, Range, TextEditor } from 'atom';
 
-export interface StandardLinter {
-  name: string;
-  scope: 'file' | 'project';
-  lintOnFly: boolean;
-  grammarScopes: string[];
-  lint(textEditor: TextEditor): Message[] | Promise<Message[] | null> | null;
-}
+  export interface StandardLinter {
+    name: string;
+    scope: 'file' | 'project';
+    lintOnFly: boolean;
+    grammarScopes: string[];
+    lint(textEditor: TextEditor): Message[] | Promise<Message[] | null> | null;
+  }
 
-export interface Message {
-  type: string;
-  text?: string;
-  html?: string;
-  name?: string;
-  // ^ Only specify this if you want the name to be something other than your linterProvider.name
-  // WARNING: There is NO replacement for this in v2
-  filePath?: string;
-  // ^ MUST be an absolute path (relative paths are not supported)
-  range?: Range;
-  trace?: Trace[];
-  fix?: Fix;
-  severity?: 'error' | 'warning' | 'info';
-  selected?: () => void;
-  // ^ WARNING: There is NO replacement for this in v2
-}
-
-export interface Trace {
-  type: 'Trace';
-  text?: string;
-  html?: string;
-  name?: string;
-  // ^ Only specify this if you want the name to be something other than your linterProvider.name
-  // WARNING: There is NO replacement for this in v2
-  filePath?: string;
-  // ^ MUST be an absolute path (relative paths are not supported)
-  range?: Range;
-  class?: string;
-  severity?: 'error' | 'warning' | 'info';
-}
-
-export interface Fix {
-  range: Range;
-  newText: string;
-  oldText?: string;
-}
-
-export interface Config {
-  name: string;
-}
-
-export interface IndieRegistry {
-  register(config: Config): Indie;
-}
-
-export interface Indie {
-  deleteMessages(): void;
-  setMessages(messages: Message[]): void;
-  dispose(): void;
-}
-
-export interface V2IndieDelegate {
-  name(): string;
-  getMessages(): Message[];
-  clearMessages(): void;
-  setMessages(filePath: string, messages: V2Message[]): void;
-  setAllMessages(messages: V2Message[]): void;
-  onDidUpdate(callback: () => void): Disposable;
-  onDidDestroy(callback: () => void): Disposable;
-  dispose(): void;
-}
-
-interface V2Message {
-  // NOTE: These are given by providers
-  location: {
-    file: string,
+  export interface Message {
+    type: string;
+    text?: string;
+    html?: string;
+    name?: string;
+    // ^ Only specify this if you want the name to be something other than your linterProvider.name
+    // WARNING: There is NO replacement for this in v2
+    filePath?: string;
     // ^ MUST be an absolute path (relative paths are not supported)
-    position: Range,
-  };
-  // ^ Location of the issue (aka where to highlight)
-  reference?: {
-    file: string,
+    range?: Range;
+    trace?: Trace[];
+    fix?: Fix;
+    severity?: 'error' | 'warning' | 'info';
+    selected?: () => void;
+    // ^ WARNING: There is NO replacement for this in v2
+  }
+
+  export interface Trace {
+    type: 'Trace';
+    text?: string;
+    html?: string;
+    name?: string;
+    // ^ Only specify this if you want the name to be something other than your linterProvider.name
+    // WARNING: There is NO replacement for this in v2
+    filePath?: string;
     // ^ MUST be an absolute path (relative paths are not supported)
-    position?: Point,
-  };
-  // ^ Reference to a different location in the editor, useful for jumping to classes etc.
-  url?: string; // external HTTP link
-  // ^ HTTP link to a resource explaining the issue. Default is a google search
-  icon?: string;
-  // ^ Name of octicon to show in gutter
-  excerpt: string;
-  // ^ Error message
-  severity: 'error' | 'warning' | 'info';
-  // ^ Severity of error
-  solutions?: Array<{
-    title?: string,
-    position: Range,
-    priority?: number,
-    currentText?: string,
-    replaceWith: string,
-  } | {
-    title?: string,
-    position: Range,
-    priority?: number,
-    apply: (() => any),
-  }>;
-  // ^ Possible solutions to the error (user can invoke them at will)
-  description?: string | (() => Promise<string> | string);
-  // ^ Markdown long description of the error, accepts callback so you can do
-  // http requests etc.
-  linterName?: string;
-  // ^ Optionally override the displayed linter name. (Defaults to provider)
+    range?: Range;
+    class?: string;
+    severity?: 'error' | 'warning' | 'info';
+  }
+
+  export interface Fix {
+    range: Range;
+    newText: string;
+    oldText?: string;
+  }
+
+  export interface Config {
+    name: string;
+  }
+
+  export interface IndieRegistry {
+    register(config: Config): Indie;
+  }
+
+  export interface Indie {
+    deleteMessages(): void;
+    setMessages(messages: Message[]): void;
+    dispose(): void;
+  }
+
+  export interface V2IndieDelegate {
+    name(): string;
+    getMessages(): Message[];
+    clearMessages(): void;
+    setMessages(filePath: string, messages: V2Message[]): void;
+    setAllMessages(messages: V2Message[]): void;
+    onDidUpdate(callback: () => void): Disposable;
+    onDidDestroy(callback: () => void): Disposable;
+    dispose(): void;
+  }
+
+  interface V2Message {
+    // NOTE: These are given by providers
+    location: {
+      file: string,
+      // ^ MUST be an absolute path (relative paths are not supported)
+      position: Range,
+    };
+    // ^ Location of the issue (aka where to highlight)
+    reference?: {
+      file: string,
+      // ^ MUST be an absolute path (relative paths are not supported)
+      position?: Point,
+    };
+    // ^ Reference to a different location in the editor, useful for jumping to classes etc.
+    url?: string; // external HTTP link
+    // ^ HTTP link to a resource explaining the issue. Default is a google search
+    icon?: string;
+    // ^ Name of octicon to show in gutter
+    excerpt: string;
+    // ^ Error message
+    severity: 'error' | 'warning' | 'info';
+    // ^ Severity of error
+    solutions?: Array<{
+      title?: string,
+      position: Range,
+      priority?: number,
+      currentText?: string,
+      replaceWith: string,
+    } | {
+      title?: string,
+      position: Range,
+      priority?: number,
+      apply: (() => any),
+    }>;
+    // ^ Possible solutions to the error (user can invoke them at will)
+    description?: string | (() => Promise<string> | string);
+    // ^ Markdown long description of the error, accepts callback so you can do
+    // http requests etc.
+    linterName?: string;
+    // ^ Optionally override the displayed linter name. (Defaults to provider)
+  }
 }


### PR DESCRIPTION
I am trying to use the types exported by this package a bit early, as I want to rewrite a package of mine using them once they're published to NPM. I've run into an issue regarding the export of the two modules within the `typings` directory.

These modules aren't accessible to the definitions within `build/lib` once installed, as the `tsconfig.json` file isn't used by those importing. The easiest way I know to solve this is to just reference them with the main source file of the library and use the typical module syntax for the modules themselves, which I've done with this pull request. This doesn't force users to use the reference imports themselves or have the path values in their `tsconfig.json` file.