### PR TITLE
 Enable noImplicitAny within the tsconfig.

### DIFF
--- a/lib/adapters/autocomplete-adapter.ts
+++ b/lib/adapters/autocomplete-adapter.ts
@@ -56,7 +56,8 @@ export default class AutocompleteAdapter {
   public async getSuggestions(
     server: ActiveServer,
     request: AutocompleteRequest,
-    onDidConvertCompletionItem?: (CompletionItem, AutocompleteSuggestion, AutocompleteRequest) => void,
+    onDidConvertCompletionItem?: (item: CompletionItem, suggestion: AutocompleteSuggestion,
+                                  request: AutocompleteRequest) => void,
   ): Promise<AutocompleteSuggestion[]> {
     const triggerChars =
       server.capabilities.completionProvider != null ?
@@ -102,7 +103,8 @@ export default class AutocompleteAdapter {
     server: ActiveServer,
     suggestion: AutocompleteSuggestion,
     request: AutocompleteRequest,
-    onDidConvertCompletionItem?: (CompletionItem, AutocompleteSuggestion, AutocompleteRequest) => void,
+    onDidConvertCompletionItem?: (item: CompletionItem, suggestion: AutocompleteSuggestion,
+                                  request: AutocompleteRequest) => void,
   ): Promise<AutocompleteSuggestion> {
     const cache = this._suggestionCache.get(server);
     if (cache) {
@@ -203,7 +205,8 @@ export default class AutocompleteAdapter {
   public completionItemsToSuggestions(
     completionItems: CompletionItem[] | CompletionList,
     request: AutocompleteRequest,
-    onDidConvertCompletionItem?: (CompletionItem, AutocompleteSuggestion, AutocompleteRequest) => void,
+    onDidConvertCompletionItem?: (item: CompletionItem, suggestion: AutocompleteSuggestion,
+                                  request: AutocompleteRequest) => void,
   ): Map<AutocompleteSuggestion, [CompletionItem, boolean]> {
     return new Map((Array.isArray(completionItems) ? completionItems : completionItems.items || [])
       .sort((a, b) => (a.sortText || a.label).localeCompare(b.sortText || b.label))
@@ -226,7 +229,8 @@ export default class AutocompleteAdapter {
     item: CompletionItem,
     suggestion: AutocompleteSuggestion,
     request: AutocompleteRequest,
-    onDidConvertCompletionItem?: (CompletionItem, AutocompleteSuggestion, AutocompleteRequest) => void,
+    onDidConvertCompletionItem?: (item: CompletionItem, suggestion: AutocompleteSuggestion,
+                                  request: AutocompleteRequest) => void,
   ): AutocompleteSuggestion {
     AutocompleteAdapter.applyCompletionItemToSuggestion(item, suggestion);
     AutocompleteAdapter.applyTextEditToSuggestion(item.textEdit, request.editor, suggestion);

--- a/lib/auto-languageclient.ts
+++ b/lib/auto-languageclient.ts
@@ -99,7 +99,7 @@ export default class AutoLanguageClient {
   }
 
   // Return the parameters used to initialize a client - you may want to extend capabilities
-  protected getInitializeParams(projectPath: string, process: cp.ChildProcess): ls.InitializeParams {
+  protected getInitializeParams(projectPath: string, process: LanguageServerProcess): ls.InitializeParams {
     return {
       processId: process.pid,
       rootPath: projectPath,
@@ -324,7 +324,7 @@ export default class AutoLanguageClient {
     return newServer;
   }
 
-  private captureServerErrors(childProcess: cp.ChildProcess, projectPath: string): void {
+  private captureServerErrors(childProcess: LanguageServerProcess, projectPath: string): void {
     childProcess.on('error', (err) => this.handleSpawnFailure(err));
     childProcess.on('exit', (code, signal) => this.logger.debug(`exit: code ${code} signal ${signal}`));
     childProcess.stderr.setEncoding('utf8');
@@ -350,14 +350,14 @@ export default class AutoLanguageClient {
   }
 
   // Creates the RPC connection which can be ipc, socket or stdio
-  private createRpcConnection(process: cp.ChildProcess): rpc.MessageConnection {
+  private createRpcConnection(process: LanguageServerProcess): rpc.MessageConnection {
     let reader: rpc.MessageReader;
     let writer: rpc.MessageWriter;
     const connectionType = this.getConnectionType();
     switch (connectionType) {
       case 'ipc':
-        reader = new rpc.IPCMessageReader(process);
-        writer = new rpc.IPCMessageWriter(process);
+        reader = new rpc.IPCMessageReader(process as cp.ChildProcess);
+        writer = new rpc.IPCMessageWriter(process as cp.ChildProcess);
         break;
       case 'socket':
         reader = new rpc.SocketMessageReader(this.socket);

--- a/lib/convert.ts
+++ b/lib/convert.ts
@@ -132,7 +132,7 @@ export default class Convert {
   // Returns a string that is HTML attribute encoded by replacing &, <, >, " and ' with their HTML entity
   // named equivalents.
   public static encodeHTMLAttribute(s: string): string {
-    const attributeMap = {
+    const attributeMap: { [key: string]: string } = {
       '&': '&amp;',
       '<': '&lt;',
       '>': '&gt;',

--- a/lib/languageclient.ts
+++ b/lib/languageclient.ts
@@ -36,7 +36,7 @@ export class LanguageClientConnection extends EventEmitter {
         this._log.warn('rpc.onUnhandledNotification', notification);
       }
     });
-    this._rpc.onNotification((...args) => this._log.debug('rpc.onNotification', args));
+    this._rpc.onNotification((...args: any[]) => this._log.debug('rpc.onNotification', args));
   }
 
   public dispose(): void {
@@ -74,7 +74,7 @@ export class LanguageClientConnection extends EventEmitter {
   // * `method`   A string containing the name of the message to listen for.
   // * `callback` The function to be called when the message is received.
   //              The payload from the message is passed to the function.
-  public onCustom(method: string, callback: (Object) => void): void {
+  public onCustom(method: string, callback: (obj: object) => void): void {
     this._onNotification({method}, callback);
   }
 
@@ -82,7 +82,7 @@ export class LanguageClientConnection extends EventEmitter {
   //
   // * `callback` The function to be called when the `window/showMessage` message is
   //              received with {ShowMessageParams} being passed.
-  public onShowMessage(callback: (ShowMessageParams) => void): void {
+  public onShowMessage(callback: (params: lsp.ShowMessageParams) => void): void {
     this._onNotification({method: 'window/showMessage'}, callback);
   }
 
@@ -91,7 +91,8 @@ export class LanguageClientConnection extends EventEmitter {
   // * `callback` The function to be called when the `window/showMessageRequest` message is
   //              received with {ShowMessageRequestParam}' being passed.
   // Returns a {Promise} containing the {MessageActionItem}.
-  public onShowMessageRequest(callback: (ShowMessageRequestParams) => Promise<lsp.MessageActionItem | null>): void {
+  public onShowMessageRequest(callback: (params: lsp.ShowMessageRequestParams)
+  => Promise<lsp.MessageActionItem | null>): void {
     this._onRequest({method: 'window/showMessageRequest'}, callback);
   }
 
@@ -99,7 +100,7 @@ export class LanguageClientConnection extends EventEmitter {
   //
   // * `callback` The function to be called when the `window/logMessage` message is
   //              received with {LogMessageParams} being passed.
-  public onLogMessage(callback: (LogMessageParams) => void): void {
+  public onLogMessage(callback: (params: lsp.LogMessageParams) => void): void {
     this._onNotification({method: 'window/logMessage'}, callback);
   }
 
@@ -107,7 +108,7 @@ export class LanguageClientConnection extends EventEmitter {
   //
   // * `callback` The function to be called when the `telemetry/event` message is
   //              received with any parameters received being passed on.
-  public onTelemetryEvent(callback: (any) => void): void {
+  public onTelemetryEvent(callback: (...args: any[]) => void): void {
     this._onNotification({method: 'telemetry/event'}, callback);
   }
 
@@ -116,7 +117,8 @@ export class LanguageClientConnection extends EventEmitter {
   // * `callback` The function to be called when the `workspace/applyEdit` message is
   //              received with {ApplyWorkspaceEditParams} being passed.
   // Returns a {Promise} containing the {ApplyWorkspaceEditResponse}.
-  public onApplyEdit(callback: (ApplyWorkspaceEditParams) => Promise<lsp.ApplyWorkspaceEditResponse>): void {
+  public onApplyEdit(callback: (params: lsp.ApplyWorkspaceEditParams) =>
+  Promise<lsp.ApplyWorkspaceEditResponse>): void {
     this._onRequest({method: 'workspace/applyEdit'}, callback);
   }
 
@@ -130,7 +132,7 @@ export class LanguageClientConnection extends EventEmitter {
   // Public: Send a `textDocument/didOpen` notification.
   //
   // * `params` The {DidOpenTextDocumentParams} containing the opened text document details.
-  public didOpenTextDocument(params: lsp .DidOpenTextDocumentParams): void {
+  public didOpenTextDocument(params: lsp.DidOpenTextDocumentParams): void {
     this._sendNotification('textDocument/didOpen', params);
   }
 
@@ -176,7 +178,7 @@ export class LanguageClientConnection extends EventEmitter {
   //
   // * `callback` The function to be called when the `textDocument/publishDiagnostics` message is
   //              received a {PublishDiagnosticsParams} containing new {Diagnostic} messages for a given uri.
-  public onPublishDiagnostics(callback: (PublishDiagnosticsParams) => void): void {
+  public onPublishDiagnostics(callback: (params: lsp.PublishDiagnosticsParams) => void): void {
     this._onNotification({method: 'textDocument/publishDiagnostics'}, callback);
   }
 
@@ -363,14 +365,14 @@ export class LanguageClientConnection extends EventEmitter {
     return this._sendRequest('workspace/executeCommand', params);
   }
 
-  private _onRequest(type: {method: string}, callback: (Object) => Promise<any>): void {
+  private _onRequest(type: {method: string}, callback: (obj: object) => Promise<any>): void {
     this._rpc.onRequest(type.method, (value) => {
       this._log.debug(`rpc.onRequest ${type.method}`, value);
       return callback(value);
     });
   }
 
-  private _onNotification(type: {method: string}, callback: (Object) => void): void {
+  private _onNotification(type: {method: string}, callback: (obj: object) => void): void {
     this._rpc.onNotification(type.method, (value) => {
       this._log.debug(`rpc.onNotification ${type.method}`, value);
       callback(value);

--- a/lib/logger.ts
+++ b/lib/logger.ts
@@ -36,7 +36,7 @@ export class ConsoleLogger {
   }
 
   public format(args_: any): any {
-    const args = args_.filter((a) => a != null);
+    const args = args_.filter((a: any) => a != null);
     if (typeof args[0] === 'string') {
       if (args.length === 1) {
         return [`${this.prefix} ${args[0]}`];

--- a/lib/server-manager.ts
+++ b/lib/server-manager.ts
@@ -16,13 +16,15 @@ import { CompositeDisposable, ProjectFileEvent, TextEditor } from 'atom';
 // ChildProcess.  This is used so that language packages with alternative
 // language server process hosting strategies can return something compatible
 // with AutoLanguageClient.startServerProcess.
-export interface LanguageServerProcess extends cp.ChildProcess {
+export interface LanguageServerProcess extends EventEmitter {
   stdin: stream.Writable;
   stdout: stream.Readable;
   stderr: stream.Readable;
   pid: number;
 
   kill(signal?: string): void;
+  on(event: 'error', listener: (err: Error) => void): this;
+  on(event: 'exit', listener: (code: number, signal: string) => void): this;
 }
 
 // The necessary elements for a server that has started or is starting.

--- a/lib/server-manager.ts
+++ b/lib/server-manager.ts
@@ -16,15 +16,13 @@ import { CompositeDisposable, ProjectFileEvent, TextEditor } from 'atom';
 // ChildProcess.  This is used so that language packages with alternative
 // language server process hosting strategies can return something compatible
 // with AutoLanguageClient.startServerProcess.
-export interface LanguageServerProcess extends EventEmitter {
+export interface LanguageServerProcess extends cp.ChildProcess {
   stdin: stream.Writable;
   stdout: stream.Readable;
   stderr: stream.Readable;
   pid: number;
 
   kill(signal?: string): void;
-  on(event: 'error', listener: (err: Error) => void): this;
-  on(event: 'exit', listener: (code: number, signal: string) => void): this;
 }
 
 // The necessary elements for a server that has started or is starting.

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -1,4 +1,4 @@
-import { Point, TextBuffer, TextEditor, Range } from 'atom';
+import { Point, TextBuffer, TextEditor, Range, BufferScanResult } from 'atom';
 import { CancellationToken, CancellationTokenSource } from 'vscode-jsonrpc';
 
 export default class Utils {
@@ -28,7 +28,7 @@ export default class Utils {
   private static _getRegexpRangeAtPosition(buffer: TextBuffer, position: Point, wordRegex: RegExp): Range | null {
     const {row, column} = position;
     const rowRange = buffer.rangeForRow(row, false);
-    let matchData;
+    let matchData: BufferScanResult | undefined | null;
     // Extract the expression from the row text.
     buffer.scanInRange(wordRegex, rowRange, (data) => {
       const {range} = data;
@@ -71,11 +71,15 @@ export default class Utils {
   public static async doWithCancellationToken<T1 extends object, T2>(
     key: T1,
     cancellationTokens: WeakMap<T1, CancellationTokenSource>,
-    work: (CancellationToken) => Promise<T2>,
+    work: (token: CancellationToken) => Promise<T2>,
   ): Promise<T2> {
     const token = Utils.cancelAndRefreshCancellationToken(key, cancellationTokens);
     const result: T2 = await work(token);
     cancellationTokens.delete(key);
     return result;
+  }
+
+  public static assertUnreachable(_: never): never {
+    return _;
   }
 }

--- a/package.json
+++ b/package.json
@@ -24,14 +24,17 @@
   },
   "atomTestRunner": "./build/test/runner",
   "devDependencies": {
+    "@types/atom-mocha-test-runner": "^1.0.2",
+    "@types/chai": "^4.1.2",
+    "@types/fuzzaldrin-plus": "0.0.1",
     "@types/mocha": "^2.2.48",
     "@types/sinon": "^4.1.3",
-    "tslint": "^5.9.1",
     "atom-mocha-test-runner": "^1.2.0",
     "chai": "^3.5.0",
     "mocha": "^3.2.0",
     "mocha-appveyor-reporter": "^0.4.0",
     "sinon": "^2.0.0",
+    "tslint": "^5.9.1",
     "typescript": "^2.6.1"
   }
 }

--- a/test/adapters/code-format-adapter.test.ts
+++ b/test/adapters/code-format-adapter.test.ts
@@ -7,9 +7,9 @@ import CodeFormatAdapter from '../../lib/adapters/code-format-adapter';
 import { createSpyConnection, createFakeEditor } from '../helpers.js';
 
 describe('CodeFormatAdapter', () => {
-  let fakeEditor;
-  let connection;
-  let range;
+  let fakeEditor: any;
+  let connection: any;
+  let range: any;
 
   beforeEach(() => {
     connection = new ls.LanguageClientConnection(createSpyConnection());

--- a/test/adapters/code-highlight-adapter.test.ts
+++ b/test/adapters/code-highlight-adapter.test.ts
@@ -7,8 +7,8 @@ import CodeHighlightAdapter from '../../lib/adapters/code-highlight-adapter';
 import { createSpyConnection, createFakeEditor } from '../helpers.js';
 
 describe('CodeHighlightAdapter', () => {
-  let fakeEditor;
-  let connection;
+  let fakeEditor: any;
+  let connection: any;
 
   beforeEach(() => {
     connection = new ls.LanguageClientConnection(createSpyConnection());

--- a/test/adapters/custom-linter-push-v2-adapter.test.ts
+++ b/test/adapters/custom-linter-push-v2-adapter.test.ts
@@ -7,7 +7,7 @@ const messageUrl = 'dummy';
 const messageSolutions: any[] = ['dummy'];
 
 class CustomLinterPushV2Adapter extends LinterPushV2Adapter {
-  public diagnosticToV2Message(path, diagnostic) {
+  public diagnosticToV2Message(path: string, diagnostic: ls.Diagnostic) {
     const message = super.diagnosticToV2Message(path, diagnostic);
     message.url = messageUrl;
     message.solutions = messageSolutions;

--- a/test/adapters/datatip-adapter.test.ts
+++ b/test/adapters/datatip-adapter.test.ts
@@ -7,8 +7,8 @@ import DatatipAdapter from '../../lib/adapters/datatip-adapter';
 import { createSpyConnection, createFakeEditor } from '../helpers.js';
 
 describe('DatatipAdapter', () => {
-  let fakeEditor;
-  let connection;
+  let fakeEditor: any;
+  let connection: any;
 
   beforeEach(() => {
     (global as any).sinon = sinon.sandbox.create();

--- a/test/adapters/document-sync-adapter.test.ts
+++ b/test/adapters/document-sync-adapter.test.ts
@@ -1,5 +1,5 @@
 import { expect } from 'chai';
-import { TextDocumentSyncKind } from '../../lib/languageclient';
+import { TextDocumentSyncKind, TextDocumentSyncOptions } from '../../lib/languageclient';
 import DocumentSyncAdapter from '../../lib/adapters/document-sync-adapter';
 
 describe('DocumentSyncAdapter', () => {
@@ -48,7 +48,7 @@ describe('DocumentSyncAdapter', () => {
   });
 
   describe('constructor', () => {
-    function create(textDocumentSync) {
+    function create(textDocumentSync: TextDocumentSyncKind | TextDocumentSyncOptions) {
       return new DocumentSyncAdapter(null as any, textDocumentSync, () => false);
     }
 

--- a/test/adapters/outline-view-adapter.test.ts
+++ b/test/adapters/outline-view-adapter.test.ts
@@ -4,7 +4,7 @@ import * as sinon from 'sinon';
 import { expect } from 'chai';
 
 describe('OutlineViewAdapter', () => {
-  const createLocation = (a, b, c, d) => ({
+  const createLocation = (a: any, b: any, c: any, d: any) => ({
     uri: '',
     range: {start: {line: a, character: b}, end: {line: c, character: d}},
   });

--- a/test/auto-languageclient.test.ts
+++ b/test/auto-languageclient.test.ts
@@ -11,7 +11,7 @@ describe('AutoLanguageClient', () => {
 
     const client = new CustomAutoLanguageClient();
 
-    function mockEditor(uri, scopeName): any {
+    function mockEditor(uri: string, scopeName: string): any {
       return {
         getURI: () => uri,
         getGrammar: () => {

--- a/test/convert.test.ts
+++ b/test/convert.test.ts
@@ -3,8 +3,8 @@ import Convert from '../lib/convert';
 import { Point, ProjectFileEvent, Range, TextEditor } from 'atom';
 import { expect } from 'chai';
 
-let originalPlatform;
-const setProcessPlatform = (platform) => {
+let originalPlatform: NodeJS.Platform;
+const setProcessPlatform = (platform: any) => {
   Object.defineProperty(process, 'platform', {value: platform});
 };
 

--- a/test/languageclient.test.ts
+++ b/test/languageclient.test.ts
@@ -32,7 +32,7 @@ describe('LanguageClientConnection', () => {
       textDocument: {uri: 'file:///1/z80.asm'},
       position: {line: 24, character: 32},
     };
-    let lc;
+    let lc: any;
 
     beforeEach(() => {
       lc = new ls.LanguageClientConnection(createSpyConnection(), new NullLogger());
@@ -264,7 +264,7 @@ describe('LanguageClientConnection', () => {
       version: 1,
     };
 
-    let lc;
+    let lc: any;
 
     beforeEach(() => {
       lc = new ls.LanguageClientConnection(createSpyConnection(), new NullLogger());
@@ -355,8 +355,8 @@ describe('LanguageClientConnection', () => {
   });
 
   describe('notification methods', () => {
-    let lc;
-    const eventMap = {};
+    let lc: any;
+    const eventMap: { [key: string]: any } = {};
 
     beforeEach(() => {
       lc = new ls.LanguageClientConnection(createSpyConnection(), new NullLogger());

--- a/test/runner.ts
+++ b/test/runner.ts
@@ -1,3 +1,4 @@
+import { TestRunnerParams } from "atom";
 import { createRunner } from 'atom-mocha-test-runner';
 
 const testRunner = createRunner(
@@ -13,7 +14,7 @@ const testRunner = createRunner(
   },
 );
 
-export = function runnerWrapper(options) {
+export = function runnerWrapper(options: TestRunnerParams) {
   // Replace the test path with the current path since Atom's internal runner
   // picks the wrong one by default
   options.testPaths = [__dirname];

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -6,7 +6,7 @@ import { expect } from 'chai';
 
 describe('Utils', () => {
   describe('getWordAtPosition', () => {
-    let editor;
+    let editor: any;
     beforeEach(() => {
       editor = createFakeEditor('test.txt');
       editor.setText('blah test1234 test-two');

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,6 +8,7 @@
         "inlineSources": true,
         "inlineSourceMap": true,
         "strictNullChecks": true,
+        "noImplicitAny": true,
         "baseUrl": "./",
         "paths": {
             "atom-ide": [

--- a/typings/atom/index.d.ts
+++ b/typings/atom/index.d.ts
@@ -4,7 +4,7 @@ declare module 'atom' {
   interface TextEditor {
     getURI(): string | null;
     getBuffer(): TextBuffer;
-    getNonWordCharacters(scope: ScopeDescriptor);
+    getNonWordCharacters(scope: ScopeDescriptor): string;
   }
 
   export interface ProjectFileEvent {


### PR DESCRIPTION
Aside from #180, there were also a lot of `noImplicitAny` errors within the definitions, primarily due to mislabeled parameters. I've enabled the rule within the `tsconfig.json` file and fixed the resulting errors within this pull request.