### PR TITLE
Respect server document sync capabilities

### DIFF
--- a/lib/adapters/document-sync-adapter.ts
+++ b/lib/adapters/document-sync-adapter.ts
@@ -8,6 +8,7 @@ import {
   TextDocumentContentChangeEvent,
   VersionedTextDocumentIdentifier,
   ServerCapabilities,
+  DidSaveTextDocumentParams,
 } from '../languageclient';
 import ApplyEditAdapter from './apply-edit-adapter';
 import {
@@ -354,7 +355,13 @@ export class TextEditorSyncAdapter {
     if (!this._isPrimaryAdapter()) { return; }
 
     const uri = this.getEditorUri();
-    this._connection.didSaveTextDocument({textDocument: {uri, version: this._getVersion((uri))}});
+    const didSaveNotification = {
+      textDocument: {uri, version: this._getVersion((uri))},
+    } as DidSaveTextDocumentParams;
+    if (this._documentSync.save && this._documentSync.save.includeText) {
+      didSaveNotification.text = this._editor.getText();
+    }
+    this._connection.didSaveTextDocument(didSaveNotification);
     if (this._fakeDidChangeWatchedFiles) {
       this._connection.didChangeWatchedFiles({
         changes: [{uri, type: FileChangeType.Changed}],


### PR DESCRIPTION
See https://github.com/atom/atom-languageclient/pull/193#discussion_r176617062 for the context. This is a minor improvement avoiding breaking changes:
* don't send `didOpen`/`didClose` notifications if `documentSync.openClose` is _explicitly disabled_
* add document content if the `documentSync.save.includeText` is enabled

----

And here are some thoughts for discussion.

I think that current behaviour is not completely correct, but fixing it may break somebody's server. IMO in LSP v3 all capability options have to be enabled explicitly. So if the server wants to receive open/close notifications, it should set `openClose: true`, same as `willSave`/`willSaveWaitUntil`. 

* right now these options are treated differently: `willSave*` has to be enabled explicitly, but `openClose` and `save` not.
* with current behaviour one still can disable `open`/`close`/`willSave*` notifications, but cannot disable `save` (because it's not a boolean and undefined  is implicitly treated as `true`)
* `change` option is treated specially: it determines whether all other notifications are even considered

An example: if a server cares only about `open`, `close` and `willSaveWaitUntil` notifications, but doesn't want to receive any other, it cannot communicate it. Turning off `change` notifications while receiving some others can be useful if server has its own file watching mechanism. But currently it will result in `DocumentSyncAdapter.canAdaptV3` returning `false` and not receiving any notifications at all.

Also, I'm not sure about this, but I think that [`didChangeWatchedFiles`](https://github.com/Microsoft/language-server-protocol/blob/gh-pages/specification.md#didchangewatchedfiles-notification-arrow_right) notifications have to be registered independently from all above.