### PR TITLE
Set a timeout on the willSaveWaitUntil handler

### DIFF
--- a/lib/adapters/document-sync-adapter.ts
+++ b/lib/adapters/document-sync-adapter.ts
@@ -20,7 +20,6 @@ import {
 } from 'atom';
 import Utils from '../utils';
 import { BusySignalService } from 'atom-ide';
-import * as path from 'path';
 
 // Public: Synchronizes the documents between Atom and the language server by notifying
 // each end of changes, opening, closing and other events as well as sending and applying

--- a/lib/adapters/document-sync-adapter.ts
+++ b/lib/adapters/document-sync-adapter.ts
@@ -363,7 +363,9 @@ export class TextEditorSyncAdapter {
         reason: TextDocumentSaveReason.Manual,
       }),
     ).then((edits) => {
+      const cursor = this._editor.getCursorBufferPosition();
       ApplyEditAdapter.applyEdits(buffer, Convert.convertLsTextEdits(edits));
+      this._editor.setCursorBufferPosition(cursor);
     }).catch((err) => {
       atom.notifications.addError('On-save action failed', {
         description: `Failed to apply edits to ${title}`,

--- a/lib/auto-languageclient.ts
+++ b/lib/auto-languageclient.ts
@@ -400,6 +400,7 @@ export default class AutoLanguageClient {
           server.connection,
           (editor) => this.shouldSyncForEditor(editor, server.projectPath),
           server.capabilities.textDocumentSync,
+          this.busySignalService,
         );
       server.disposable.add(server.docSyncAdapter);
     }

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -91,4 +91,21 @@ export default class Utils {
   public static assertUnreachable(_: never): never {
     return _;
   }
+
+  public static promiseWithTimeout<T>(ms: number, promise: Promise<T>): Promise<T> {
+    return new Promise((resolve, reject) => {
+      // create a timeout to reject promise if not resolved
+      const timer = setTimeout(() => {
+        reject(new Error(`Timeout after ${ms}ms`));
+      }, ms);
+
+      promise.then((res) => {
+        clearTimeout(timer);
+        resolve(res);
+      }).catch((err) => {
+        clearTimeout(timer);
+        reject(err);
+      });
+    });
+  }
 }


### PR DESCRIPTION
Addresses #200. I have several doubts here:

1. I added this `Utils.promiseWithTimeout` combined from several solutions found on StackOverflow. It seems there is no canonical way of doing this, so I'm not sure this is correct.

1. I randomly set a hardcoded 2.5 seconds timeout. I've actually seen server replying to this request with formatting edits in 3.5s on a big file. It's hard to choose a reasonable time limit: user may get frustrated with the delay on save as well as with the constant error messages. Probably a higher time limit + a spinning wheel while would be a good compromise?

1. I think it would make sense to cancel request on timeout, but I don't know how to do it: `LanguageClientConnection` doesn't have a method for `$/cancelRequest` and even if it did, where do I get the request id? I see `cancellationToken`s somewhere, but is it only for the server-cancelled requests?