### PR TITLE
Autocomplete improvements

### DIFF
--- a/lib/adapters/autocomplete-adapter.ts
+++ b/lib/adapters/autocomplete-adapter.ts
@@ -68,9 +68,9 @@ export default class AutocompleteAdapter {
     const triggerColumn = request.bufferPosition.column - prefixWithTrigger.length;
     const triggerPoint = new Point(request.bufferPosition.row, triggerColumn);
 
-    // We auto-trigger on a trigger character or after the minimum number of characters from autocomplete-plus
+    // Only auto-trigger on a trigger character or after the minimum number of characters from autocomplete-plus
     const minimumWordLength = atom.config.get('autocomplete-plus.minimumWordLength') || 0;
-    if (triggerChar === '' && minimumWordLength > 0 && request.prefix.length < minimumWordLength) {
+    if (!request.activatedManually && triggerChar === '' && minimumWordLength > 0 && request.prefix.length < minimumWordLength) {
       return [];
     }
 

--- a/lib/adapters/autocomplete-adapter.ts
+++ b/lib/adapters/autocomplete-adapter.ts
@@ -68,6 +68,12 @@ export default class AutocompleteAdapter {
     const triggerPoint = new Point(request.bufferPosition.row, triggerColumn);
     const prefixWithTrigger = triggerChar + request.prefix;
 
+    // We auto-trigger on a trigger character or after the minimum number of characters from autocomplete-plus
+    const minimumWordLength = atom.config.get('autocomplete-plus.minimumWordLength') || 0;
+    if (triggerChar === '' && minimumWordLength > 0 && request.prefix.length < minimumWordLength) {
+      return [];
+    }
+
     const cache = this._suggestionCache.get(server);
 
     // Do we have complete cached suggestions that are still valid for this request

--- a/lib/adapters/autocomplete-adapter.ts
+++ b/lib/adapters/autocomplete-adapter.ts
@@ -97,10 +97,10 @@ export default class AutocompleteAdapter {
       this._suggestionCache.set(server, {isIncomplete, triggerChar, triggerPoint, suggestionMap});
     }
 
-    // Always filter the results to recalculate the score and ordering
+    // Filter the results to recalculate the score and ordering (unless only triggerChar)
     const suggestions = Array.from(suggestionMap.keys());
     AutocompleteAdapter.setReplacementPrefixOnSuggestions(suggestions, request.prefix);
-    return filter(suggestions, request.prefix, {key: 'text'});
+    return request.prefix === triggerChar ? suggestions : filter(suggestions, request.prefix, {key: 'text'});
   }
 
   // Public: Obtain a complete version of a suggestion with additional information

--- a/lib/adapters/autocomplete-adapter.ts
+++ b/lib/adapters/autocomplete-adapter.ts
@@ -70,12 +70,13 @@ export default class AutocompleteAdapter {
 
     // Only auto-trigger on a trigger character or after the minimum number of characters from autocomplete-plus
     const minimumWordLength = atom.config.get('autocomplete-plus.minimumWordLength') || 0;
-    if (!request.activatedManually && triggerChar === '' && minimumWordLength > 0 && request.prefix.length < minimumWordLength) {
+    if (!request.activatedManually && triggerChar === '' &&
+        minimumWordLength > 0 && request.prefix.length < minimumWordLength) {
       return [];
     }
 
     const cache = this._suggestionCache.get(server);
-    var suggestionMap = null;
+    let suggestionMap = null;
 
     // Do we have complete cached suggestions that are still valid for this request
     if (cache && !cache.isIncomplete && cache.triggerChar === triggerChar && cache.triggerPoint.isEqual(triggerPoint)) {

--- a/lib/adapters/autocomplete-adapter.ts
+++ b/lib/adapters/autocomplete-adapter.ts
@@ -64,9 +64,9 @@ export default class AutocompleteAdapter {
       server.capabilities.completionProvider != null ?
         server.capabilities.completionProvider.triggerCharacters || [] : [];
     const triggerChar = AutocompleteAdapter.getTriggerCharacter(request, triggerChars);
-    const triggerColumn = request.bufferPosition.column - (triggerChar != null ? triggerChar.length : 0);
-    const triggerPoint = new Point(request.bufferPosition.row, triggerColumn);
     const prefixWithTrigger = triggerChar + request.prefix;
+    const triggerColumn = request.bufferPosition.column - prefixWithTrigger.length;
+    const triggerPoint = new Point(request.bufferPosition.row, triggerColumn);
 
     // We auto-trigger on a trigger character or after the minimum number of characters from autocomplete-plus
     const minimumWordLength = atom.config.get('autocomplete-plus.minimumWordLength') || 0;

--- a/lib/adapters/autocomplete-adapter.ts
+++ b/lib/adapters/autocomplete-adapter.ts
@@ -59,6 +59,7 @@ export default class AutocompleteAdapter {
     request: AutocompleteRequest,
     onDidConvertCompletionItem?: (item: CompletionItem, suggestion: AutocompleteSuggestion,
                                   request: AutocompleteRequest) => void,
+    minimumWordLength?: number,
   ): Promise<AutocompleteSuggestion[]> {
     const triggerChars =
       server.capabilities.completionProvider != null ?
@@ -69,7 +70,7 @@ export default class AutocompleteAdapter {
     const triggerPoint = new Point(request.bufferPosition.row, triggerColumn);
 
     // Only auto-trigger on a trigger character or after the minimum number of characters from autocomplete-plus
-    const minimumWordLength = atom.config.get('autocomplete-plus.minimumWordLength') || 0;
+    minimumWordLength = minimumWordLength || 0;
     if (!request.activatedManually && triggerChar === '' &&
         minimumWordLength > 0 && request.prefix.length < minimumWordLength) {
       return [];

--- a/lib/auto-languageclient.ts
+++ b/lib/auto-languageclient.ts
@@ -443,7 +443,7 @@ export default class AutoLanguageClient {
 
     this.autoComplete = this.autoComplete || new AutocompleteAdapter();
     this._lastAutocompleteRequest = request;
-    return this.autoComplete.getSuggestions(server, request, this.onDidConvertAutocomplete);
+    return this.autoComplete.getSuggestions(server, request, this.onDidConvertAutocomplete, atom.config.get('autocomplete-plus.minimumWordLength'));
   }
 
   protected async getSuggestionDetailsOnSelect(

--- a/lib/auto-languageclient.ts
+++ b/lib/auto-languageclient.ts
@@ -443,7 +443,8 @@ export default class AutoLanguageClient {
 
     this.autoComplete = this.autoComplete || new AutocompleteAdapter();
     this._lastAutocompleteRequest = request;
-    return this.autoComplete.getSuggestions(server, request, this.onDidConvertAutocomplete, atom.config.get('autocomplete-plus.minimumWordLength'));
+    return this.autoComplete.getSuggestions(server, request, this.onDidConvertAutocomplete,
+      atom.config.get('autocomplete-plus.minimumWordLength'));
   }
 
   protected async getSuggestionDetailsOnSelect(

--- a/test/adapters/autocomplete-adapter.test.ts
+++ b/test/adapters/autocomplete-adapter.test.ts
@@ -35,7 +35,7 @@ describe('AutoCompleteAdapter', () => {
   const request: AutocompleteRequest = {
     editor: createFakeEditor(),
     bufferPosition: new Point(123, 456),
-    prefix: 'def',
+    prefix: 'lab',
     scopeDescriptor: 'some.scope',
     activatedManually: true,
   };
@@ -61,6 +61,13 @@ describe('AutoCompleteAdapter', () => {
       detail: 'description3',
       documentation: 'a very exciting variable',
     },
+    {
+      label: 'filteredout',
+      kind: ls.CompletionItemKind.Snippet,
+      detail: 'description4',
+      documentation: 'should not appear',
+      sortText: 'zzz'
+    },
   ];
 
   describe('getSuggestions', () => {
@@ -70,6 +77,7 @@ describe('AutoCompleteAdapter', () => {
     it('gets AutoComplete suggestions via LSP given an AutoCompleteRequest', async () => {
       const autoCompleteAdapter = new AutoCompleteAdapter();
       const results = await autoCompleteAdapter.getSuggestions(server, request);
+
       expect(results.length).equals(3);
       expect(results[0].text).equals('label2');
       expect(results[1].description).equals('a very exciting variable');
@@ -135,7 +143,7 @@ describe('AutoCompleteAdapter', () => {
     it('converts LSP CompletionItem array to AutoComplete Suggestions array', () => {
       const autoCompleteAdapter = new AutoCompleteAdapter();
       const results = Array.from(autoCompleteAdapter.completionItemsToSuggestions(completionItems, request));
-      expect(results.length).equals(3);
+      expect(results.length).equals(4);
       expect(results[0][0].text).equals('label2');
       expect(results[1][0].description).equals('a very exciting variable');
       expect(results[2][0].type).equals('keyword');
@@ -145,7 +153,7 @@ describe('AutoCompleteAdapter', () => {
       const completionList = {items: completionItems, isIncomplete: false};
       const autoCompleteAdapter = new AutoCompleteAdapter();
       const results = Array.from(autoCompleteAdapter.completionItemsToSuggestions(completionList, request));
-      expect(results.length).equals(3);
+      expect(results.length).equals(4);
       expect(results[0][0].description).equals('a very exciting field');
       expect(results[1][0].text).equals('label3');
     });
@@ -160,7 +168,7 @@ describe('AutoCompleteAdapter', () => {
             a.displayText = r.scopeDescriptor;
           }));
 
-      expect(results.length).equals(3);
+      expect(results.length).equals(4);
       expect(results[0][0].displayText).equals('some.scope');
       expect(results[1][0].text).equals('label3 ok');
     });

--- a/test/adapters/autocomplete-adapter.test.ts
+++ b/test/adapters/autocomplete-adapter.test.ts
@@ -66,7 +66,7 @@ describe('AutoCompleteAdapter', () => {
       kind: ls.CompletionItemKind.Snippet,
       detail: 'description4',
       documentation: 'should not appear',
-      sortText: 'zzz'
+      sortText: 'zzz',
     },
   ];
 

--- a/test/adapters/autocomplete-adapter.test.ts
+++ b/test/adapters/autocomplete-adapter.test.ts
@@ -115,7 +115,7 @@ describe('AutoCompleteAdapter', () => {
 
   describe('createCompletionParams', () => {
     it('creates CompletionParams from an AutocompleteRequest with no trigger', () => {
-      const result = AutoCompleteAdapter.createCompletionParams(request, null);
+      const result = AutoCompleteAdapter.createCompletionParams(request, '');
       expect(result.textDocument.uri).equals('file:///a/b/c/d.js');
       expect(result.position).deep.equals({line: 123, character: 456});
       expect(result.context && result.context.triggerKind === ls.CompletionTriggerKind.Invoked);

--- a/test/adapters/autocomplete-adapter.test.ts
+++ b/test/adapters/autocomplete-adapter.test.ts
@@ -77,7 +77,6 @@ describe('AutoCompleteAdapter', () => {
     it('gets AutoComplete suggestions via LSP given an AutoCompleteRequest', async () => {
       const autoCompleteAdapter = new AutoCompleteAdapter();
       const results = await autoCompleteAdapter.getSuggestions(server, request);
-
       expect(results.length).equals(3);
       expect(results[0].text).equals('label2');
       expect(results[1].description).equals('a very exciting variable');


### PR DESCRIPTION
This reworks autocompletion (again) to:

- Trigger on trigger character OR a min char count specified in autocomplete-plus settings (defaults to 3)
- Always filter the results in case the server does not look back from the cursor position (some do not)
- Simplify the code

Note: Some static methods marked *public* have been changed or removed. We'll use semver once we hit 1.0.0.