### PR TITLE
Console logging adapter

### DIFF
--- a/lib/adapters/apply-edit-adapter.ts
+++ b/lib/adapters/apply-edit-adapter.ts
@@ -1,11 +1,14 @@
+import * as atomIde from 'atom-ide';
+import Convert from '../convert';
 import {
   LanguageClientConnection,
   ApplyWorkspaceEditParams,
   ApplyWorkspaceEditResponse,
 } from '../languageclient';
-import { TextBuffer, TextEditor } from 'atom';
-import * as atomIde from 'atom-ide';
-import Convert from '../convert';
+import {
+  TextBuffer,
+  TextEditor,
+} from 'atom';
 
 // Public: Adapts workspace/applyEdit commands to editors.
 export default class ApplyEditAdapter {

--- a/lib/adapters/autocomplete-adapter.ts
+++ b/lib/adapters/autocomplete-adapter.ts
@@ -1,3 +1,8 @@
+import Convert from '../convert';
+import Utils from '../utils';
+import { CancellationTokenSource } from 'vscode-jsonrpc';
+import { ActiveServer } from '../server-manager';
+import { filter } from 'fuzzaldrin-plus';
 import {
   CompletionItemKind,
   CompletionTriggerKind,
@@ -16,11 +21,6 @@ import {
   Point,
   TextEditor,
 } from 'atom';
-import { CancellationTokenSource } from 'vscode-jsonrpc';
-import { ActiveServer } from '../server-manager';
-import Convert from '../convert';
-import { filter } from 'fuzzaldrin-plus';
-import Utils from '../utils';
 
 interface SuggestionCacheEntry {
   isIncomplete: boolean;

--- a/lib/adapters/code-action-adapter.ts
+++ b/lib/adapters/code-action-adapter.ts
@@ -1,10 +1,15 @@
-import LinterPushV2Adapter from './linter-push-v2-adapter';
-
-import assert = require('assert');
-import { LanguageClientConnection, ServerCapabilities } from '../languageclient';
-import { TextEditor, Range } from 'atom';
-import Convert from '../convert';
 import * as atomIde from 'atom-ide';
+import LinterPushV2Adapter from './linter-push-v2-adapter';
+import assert = require('assert');
+import Convert from '../convert';
+import {
+  LanguageClientConnection,
+  ServerCapabilities,
+} from '../languageclient';
+import {
+  TextEditor,
+  Range,
+} from 'atom';
 
 export default class CodeActionAdapter {
   // Returns a {Boolean} indicating this adapter can adapt the server based on the

--- a/lib/adapters/code-format-adapter.ts
+++ b/lib/adapters/code-format-adapter.ts
@@ -1,3 +1,5 @@
+import * as atomIde from 'atom-ide';
+import Convert from '../convert';
 import {
   LanguageClientConnection,
   DocumentFormattingParams,
@@ -5,9 +7,10 @@ import {
   FormattingOptions,
   ServerCapabilities,
 } from '../languageclient';
-import { TextEditor, Range } from 'atom';
-import * as atomIde from 'atom-ide';
-import Convert from '../convert';
+import {
+  TextEditor,
+  Range,
+} from 'atom';
 
 // Public: Adapts the language server protocol "textDocument/completion" to the
 // Atom IDE UI Code-format package.

--- a/lib/adapters/code-highlight-adapter.ts
+++ b/lib/adapters/code-highlight-adapter.ts
@@ -1,7 +1,14 @@
 import assert = require('assert');
-import { Point, TextEditor, Range } from 'atom';
-import { LanguageClientConnection, ServerCapabilities } from '../languageclient';
 import Convert from '../convert';
+import {
+  Point,
+  TextEditor,
+  Range,
+} from 'atom';
+import {
+  LanguageClientConnection,
+  ServerCapabilities,
+} from '../languageclient';
 
 export default class CodeHighlightAdapter {
   // Returns a {Boolean} indicating this adapter can adapt the server based on the

--- a/lib/adapters/datatip-adapter.ts
+++ b/lib/adapters/datatip-adapter.ts
@@ -1,13 +1,16 @@
+import * as atomIde from 'atom-ide';
+import Convert from '../convert';
+import Utils from '../utils';
 import {
   LanguageClientConnection,
   MarkupContent,
   MarkedString,
   ServerCapabilities,
 } from '../languageclient';
-import { Point, TextEditor } from 'atom';
-import * as atomIde from 'atom-ide';
-import Convert from '../convert';
-import Utils from '../utils';
+import {
+  Point,
+  TextEditor,
+} from 'atom';
 
 // Public: Adapts the language server protocol "textDocument/hover" to the
 // Atom IDE UI Datatip package.

--- a/lib/adapters/definition-adapter.ts
+++ b/lib/adapters/definition-adapter.ts
@@ -1,8 +1,16 @@
-import { LanguageClientConnection, Location, ServerCapabilities } from '../languageclient';
+import * as atomIde from 'atom-ide';
 import Convert from '../convert';
 import Utils from '../utils';
-import { Point, TextEditor, Range } from 'atom';
-import * as atomIde from 'atom-ide';
+import {
+  LanguageClientConnection,
+  Location,
+  ServerCapabilities,
+} from '../languageclient';
+import {
+  Point,
+  TextEditor,
+  Range,
+} from 'atom';
 
 // Public: Adapts the language server definition provider to the
 // Atom IDE UI Definitions package for 'Go To Definition' functionality.

--- a/lib/adapters/find-references-adapter.ts
+++ b/lib/adapters/find-references-adapter.ts
@@ -1,12 +1,15 @@
+import * as atomIde from 'atom-ide';
+import Convert from '../convert';
+import {
+  Point,
+  TextEditor,
+} from 'atom';
 import {
   LanguageClientConnection,
   Location,
   ServerCapabilities,
   ReferenceParams,
 } from '../languageclient';
-import { Point, TextEditor } from 'atom';
-import * as atomIde from 'atom-ide';
-import Convert from '../convert';
 
 // Public: Adapts the language server definition provider to the
 // Atom IDE UI Definitions package for 'Go To Definition' functionality.

--- a/lib/adapters/linter-push-v2-adapter.ts
+++ b/lib/adapters/linter-push-v2-adapter.ts
@@ -1,5 +1,6 @@
 import * as linter from 'atom/linter';
 import * as atom from 'atom';
+import Convert from '../convert';
 import {
   Diagnostic,
   DiagnosticCode,
@@ -7,7 +8,6 @@ import {
   LanguageClientConnection,
   PublishDiagnosticsParams,
 } from '../languageclient';
-import Convert from '../convert';
 
 // Public: Listen to diagnostics messages from the language server and publish them
 // to the user by way of the Linter Push (Indie) v2 API supported by Atom IDE UI.

--- a/lib/adapters/linter-push-v2-adapter.ts
+++ b/lib/adapters/linter-push-v2-adapter.ts
@@ -41,8 +41,6 @@ export default class LinterPushV2Adapter {
   }
 
   // Public: Remove all {V2IndieDelegate} registries attached to this adapter and clear them.
-  //
-  // * `indie` A {V2IndieDelegate} that wants to receive messages.
   public detachAll(): void {
     this._indies.forEach((i) => i.clearMessages());
     this._indies.clear();

--- a/lib/adapters/logging-console-adapter.ts
+++ b/lib/adapters/logging-console-adapter.ts
@@ -1,0 +1,29 @@
+import * as atomIde from 'atom-ide';
+import {
+  LanguageClientConnection,
+  LogMessageParams,
+} from '../languageclient';
+
+// Public: Adapts Atom's user notifications to those of the language server protocol.
+export default class LoggingConsoleAdapter {
+  private _consoles: Map<LanguageClientConnection, Console> = new Map();
+
+  // Public: Attach to a {LanguageClientConnection} to recieve events indicating
+  // when user notifications should be displayed.
+  public attach(connection: LanguageClientConnection, name: string, projectPath: string): void {
+    connection.onLogMessage((m) => LoggingConsoleAdapter.onLogMessage(m, name, projectPath));
+  }
+
+  public detach(connection: LanguageClientConnection): void {
+  }
+
+  // Public: Log a message using the Atom IDE UI Console API.
+  //
+  // * `params` The {LogMessageParams} received from the language server
+  //            indicating the details of the message to be loggedd.
+  // * `name`   The name of the language server so the user can identify the
+  //            context of the message.
+  public static onLogMessage(params: LogMessageParams, name: string, projectPath: string): void {
+
+  }
+}

--- a/lib/adapters/logging-console-adapter.ts
+++ b/lib/adapters/logging-console-adapter.ts
@@ -1,29 +1,67 @@
 import * as atomIde from 'atom-ide';
+import { ActiveServer } from '../server-manager';
 import {
   LanguageClientConnection,
   LogMessageParams,
+  MessageType,
 } from '../languageclient';
+import { ConsoleService, ConsoleApi } from "atom-ide";
 
-// Public: Adapts Atom's user notifications to those of the language server protocol.
+// Adapts Atom's user notifications to those of the language server protocol.
 export default class LoggingConsoleAdapter {
-  private _consoles: Map<LanguageClientConnection, Console> = new Map();
+  private _consoles: Set<ConsoleApi> = new Set();
 
-  // Public: Attach to a {LanguageClientConnection} to recieve events indicating
-  // when user notifications should be displayed.
-  public attach(connection: LanguageClientConnection, name: string, projectPath: string): void {
-    connection.onLogMessage((m) => LoggingConsoleAdapter.onLogMessage(m, name, projectPath));
+  // Create a new {LoggingConsoleAdapter} that will listen for diagnostics
+  // via the supplied {LanguageClientConnection}.
+  //
+  // * `connection` A {LanguageClientConnection} to the language server that will provide log messages.
+  constructor(connection: LanguageClientConnection) {
+    connection.onLogMessage(this.logMessage.bind(this));
   }
 
-  public detach(connection: LanguageClientConnection): void {
+  // Dispose this adapter ensuring any resources are freed and events unhooked.
+  public dispose(): void {
+    this.detachAll();
   }
 
-  // Public: Log a message using the Atom IDE UI Console API.
+  // Public: Attach this {LoggingConsoleAdapter} to a given {ConsoleService}.
+  //
+  // * `console` A {ConsoleApi} that wants to receive messages.
+  public attach(console: ConsoleApi): void {
+    this._consoles.add(console);
+  }
+
+  // Public: Remove all {V2IndieDelegate} registries attached to this adapter.
+  public detachAll(): void {
+    this._consoles.clear();
+  }
+
+  private generateId(): string {
+    return new Date().toISOString();
+  }
+
+  // Log a message using the Atom IDE UI Console API.
   //
   // * `params` The {LogMessageParams} received from the language server
   //            indicating the details of the message to be loggedd.
-  // * `name`   The name of the language server so the user can identify the
-  //            context of the message.
-  public static onLogMessage(params: LogMessageParams, name: string, projectPath: string): void {
-
+  private logMessage(params: LogMessageParams): void {
+    switch (params.type) {
+      case MessageType.Error: {
+        this._consoles.forEach((c) => c.error(params.message));
+        return;
+      }
+      case MessageType.Warning: {
+        this._consoles.forEach((c) => c.warn(params.message));
+        return;
+      }
+      case MessageType.Info: {
+        this._consoles.forEach((c) => c.info(params.message));
+        return;
+      }
+      case MessageType.Log: {
+        this._consoles.forEach((c) => c.log(params.message));
+        return;
+      }
+    }
   }
 }

--- a/lib/adapters/logging-console-adapter.ts
+++ b/lib/adapters/logging-console-adapter.ts
@@ -11,7 +11,7 @@ import { ConsoleService, ConsoleApi } from "atom-ide";
 export default class LoggingConsoleAdapter {
   private _consoles: Set<ConsoleApi> = new Set();
 
-  // Create a new {LoggingConsoleAdapter} that will listen for diagnostics
+  // Create a new {LoggingConsoleAdapter} that will listen for log messages
   // via the supplied {LanguageClientConnection}.
   //
   // * `connection` A {LanguageClientConnection} to the language server that will provide log messages.
@@ -24,14 +24,14 @@ export default class LoggingConsoleAdapter {
     this.detachAll();
   }
 
-  // Public: Attach this {LoggingConsoleAdapter} to a given {ConsoleService}.
+  // Public: Attach this {LoggingConsoleAdapter} to a given {ConsoleApi}.
   //
   // * `console` A {ConsoleApi} that wants to receive messages.
   public attach(console: ConsoleApi): void {
     this._consoles.add(console);
   }
 
-  // Public: Remove all {V2IndieDelegate} registries attached to this adapter.
+  // Public: Remove all {ConsoleApi}'s attached to this adapter.
   public detachAll(): void {
     this._consoles.clear();
   }

--- a/lib/adapters/logging-console-adapter.ts
+++ b/lib/adapters/logging-console-adapter.ts
@@ -1,11 +1,9 @@
-import * as atomIde from 'atom-ide';
-import { ActiveServer } from '../server-manager';
+import { ConsoleApi } from 'atom-ide';
 import {
   LanguageClientConnection,
   LogMessageParams,
   MessageType,
 } from '../languageclient';
-import { ConsoleService, ConsoleApi } from "atom-ide";
 
 // Adapts Atom's user notifications to those of the language server protocol.
 export default class LoggingConsoleAdapter {

--- a/lib/adapters/outline-view-adapter.ts
+++ b/lib/adapters/outline-view-adapter.ts
@@ -1,9 +1,17 @@
-import { LanguageClientConnection, SymbolKind, ServerCapabilities, SymbolInformation } from '../languageclient';
+import * as atomIde from 'atom-ide';
 import Convert from '../convert';
 import Utils from '../utils';
-import { Point, TextEditor } from 'atom';
 import { CancellationTokenSource } from 'vscode-jsonrpc';
-import * as atomIde from 'atom-ide';
+import {
+  LanguageClientConnection,
+  SymbolKind,
+  ServerCapabilities,
+  SymbolInformation,
+} from '../languageclient';
+import {
+  Point,
+  TextEditor,
+} from 'atom';
 
 // Public: Adapts the documentSymbolProvider of the language server to the Outline View
 // supplied by Atom IDE UI.

--- a/lib/adapters/signature-help-adapter.ts
+++ b/lib/adapters/signature-help-adapter.ts
@@ -1,9 +1,17 @@
+import * as atomIde from 'atom-ide';
 import assert = require('assert');
-import { CompositeDisposable, Point, TextEditor } from 'atom';
-import { LanguageClientConnection, ServerCapabilities, SignatureHelp } from '../languageclient';
 import Convert from '../convert';
 import { ActiveServer } from '../server-manager';
-import * as atomIde from 'atom-ide';
+import {
+  CompositeDisposable,
+  Point,
+  TextEditor,
+} from 'atom';
+import {
+  LanguageClientConnection,
+  ServerCapabilities,
+  SignatureHelp,
+} from '../languageclient';
 
 export default class SignatureHelpAdapter {
   private _disposables: CompositeDisposable = new CompositeDisposable();

--- a/lib/auto-languageclient.ts
+++ b/lib/auto-languageclient.ts
@@ -409,6 +409,12 @@ export default class AutoLanguageClient {
     }
     server.disposable.add(server.linterPushV2);
 
+    server.loggingConsole = new LoggingConsoleAdapter(server.connection);
+    if (this._consoleDelegate != null) {
+      server.loggingConsole.attach(this._consoleDelegate({ id: this.name, name: 'abc' }));
+    }
+    server.disposable.add(server.loggingConsole);
+
     if (SignatureHelpAdapter.canAdapt(server.capabilities)) {
       server.signatureHelpAdapter = new SignatureHelpAdapter(server, this.getGrammarScopes());
       if (this._signatureHelpRegistry != null) {
@@ -584,18 +590,14 @@ export default class AutoLanguageClient {
     this._consoleDelegate = createConsole;
 
     for (const server of this._serverManager.getActiveServers()) {
-      if (server.loggingConsole != null) {
-        server.loggingConsole.attach(this._consoleDelegate);
+      if (server.loggingConsole == null) {
+        server.loggingConsole = new LoggingConsoleAdapter(server.connection);
       }
+      server.loggingConsole.attach(this._consoleDelegate({ id: this.name, name: 'abc' }));
     }
 
-    return new Disposable(() => {
-      for (const server of this._serverManager.getActiveServers()) {
-        if (server.loggingConsole != null) {
-          server.loggingConsole.detach(this._consoleDelegate);
-        }
-      }
-    });
+    // No way of detaching from client connections today
+    return new Disposable(() => { });
   }
 
   // Code Format via LS formatDocument & formatDocumentRange------------

--- a/lib/auto-languageclient.ts
+++ b/lib/auto-languageclient.ts
@@ -15,6 +15,7 @@ import DefinitionAdapter from './adapters/definition-adapter';
 import DocumentSyncAdapter from './adapters/document-sync-adapter';
 import FindReferencesAdapter from './adapters/find-references-adapter';
 import LinterPushV2Adapter from './adapters/linter-push-v2-adapter';
+import LoggingConsoleAdapter from './adapters/logging-console-adapter';
 import NotificationsAdapter from './adapters/notifications-adapter';
 import OutlineViewAdapter from './adapters/outline-view-adapter';
 import SignatureHelpAdapter from './adapters/signature-help-adapter';
@@ -53,6 +54,7 @@ export type ConnectionType = 'stdio' | 'socket' | 'ipc';
 export default class AutoLanguageClient {
   private _disposable = new CompositeDisposable();
   private _serverManager: ServerManager;
+  private _consoleDelegate: atomIde.ConsoleService;
   private _linterDelegate: linter.IndieDelegate;
   private _signatureHelpRegistry: atomIde.SignatureHelpRegistry | null;
   private _lastAutocompleteRequest: AutocompleteRequest;
@@ -575,6 +577,25 @@ export default class AutoLanguageClient {
 
     this.datatip = this.datatip || new DatatipAdapter();
     return this.datatip.getDatatip(server.connection, editor, point);
+  }
+
+  // Console via LS logging---------------------------------------------
+  public consumeConsole(createConsole: atomIde.ConsoleService): Disposable {
+    this._consoleDelegate = createConsole;
+
+    for (const server of this._serverManager.getActiveServers()) {
+      if (server.loggingConsole != null) {
+        server.loggingConsole.attach(this._consoleDelegate);
+      }
+    }
+
+    return new Disposable(() => {
+      for (const server of this._serverManager.getActiveServers()) {
+        if (server.loggingConsole != null) {
+          server.loggingConsole.detach(this._consoleDelegate);
+        }
+      }
+    });
   }
 
   // Code Format via LS formatDocument & formatDocumentRange------------

--- a/lib/auto-languageclient.ts
+++ b/lib/auto-languageclient.ts
@@ -4,26 +4,7 @@ import * as rpc from 'vscode-jsonrpc';
 import * as path from 'path';
 import * as atomIde from 'atom-ide';
 import * as linter from 'atom/linter';
-import { Socket } from 'net';
-import { LanguageClientConnection } from './languageclient';
-import { ConsoleLogger, NullLogger, Logger } from './logger';
-import { LanguageServerProcess, ServerManager, ActiveServer } from './server-manager.js';
 import Convert from './convert.js';
-
-export { ActiveServer, LanguageClientConnection, LanguageServerProcess };
-
-import {
-  AutocompleteDidInsert,
-  AutocompleteProvider,
-  AutocompleteRequest,
-  AutocompleteSuggestion,
-  CompositeDisposable,
-  Disposable,
-  Point,
-  Range,
-  TextEditor,
-} from 'atom';
-
 import ApplyEditAdapter from './adapters/apply-edit-adapter';
 import AutocompleteAdapter from './adapters/autocomplete-adapter';
 import CodeActionAdapter from './adapters/code-action-adapter';
@@ -38,7 +19,31 @@ import NotificationsAdapter from './adapters/notifications-adapter';
 import OutlineViewAdapter from './adapters/outline-view-adapter';
 import SignatureHelpAdapter from './adapters/signature-help-adapter';
 import Utils from './utils';
+import { Socket } from 'net';
+import { LanguageClientConnection } from './languageclient';
+import {
+  ConsoleLogger,
+  NullLogger,
+  Logger,
+} from './logger';
+import {
+  LanguageServerProcess,
+  ServerManager,
+  ActiveServer,
+} from './server-manager.js';
+import {
+  AutocompleteDidInsert,
+  AutocompleteProvider,
+  AutocompleteRequest,
+  AutocompleteSuggestion,
+  CompositeDisposable,
+  Disposable,
+  Point,
+  Range,
+  TextEditor,
+} from 'atom';
 
+export { ActiveServer, LanguageClientConnection, LanguageServerProcess };
 export type ConnectionType = 'stdio' | 'socket' | 'ipc';
 
 // Public: AutoLanguageClient provides a simple way to have all the supported

--- a/lib/convert.ts
+++ b/lib/convert.ts
@@ -1,8 +1,17 @@
 
 import * as ls from './languageclient';
-import { Point, ProjectFileEvent, Range, TextEditor } from 'atom';
-import { Diagnostic, DiagnosticType, TextEdit } from 'atom-ide';
 import * as URL from 'url';
+import {
+  Point,
+  ProjectFileEvent,
+  Range,
+  TextEditor,
+} from 'atom';
+import {
+  Diagnostic,
+  DiagnosticType,
+  TextEdit,
+} from 'atom-ide';
 
 // Public: Class that contains a number of helper methods for general conversions
 // between the language server protocol and Atom/Atom packages.

--- a/lib/languageclient.ts
+++ b/lib/languageclient.ts
@@ -1,9 +1,12 @@
 import * as jsonrpc from 'vscode-jsonrpc';
 import * as lsp from 'vscode-languageserver-protocol';
-export * from 'vscode-languageserver-protocol';
-
 import { EventEmitter } from 'events';
-import { NullLogger, Logger } from './logger';
+import {
+  NullLogger,
+  Logger,
+} from './logger';
+
+export * from 'vscode-languageserver-protocol';
 
 // TypeScript wrapper around JSONRPC to implement Microsoft Language Server Protocol v3
 // https://github.com/Microsoft/language-server-protocol/blob/master/protocol.md

--- a/lib/main.ts
+++ b/lib/main.ts
@@ -9,4 +9,9 @@ import DownloadFile from './download-file';
 import LinterPushV2Adapter from './adapters/linter-push-v2-adapter';
 
 export * from './auto-languageclient';
-export { AutoLanguageClient, Convert, DownloadFile, LinterPushV2Adapter };
+export {
+  AutoLanguageClient,
+  Convert,
+  DownloadFile,
+  LinterPushV2Adapter,
+};

--- a/lib/server-manager.ts
+++ b/lib/server-manager.ts
@@ -1,5 +1,6 @@
 import DocumentSyncAdapter from './adapters/document-sync-adapter';
 import LinterPushV2Adapter from './adapters/linter-push-v2-adapter';
+import LoggingConsoleAdapter from './adapters/logging-console-adapter';
 import SignatureHelpAdapter from './adapters/signature-help-adapter';
 import Convert from './convert';
 import * as path from 'path';
@@ -37,6 +38,7 @@ export interface ActiveServer {
   connection: ls.LanguageClientConnection;
   capabilities: ls.ServerCapabilities;
   linterPushV2?: LinterPushV2Adapter;
+  loggingConsole?: LoggingConsoleAdapter;
   docSyncAdapter?: DocumentSyncAdapter;
   signatureHelpAdapter?: SignatureHelpAdapter;
 }

--- a/lib/server-manager.ts
+++ b/lib/server-manager.ts
@@ -1,15 +1,18 @@
-import { Logger } from './logger';
-import { EventEmitter } from 'events';
-import LinterPushV2Adapter from './adapters/linter-push-v2-adapter';
 import DocumentSyncAdapter from './adapters/document-sync-adapter';
+import LinterPushV2Adapter from './adapters/linter-push-v2-adapter';
 import SignatureHelpAdapter from './adapters/signature-help-adapter';
-
+import Convert from './convert';
 import * as path from 'path';
 import * as stream from 'stream';
 import * as ls from './languageclient';
 import * as atomIde from 'atom-ide';
-import Convert from './convert';
-import { CompositeDisposable, ProjectFileEvent, TextEditor } from 'atom';
+import { EventEmitter } from 'events';
+import { Logger } from './logger';
+import {
+  CompositeDisposable,
+  ProjectFileEvent,
+  TextEditor,
+} from 'atom';
 
 // Public: Defines the minimum surface area for an object that resembles a
 // ChildProcess.  This is used so that language packages with alternative

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -1,5 +1,14 @@
-import { Point, TextBuffer, TextEditor, Range, BufferScanResult } from 'atom';
-import { CancellationToken, CancellationTokenSource } from 'vscode-jsonrpc';
+import {
+  Point,
+  TextBuffer,
+  TextEditor,
+  Range,
+  BufferScanResult,
+} from 'atom';
+import {
+  CancellationToken,
+  CancellationTokenSource,
+} from 'vscode-jsonrpc';
 
 export default class Utils {
   /**

--- a/test/convert.test.ts
+++ b/test/convert.test.ts
@@ -1,7 +1,12 @@
 import * as ls from '../lib/languageclient';
 import Convert from '../lib/convert';
-import { Point, ProjectFileEvent, Range, TextEditor } from 'atom';
 import { expect } from 'chai';
+import {
+  Point,
+  ProjectFileEvent,
+  Range,
+  TextEditor,
+} from 'atom';
 
 let originalPlatform: NodeJS.Platform;
 const setProcessPlatform = (platform: any) => {

--- a/test/helpers.ts
+++ b/test/helpers.ts
@@ -1,8 +1,6 @@
-// @flow
-
 import * as sinon from 'sinon';
-import { TextEditor } from 'atom';
 import * as rpc from 'vscode-jsonrpc';
+import { TextEditor } from 'atom';
 
 export function createSpyConnection(): rpc.MessageConnection {
   return {

--- a/test/languageclient.test.ts
+++ b/test/languageclient.test.ts
@@ -1,8 +1,8 @@
 import * as ls from '../lib/languageclient';
-import { NullLogger } from '../lib/logger';
 import * as sinon from 'sinon';
 import { expect } from 'chai';
 import { createSpyConnection } from './helpers.js';
+import { NullLogger } from '../lib/logger';
 
 describe('LanguageClientConnection', () => {
   beforeEach(() => {

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -1,8 +1,7 @@
 import Utils from '../lib/utils';
 import { createFakeEditor } from './helpers';
-
-import { Point } from 'atom';
 import { expect } from 'chai';
+import { Point } from 'atom';
 
 describe('Utils', () => {
   describe('getWordAtPosition', () => {

--- a/typings/atom-ide/index.d.ts
+++ b/typings/atom-ide/index.d.ts
@@ -265,4 +265,51 @@ declare module 'atom-ide' {
     label: string;
     documentation?: string;
   }
+
+  export interface SourceInfo {
+    id: string;
+    name: string;
+    start?: () => void;
+    stop?: () => void;
+  }
+
+  // Console service
+
+  export type ConsoleService = (options: SourceInfo) => ConsoleApi;
+
+  export interface ConsoleApi {
+    setStatus(status: OutputProviderStatus): void,
+    append(message: Message): void,
+    dispose(): void,
+    log(object: string): void,
+    error(object: string): void,
+    warn(object: string): void,
+    info(object: string): void,
+  }
+
+  export type OutputProviderStatus = 'starting' | 'running' | 'stopped';
+
+  export type Message = {
+    text: string,
+    level: Level,
+    // data?: EvaluationResult,  // Excluded for now, brings in React etc.
+    tags?: Array<string> | null,
+    kind?: MessageKind | null,
+    scopeName?: string | null,
+  };
+
+
+  export type TaskLevelType = 'info' | 'log' | 'warning' | 'error' | 'debug' | 'success';
+  export type Level = TaskLevelType | Color;
+  type Color =
+    | 'red'
+    | 'orange'
+    | 'yellow'
+    | 'green'
+    | 'blue'
+    | 'purple'
+    | 'violet'
+    | 'rainbow';
+
+  export type MessageKind = 'message' | 'request' | 'response';
 }

--- a/typings/atom-ide/index.d.ts
+++ b/typings/atom-ide/index.d.ts
@@ -278,26 +278,24 @@ declare module 'atom-ide' {
   export type ConsoleService = (options: SourceInfo) => ConsoleApi;
 
   export interface ConsoleApi {
-    setStatus(status: OutputProviderStatus): void,
-    append(message: Message): void,
-    dispose(): void,
-    log(object: string): void,
-    error(object: string): void,
-    warn(object: string): void,
-    info(object: string): void,
+    setStatus(status: OutputProviderStatus): void;
+    append(message: Message): void;
+    dispose(): void;
+    log(object: string): void;
+    error(object: string): void;
+    warn(object: string): void;
+    info(object: string): void;
   }
 
   export type OutputProviderStatus = 'starting' | 'running' | 'stopped';
 
-  export type Message = {
-    text: string,
-    level: Level,
-    // data?: EvaluationResult,  // Excluded for now, brings in React etc.
-    tags?: Array<string> | null,
-    kind?: MessageKind | null,
-    scopeName?: string | null,
-  };
-
+  export interface Message {
+    text: string;
+    level: Level;
+    tags?: string[] | null;
+    kind?: MessageKind | null;
+    scopeName?: string | null;
+  }
 
   export type TaskLevelType = 'info' | 'log' | 'warning' | 'error' | 'debug' | 'success';
   export type Level = TaskLevelType | Color;


### PR DESCRIPTION
Wires up `workspace/logMessage` to the Console in Atom-IDE-UI