### PR TITLE
Add support for custom requests and notifications

### DIFF
--- a/lib/languageclient.ts
+++ b/lib/languageclient.ts
@@ -81,6 +81,22 @@ export class LanguageClientConnection extends EventEmitter {
     this._onNotification({method}, callback);
   }
 
+  // Public: Send a custom request
+  //
+  // * `method`   A string containing the name of the request message.
+  // * `params`   The method's parameters
+  public sendCustomRequest(method: string, params?: Array<any> | object): Promise<any | null> {
+    return this._sendRequest(method, params);
+  }
+
+  // Public: Send a custom notification
+  //
+  // * `method`   A string containing the name of the notification message.
+  // * `params`  The method's parameters
+  public sendCustomNotification(method: string, params?: Array<any> | object): void {
+    this._sendNotification(method, params);
+  }
+
   // Public: Register a callback for the `window/showMessage` message.
   //
   // * `callback` The function to be called when the `window/showMessage` message is

--- a/lib/languageclient.ts
+++ b/lib/languageclient.ts
@@ -85,7 +85,7 @@ export class LanguageClientConnection extends EventEmitter {
   //
   // * `method`   A string containing the name of the request message.
   // * `params`   The method's parameters
-  public sendCustomRequest(method: string, params?: Array<any> | object): Promise<any | null> {
+  public sendCustomRequest(method: string, params?: any[] | object): Promise<any | null> {
     return this._sendRequest(method, params);
   }
 
@@ -93,7 +93,7 @@ export class LanguageClientConnection extends EventEmitter {
   //
   // * `method`   A string containing the name of the notification message.
   // * `params`  The method's parameters
-  public sendCustomNotification(method: string, params?: Array<any> | object): void {
+  public sendCustomNotification(method: string, params?: any[] | object): void {
     this._sendNotification(method, params);
   }
 


### PR DESCRIPTION
[cquery](https://github.com/cquery-project/cquery/blob/master/src/methods.inc#L31-L60), [eclipse.jdt.ls](https://github.com/eclipse/eclipse.jdt.ls/wiki/Language-Server-Protocol-Extensions), [rustls](https://github.com/rust-lang-nursery/rls/blob/master/contributing.md#extensions-to-the-language-server-protocol), and I'm sure several other language servers offer extended methods for clients to use. It would be nice to be able to take advantage of these methods. There is currently support for custom notifications, but no support for custom requests.

I took a look at LanguageCleintConnection and see that there are nearly-ready extensions points for this sort of task with the private `_sendRequest` function. I'm not sure if it would be better to make the existing private function public, or create a `sendCustomRequest` wrapper.