### PR TITLE
Split off AtomIDE-specific parts from AutoLanguageClient

### DIFF
--- a/lib/adapters/apply-edit-adapter.ts
+++ b/lib/adapters/apply-edit-adapter.ts
@@ -29,7 +29,7 @@ export default class ApplyEditAdapter {
     try {
       // Sort edits in reverse order to prevent edit conflicts.
       edits.sort((edit1, edit2) => -edit1.oldRange.compare(edit2.oldRange));
-      edits.reduce((previous, current) => {
+      edits.reduce((previous: atomIde.TextEdit | null, current) => {
         ApplyEditAdapter.validateEdit(buffer, current, previous);
         buffer.setTextInRange(current.oldRange, current.newText);
         return current;

--- a/lib/adapters/document-sync-adapter.ts
+++ b/lib/adapters/document-sync-adapter.ts
@@ -96,7 +96,7 @@ export default class DocumentSyncAdapter {
   //
   // * `editor` A {TextEditor} to consider for observation.
   public observeTextEditor(editor: TextEditor): void {
-    const listener = editor.observeGrammar((grammar) => this._handleGrammarChange(editor));
+    const listener = editor.observeGrammar((_grammar) => this._handleGrammarChange(editor));
     this._disposable.add(
       editor.onDidDestroy(() => {
         this._disposable.remove(listener);

--- a/lib/adapters/document-sync-adapter.ts
+++ b/lib/adapters/document-sync-adapter.ts
@@ -111,6 +111,7 @@ export default class DocumentSyncAdapter {
     if (sync != null && !this._editorSelector(editor)) {
       this._editors.delete(editor);
       this._disposable.remove(sync);
+      sync.didClose();
       sync.dispose();
     } else if (sync == null && this._editorSelector(editor)) {
       this._handleNewEditor(editor);

--- a/lib/adapters/logging-console-adapter.ts
+++ b/lib/adapters/logging-console-adapter.ts
@@ -34,10 +34,6 @@ export default class LoggingConsoleAdapter {
     this._consoles.clear();
   }
 
-  private generateId(): string {
-    return new Date().toISOString();
-  }
-
   // Log a message using the Atom IDE UI Console API.
   //
   // * `params` The {LogMessageParams} received from the language server

--- a/lib/adapters/notifications-adapter.ts
+++ b/lib/adapters/notifications-adapter.ts
@@ -37,7 +37,7 @@ export default class NotificationsAdapter {
     name: string,
     projectPath: string,
   ): Promise<MessageActionItem | null> {
-    return new Promise((resolve, reject) => {
+    return new Promise((resolve, _reject) => {
       const options: NotificationOptions = {
         dismissable: true,
         detail: `${name} ${projectPath}`,

--- a/lib/auto-languageclient.ts
+++ b/lib/auto-languageclient.ts
@@ -53,27 +53,27 @@ export type ConnectionType = 'stdio' | 'socket' | 'ipc';
 // getServerName.
 export default class AutoLanguageClient {
   private _disposable = new CompositeDisposable();
-  private _serverManager: ServerManager;
-  private _consoleDelegate: atomIde.ConsoleService;
-  private _linterDelegate: linter.IndieDelegate;
-  private _signatureHelpRegistry: atomIde.SignatureHelpRegistry | null;
-  private _lastAutocompleteRequest: AutocompleteRequest;
-  private _isDeactivating: boolean;
+  private _serverManager!: ServerManager;
+  private _consoleDelegate?: atomIde.ConsoleService;
+  private _linterDelegate?: linter.IndieDelegate;
+  private _signatureHelpRegistry?: atomIde.SignatureHelpRegistry;
+  private _lastAutocompleteRequest?: AutocompleteRequest;
+  private _isDeactivating: boolean = false;
 
   // Available if consumeBusySignal is setup
-  protected busySignalService: atomIde.BusySignalService;
+  protected busySignalService!: atomIde.BusySignalService;
 
   protected processStdErr: string = '';
-  protected logger: Logger;
-  protected name: string;
-  protected socket: Socket;
+  protected logger!: Logger;
+  protected name!: string;
+  protected socket!: Socket;
 
   // Shared adapters that can take the RPC connection as required
-  protected autoComplete: AutocompleteAdapter;
-  protected datatip: DatatipAdapter;
-  protected definitions: DefinitionAdapter;
-  protected findReferences: FindReferencesAdapter;
-  protected outlineView: OutlineViewAdapter;
+  protected autoComplete?: AutocompleteAdapter;
+  protected datatip?: DatatipAdapter;
+  protected definitions?: DefinitionAdapter;
+  protected findReferences?: FindReferencesAdapter;
+  protected outlineView?: OutlineViewAdapter;
 
   // You must implement these so we know how to deal with your language and server
   // -------------------------------------------------------------------------
@@ -94,7 +94,7 @@ export default class AutoLanguageClient {
   }
 
   // Start your server process
-  protected startServerProcess(projectPath: string): LanguageServerProcess | Promise<LanguageServerProcess> {
+  protected startServerProcess(_projectPath: string): LanguageServerProcess | Promise<LanguageServerProcess> {
     throw Error('Must override startServerProcess to start language server process when extending AutoLanguageClient');
   }
 
@@ -192,10 +192,10 @@ export default class AutoLanguageClient {
   }
 
   // Early wire-up of listeners before initialize method is sent
-  protected preInitialization(connection: LanguageClientConnection): void {}
+  protected preInitialization(_connection: LanguageClientConnection): void {}
 
   // Late wire-up of listeners after initialize method has been sent
-  protected postInitialization(server: ActiveServer): void {}
+  protected postInitialization(_server: ActiveServer): void {}
 
   // Determine whether to use ipc, stdio or socket to connect to the server
   protected getConnectionType(): ConnectionType {
@@ -380,9 +380,9 @@ export default class AutoLanguageClient {
     }
 
     return rpc.createMessageConnection(reader, writer, {
-      log: (...args: any[]) => {},
-      warn: (...args: any[]) => {},
-      info: (...args: any[]) => {},
+      log: (..._args: any[]) => {},
+      warn: (..._args: any[]) => {},
+      info: (..._args: any[]) => {},
       error: (...args: any[]) => {
         this.logger.error(args);
       },
@@ -476,13 +476,13 @@ export default class AutoLanguageClient {
   }
 
   protected onDidConvertAutocomplete(
-    completionItem: ls.CompletionItem,
-    suggestion: AutocompleteSuggestion,
-    request: AutocompleteRequest,
+    _completionItem: ls.CompletionItem,
+    _suggestion: AutocompleteSuggestion,
+    _request: AutocompleteRequest,
   ): void {
   }
 
-  protected onDidInsertSuggestion(arg: AutocompleteDidInsert): void {}
+  protected onDidInsertSuggestion(_arg: AutocompleteDidInsert): void {}
 
   // Definitions via LS documentHighlight and gotoDefinition------------
   public provideDefinitions(): atomIde.DefinitionProvider {
@@ -673,7 +673,7 @@ export default class AutoLanguageClient {
       }
     }
     return new Disposable(() => {
-      this._signatureHelpRegistry = null;
+      this._signatureHelpRegistry = undefined;
     });
   }
 
@@ -687,7 +687,7 @@ export default class AutoLanguageClient {
    * @param filePath path of a file that has changed in the project path
    * @return false => message will not be sent to the language server
    */
-  protected filterChangeWatchedFiles(filePath: string): boolean {
+  protected filterChangeWatchedFiles(_filePath: string): boolean {
     return true;
   }
 
@@ -695,7 +695,7 @@ export default class AutoLanguageClient {
    * Called on language server stderr output.
    * @param stderr a chunk of stderr from a language server instance
    */
-  private handleServerStderr(stderr: string, projectPath: string) {
+  private handleServerStderr(stderr: string, _projectPath: string) {
     stderr.split('\n').filter((l) => l).forEach((line) => this.logger.warn(`stderr ${line}`));
   }
 }

--- a/lib/auto-languageclient.ts
+++ b/lib/auto-languageclient.ts
@@ -101,7 +101,7 @@ export default class AutoLanguageClient extends BaseLanguageClient {
           server.connection,
           (editor) => this.shouldSyncForEditor(editor, server.projectPath),
           server.capabilities.textDocumentSync,
-          this.busySignalService,
+          this.reportBusyWhile.bind(this),
         );
       server.disposable.add(docSyncAdapter);
     }

--- a/lib/auto-languageclient.ts
+++ b/lib/auto-languageclient.ts
@@ -1,10 +1,6 @@
-import * as cp from 'child_process';
 import * as ls from './languageclient';
-import * as rpc from 'vscode-jsonrpc';
-import * as path from 'path';
 import * as atomIde from 'atom-ide';
 import * as linter from 'atom/linter';
-import Convert from './convert.js';
 import ApplyEditAdapter from './adapters/apply-edit-adapter';
 import AutocompleteAdapter from './adapters/autocomplete-adapter';
 import CodeActionAdapter from './adapters/code-action-adapter';
@@ -19,17 +15,9 @@ import LoggingConsoleAdapter from './adapters/logging-console-adapter';
 import NotificationsAdapter from './adapters/notifications-adapter';
 import OutlineViewAdapter from './adapters/outline-view-adapter';
 import SignatureHelpAdapter from './adapters/signature-help-adapter';
-import Utils from './utils';
-import { Socket } from 'net';
 import { LanguageClientConnection } from './languageclient';
 import {
-  ConsoleLogger,
-  NullLogger,
-  Logger,
-} from './logger';
-import {
   LanguageServerProcess,
-  ServerManager,
   ActiveServer,
 } from './server-manager.js';
 import {
@@ -37,36 +25,36 @@ import {
   AutocompleteProvider,
   AutocompleteRequest,
   AutocompleteSuggestion,
-  CompositeDisposable,
   Disposable,
   Point,
   Range,
   TextEditor,
 } from 'atom';
+import BaseLanguageClient from './base-languageclient';
 
 export { ActiveServer, LanguageClientConnection, LanguageServerProcess };
 export type ConnectionType = 'stdio' | 'socket' | 'ipc';
+
+export interface ServerAdapters {
+  linterPushV2: LinterPushV2Adapter;
+  loggingConsole: LoggingConsoleAdapter;
+  docSyncAdapter?: DocumentSyncAdapter;
+  signatureHelpAdapter?: SignatureHelpAdapter;
+}
 
 // Public: AutoLanguageClient provides a simple way to have all the supported
 // Atom-IDE services wired up entirely for you by just subclassing it and
 // implementing startServerProcess/getGrammarScopes/getLanguageName and
 // getServerName.
-export default class AutoLanguageClient {
-  private _disposable = new CompositeDisposable();
-  private _serverManager!: ServerManager;
+export default class AutoLanguageClient extends BaseLanguageClient {
   private _consoleDelegate?: atomIde.ConsoleService;
   private _linterDelegate?: linter.IndieDelegate;
   private _signatureHelpRegistry?: atomIde.SignatureHelpRegistry;
   private _lastAutocompleteRequest?: AutocompleteRequest;
-  private _isDeactivating: boolean = false;
+  private _serverAdapters = new WeakMap<ActiveServer, ServerAdapters>();
 
   // Available if consumeBusySignal is setup
-  protected busySignalService!: atomIde.BusySignalService;
-
-  protected processStdErr: string = '';
-  protected logger!: Logger;
-  protected name!: string;
-  protected socket!: Socket;
+  protected busySignalService?: atomIde.BusySignalService;
 
   // Shared adapters that can take the RPC connection as required
   protected autoComplete?: AutocompleteAdapter;
@@ -98,340 +86,70 @@ export default class AutoLanguageClient {
     throw Error('Must override startServerProcess to start language server process when extending AutoLanguageClient');
   }
 
-  // You might want to override these for different behavior
-  // ---------------------------------------------------------------------------
-
-  // Determine whether we should start a server for a given editor if we don't have one yet
-  protected shouldStartForEditor(editor: TextEditor): boolean {
-    return this.getGrammarScopes().includes(editor.getGrammar().scopeName);
-  }
-
-  // Return the parameters used to initialize a client - you may want to extend capabilities
-  protected getInitializeParams(projectPath: string, process: LanguageServerProcess): ls.InitializeParams {
-    return {
-      processId: process.pid,
-      rootPath: projectPath,
-      rootUri: Convert.pathToUri(projectPath),
-      capabilities: {
-        workspace: {
-          applyEdit: true,
-          workspaceEdit: {
-            documentChanges: true,
-          },
-          didChangeConfiguration: {
-            dynamicRegistration: false,
-          },
-          didChangeWatchedFiles: {
-            dynamicRegistration: false,
-          },
-          symbol: {
-            dynamicRegistration: false,
-          },
-          executeCommand: {
-            dynamicRegistration: false,
-          },
-        },
-        textDocument: {
-          synchronization: {
-            dynamicRegistration: false,
-            willSave: true,
-            willSaveWaitUntil: true,
-            didSave: true,
-          },
-          completion: {
-            dynamicRegistration: false,
-            completionItem: {
-              snippetSupport: true,
-              commitCharactersSupport: false,
-            },
-            contextSupport: true,
-          },
-          hover: {
-            dynamicRegistration: false,
-          },
-          signatureHelp: {
-            dynamicRegistration: false,
-          },
-          references: {
-            dynamicRegistration: false,
-          },
-          documentHighlight: {
-            dynamicRegistration: false,
-          },
-          documentSymbol: {
-            dynamicRegistration: false,
-          },
-          formatting: {
-            dynamicRegistration: false,
-          },
-          rangeFormatting: {
-            dynamicRegistration: false,
-          },
-          onTypeFormatting: {
-            dynamicRegistration: false,
-          },
-          definition: {
-            dynamicRegistration: false,
-          },
-          codeAction: {
-            dynamicRegistration: false,
-          },
-          codeLens: {
-            dynamicRegistration: false,
-          },
-          documentLink: {
-            dynamicRegistration: false,
-          },
-          rename: {
-            dynamicRegistration: false,
-          },
-        },
-        experimental: {},
-      },
-    };
-  }
-
-  // Early wire-up of listeners before initialize method is sent
-  protected preInitialization(_connection: LanguageClientConnection): void {}
-
-  // Late wire-up of listeners after initialize method has been sent
-  protected postInitialization(_server: ActiveServer): void {}
-
-  // Determine whether to use ipc, stdio or socket to connect to the server
-  protected getConnectionType(): ConnectionType {
-    return this.socket != null ? 'socket' : 'stdio';
-  }
-
-  // Return the name of your root configuration key
-  protected getRootConfigurationKey(): string {
-    return '';
-  }
-
-  // Optionally transform the configuration object before it is sent to the server
-  protected mapConfigurationObject(configuration: any): any {
-    return configuration;
-  }
-
-  // Helper methods that are useful for implementors
-  // ---------------------------------------------------------------------------
-
-  // Gets a LanguageClientConnection for a given TextEditor
-  protected async getConnectionForEditor(editor: TextEditor): Promise<LanguageClientConnection | null> {
-    const server = await this._serverManager.getServer(editor);
-    return server ? server.connection : null;
-  }
-
-  // Restart all active language servers for this language client in the workspace
-  protected async restartAllServers() {
-    await this._serverManager.restartAllServers();
-  }
-
   // Default implementation of the rest of the AutoLanguageClient
   // ---------------------------------------------------------------------------
 
-  // Activate does very little for perf reasons - hooks in via ServerManager for later 'activation'
-  public activate(): void {
-    this.name = `${this.getLanguageName()} (${this.getServerName()})`;
-    this.logger = this.getLogger();
-    this._serverManager = new ServerManager(
-      (p) => this.startServer(p),
-      this.logger,
-      (e) => this.shouldStartForEditor(e),
-      (filepath) => this.filterChangeWatchedFiles(filepath),
-      () => this.busySignalService,
-      this.getServerName(),
-    );
-    this._serverManager.startListening();
-    process.on('exit', () => this.exitCleanup.bind(this));
-  }
-
-  private exitCleanup(): void {
-    this._serverManager.terminate();
-  }
-
-  // Deactivate disposes the resources we're using
-  public async deactivate(): Promise<any> {
-    this._isDeactivating = true;
-    this._disposable.dispose();
-    this._serverManager.stopListening();
-    await this._serverManager.stopAllServers();
-  }
-
-  protected spawnChildNode(args: string[], options: cp.SpawnOptions = {}): cp.ChildProcess {
-    this.logger.debug(`starting child Node "${args.join(' ')}"`);
-    options.env = options.env || Object.create(process.env);
-    options.env.ELECTRON_RUN_AS_NODE = '1';
-    options.env.ELECTRON_NO_ATTACH_CONSOLE = '1';
-    return cp.spawn(process.execPath, args, options);
-  }
-
-  // By default LSP logging is switched off but you can switch it on via the core.debugLSP setting
-  protected getLogger(): Logger {
-    return atom.config.get('core.debugLSP') ? new ConsoleLogger(this.name) : new NullLogger();
-  }
-
-  // Starts the server by starting the process, then initializing the language server and starting adapters
-  private async startServer(projectPath: string): Promise<ActiveServer> {
-    const startingSignal = this.busySignalService && this.busySignalService.reportBusy(
-      `Starting ${this.getServerName()} for ${path.basename(projectPath)}`,
-    );
-    let process;
-    try {
-      process = await this.startServerProcess(projectPath);
-    } finally {
-      startingSignal && startingSignal.dispose();
-    }
-    this.captureServerErrors(process, projectPath);
-    const connection = new LanguageClientConnection(this.createRpcConnection(process), this.logger);
-    this.preInitialization(connection);
-    const initializeParams = this.getInitializeParams(projectPath, process);
-    const initialization = connection.initialize(initializeParams);
-    this.busySignalService && this.busySignalService.reportBusyWhile(
-      `${this.getServerName()} initializing for ${path.basename(projectPath)}`,
-      () => initialization,
-    );
-    const initializeResponse = await initialization;
-    const newServer = {
-      projectPath,
-      process,
-      connection,
-      capabilities: initializeResponse.capabilities,
-      disposable: new CompositeDisposable(),
-    };
-    this.postInitialization(newServer);
-    connection.initialized();
-    connection.on('close', () => {
-      if (!this._isDeactivating) {
-        this._serverManager.stopServer(newServer);
-        if (!this._serverManager.hasServerReachedRestartLimit(newServer)) {
-          this.logger.debug(`Restarting language server for project '${newServer.projectPath}'`);
-          this._serverManager.startServer(projectPath);
-        } else {
-          this.logger.warn(`Language server has exceeded auto-restart limit for project '${newServer.projectPath}'`);
-          atom.notifications.addError(
-            // tslint:disable-next-line:max-line-length
-            `The ${this.name} language server has exited and exceeded the restart limit for project '${newServer.projectPath}'`);
-        }
-      }
-    });
-
-    const configurationKey = this.getRootConfigurationKey();
-    if (configurationKey) {
-      this._disposable.add(
-        atom.config.observe(configurationKey, (config) => {
-          const mappedConfig = this.mapConfigurationObject(config || {});
-          if (mappedConfig) {
-            connection.didChangeConfiguration({
-              settings: mappedConfig,
-            });
-          }
-        }));
-    }
-
-    this.startExclusiveAdapters(newServer);
-    return newServer;
-  }
-
-  private captureServerErrors(childProcess: LanguageServerProcess, projectPath: string): void {
-    childProcess.on('error', (err) => this.handleSpawnFailure(err));
-    childProcess.on('exit', (code, signal) => this.logger.debug(`exit: code ${code} signal ${signal}`));
-    childProcess.stderr.setEncoding('utf8');
-    childProcess.stderr.on('data', (chunk: Buffer) => {
-      const errorString = chunk.toString();
-      this.handleServerStderr(errorString, projectPath);
-      // Keep the last 5 lines for packages to use in messages
-      this.processStdErr = (this.processStdErr + errorString)
-        .split('\n')
-        .slice(-5)
-        .join('\n');
-    });
-  }
-
-  private handleSpawnFailure(err: any): void {
-    atom.notifications.addError(
-      `${this.getServerName()} language server for ${this.getLanguageName()} unable to start`,
-      {
-        dismissable: true,
-        description: err.toString(),
-      },
-    );
-  }
-
-  // Creates the RPC connection which can be ipc, socket or stdio
-  private createRpcConnection(process: LanguageServerProcess): rpc.MessageConnection {
-    let reader: rpc.MessageReader;
-    let writer: rpc.MessageWriter;
-    const connectionType = this.getConnectionType();
-    switch (connectionType) {
-      case 'ipc':
-        reader = new rpc.IPCMessageReader(process as cp.ChildProcess);
-        writer = new rpc.IPCMessageWriter(process as cp.ChildProcess);
-        break;
-      case 'socket':
-        reader = new rpc.SocketMessageReader(this.socket);
-        writer = new rpc.SocketMessageWriter(this.socket);
-        break;
-      case 'stdio':
-        reader = new rpc.StreamMessageReader(process.stdout);
-        writer = new rpc.StreamMessageWriter(process.stdin);
-        break;
-      default:
-        return Utils.assertUnreachable(connectionType);
-    }
-
-    return rpc.createMessageConnection(reader, writer, {
-      log: (..._args: any[]) => {},
-      warn: (..._args: any[]) => {},
-      info: (..._args: any[]) => {},
-      error: (...args: any[]) => {
-        this.logger.error(args);
-      },
-    });
-  }
-
   // Start adapters that are not shared between servers
-  private startExclusiveAdapters(server: ActiveServer): void {
+  protected startExclusiveAdapters(server: ActiveServer): void {
     ApplyEditAdapter.attach(server.connection);
     NotificationsAdapter.attach(server.connection, this.name, server.projectPath);
 
+    let docSyncAdapter;
     if (DocumentSyncAdapter.canAdapt(server.capabilities)) {
-      server.docSyncAdapter =
+      docSyncAdapter =
         new DocumentSyncAdapter(
           server.connection,
           (editor) => this.shouldSyncForEditor(editor, server.projectPath),
           server.capabilities.textDocumentSync,
           this.busySignalService,
         );
-      server.disposable.add(server.docSyncAdapter);
+      server.disposable.add(docSyncAdapter);
     }
 
-    server.linterPushV2 = new LinterPushV2Adapter(server.connection);
+    const linterPushV2 = new LinterPushV2Adapter(server.connection);
     if (this._linterDelegate != null) {
-      server.linterPushV2.attach(this._linterDelegate);
+      linterPushV2.attach(this._linterDelegate);
     }
-    server.disposable.add(server.linterPushV2);
+    server.disposable.add(linterPushV2);
 
-    server.loggingConsole = new LoggingConsoleAdapter(server.connection);
+    const loggingConsole = new LoggingConsoleAdapter(server.connection);
     if (this._consoleDelegate != null) {
-      server.loggingConsole.attach(this._consoleDelegate({ id: this.name, name: 'abc' }));
+      loggingConsole.attach(this._consoleDelegate({ id: this.name, name: 'abc' }));
     }
-    server.disposable.add(server.loggingConsole);
+    server.disposable.add(loggingConsole);
 
+    let signatureHelpAdapter;
     if (SignatureHelpAdapter.canAdapt(server.capabilities)) {
-      server.signatureHelpAdapter = new SignatureHelpAdapter(server, this.getGrammarScopes());
+      signatureHelpAdapter = new SignatureHelpAdapter(server, this.getGrammarScopes());
       if (this._signatureHelpRegistry != null) {
-        server.signatureHelpAdapter.attach(this._signatureHelpRegistry);
+        signatureHelpAdapter.attach(this._signatureHelpRegistry);
       }
-      server.disposable.add(server.signatureHelpAdapter);
+      server.disposable.add(signatureHelpAdapter);
+    }
+
+    this._serverAdapters.set(server, {
+      docSyncAdapter, linterPushV2, loggingConsole, signatureHelpAdapter,
+    });
+  }
+
+  protected reportBusyWhile<T>(message: string, promiseGenerator: () => Promise<T>): Promise<T> {
+    if (this.busySignalService) {
+      return this.busySignalService.reportBusyWhile(message, promiseGenerator);
+    } else {
+      this.logger.info(message);
+      return promiseGenerator();
     }
   }
 
-  public shouldSyncForEditor(editor: TextEditor, projectPath: string): boolean {
-    return this.isFileInProject(editor, projectPath) && this.shouldStartForEditor(editor);
-  }
-
-  protected isFileInProject(editor: TextEditor, projectPath: string): boolean {
-    return (editor.getURI() || '').startsWith(projectPath);
+  protected unsupportedEditorGrammar(server: ActiveServer, editor: TextEditor): void {
+    const adapter = this.getServerAdapter(server, 'docSyncAdapter');
+    if (adapter) {
+      const syncAdapter = adapter.getEditorSyncAdapter(editor);
+      if (syncAdapter) {
+        // Immitate editor close to disconnect LS from the editor
+        syncAdapter.didClose();
+      }
+    }
   }
 
   // Autocomplete+ via LS completion---------------------------------------
@@ -538,8 +256,9 @@ export default class AutoLanguageClient {
     }
 
     for (const server of this._serverManager.getActiveServers()) {
-      if (server.linterPushV2 != null) {
-        server.linterPushV2.attach(this._linterDelegate);
+      const adapter = this.getServerAdapter(server, 'linterPushV2');
+      if (adapter) {
+        adapter.attach(this._linterDelegate);
       }
     }
   }
@@ -592,10 +311,10 @@ export default class AutoLanguageClient {
     this._consoleDelegate = createConsole;
 
     for (const server of this._serverManager.getActiveServers()) {
-      if (server.loggingConsole == null) {
-        server.loggingConsole = new LoggingConsoleAdapter(server.connection);
+      const adapter = this.getServerAdapter(server, 'loggingConsole');
+      if (adapter) {
+        adapter.attach(this._consoleDelegate({ id: this.name, name: 'abc' }));
       }
-      server.loggingConsole.attach(this._consoleDelegate({ id: this.name, name: 'abc' }));
     }
 
     // No way of detaching from client connections today
@@ -658,7 +377,7 @@ export default class AutoLanguageClient {
     return CodeActionAdapter.getCodeActions(
       server.connection,
       server.capabilities,
-      server.linterPushV2,
+      this.getServerAdapter(server, 'linterPushV2'),
       editor,
       range,
       diagnostics,
@@ -668,8 +387,9 @@ export default class AutoLanguageClient {
   public consumeSignatureHelp(registry: atomIde.SignatureHelpRegistry): Disposable {
     this._signatureHelpRegistry = registry;
     for (const server of this._serverManager.getActiveServers()) {
-      if (server.signatureHelpAdapter != null) {
-        server.signatureHelpAdapter.attach(registry);
+      const signatureHelpAdapter = this.getServerAdapter(server, 'signatureHelpAdapter');
+      if (signatureHelpAdapter) {
+        signatureHelpAdapter.attach(registry);
       }
     }
     return new Disposable(() => {
@@ -682,20 +402,10 @@ export default class AutoLanguageClient {
     return new Disposable(() => delete this.busySignalService);
   }
 
-  /**
-   * `didChangeWatchedFiles` message filtering, override for custom logic.
-   * @param filePath path of a file that has changed in the project path
-   * @return false => message will not be sent to the language server
-   */
-  protected filterChangeWatchedFiles(_filePath: string): boolean {
-    return true;
-  }
-
-  /**
-   * Called on language server stderr output.
-   * @param stderr a chunk of stderr from a language server instance
-   */
-  private handleServerStderr(stderr: string, _projectPath: string) {
-    stderr.split('\n').filter((l) => l).forEach((line) => this.logger.warn(`stderr ${line}`));
+  private getServerAdapter<T extends keyof ServerAdapters>(
+    server: ActiveServer, adapter: T,
+  ): ServerAdapters[T] | undefined {
+    const adapters = this._serverAdapters.get(server);
+    return adapters && adapters[adapter];
   }
 }

--- a/lib/base-languageclient.ts
+++ b/lib/base-languageclient.ts
@@ -375,7 +375,7 @@ export default abstract class BaseLanguageClient {
    * Called on language server stderr output.
    * @param stderr a chunk of stderr from a language server instance
    */
-  private handleServerStderr(stderr: string, _projectPath: string) {
+  protected handleServerStderr(stderr: string, _projectPath: string) {
     stderr.split('\n').filter((l) => l).forEach((line) => this.logger.warn(`stderr ${line}`));
   }
 }

--- a/lib/base-languageclient.ts
+++ b/lib/base-languageclient.ts
@@ -59,9 +59,6 @@ export default abstract class BaseLanguageClient {
   // Report busy status
   protected abstract reportBusyWhile<T>(message: string, promiseGenerator: () => Promise<T>): Promise<T>;
 
-  // Handle editor switching to unsupported grammar
-  protected abstract unsupportedEditorGrammar(server: ActiveServer, editor: TextEditor): void;
-
   // You might want to override these for different behavior
   // ---------------------------------------------------------------------------
 
@@ -204,7 +201,6 @@ export default abstract class BaseLanguageClient {
       (filepath) => this.filterChangeWatchedFiles(filepath),
       this.reportBusyWhile.bind(this),
       this.getServerName(),
-      this.unsupportedEditorGrammar.bind(this),
     );
     this._serverManager.startListening();
     process.on('exit', () => this.exitCleanup.bind(this));

--- a/lib/base-languageclient.ts
+++ b/lib/base-languageclient.ts
@@ -1,0 +1,381 @@
+import * as cp from 'child_process';
+import * as ls from './languageclient';
+import * as rpc from 'vscode-jsonrpc';
+import * as path from 'path';
+import Convert from './convert.js';
+import Utils from './utils';
+import { Socket } from 'net';
+import { LanguageClientConnection } from './languageclient';
+import {
+  ConsoleLogger,
+  NullLogger,
+  Logger,
+} from './logger';
+import {
+  LanguageServerProcess,
+  ServerManager,
+  ActiveServer,
+} from './server-manager.js';
+import {
+  CompositeDisposable,
+  TextEditor,
+} from 'atom';
+
+export { ActiveServer, LanguageClientConnection, LanguageServerProcess };
+export type ConnectionType = 'stdio' | 'socket' | 'ipc';
+
+// Public: AutoLanguageClient provides a simple way to have all the supported
+// Atom-IDE services wired up entirely for you by just subclassing it and
+// implementing startServerProcess/getGrammarScopes/getLanguageName and
+// getServerName.
+export default abstract class BaseLanguageClient {
+  private _isDeactivating: boolean = false;
+
+  protected _disposable = new CompositeDisposable();
+  protected processStdErr: string = '';
+  protected _serverManager!: ServerManager;
+  protected logger!: Logger;
+  protected name!: string;
+  protected socket!: Socket;
+
+  // You must implement these so we know how to deal with your language and server
+  // -------------------------------------------------------------------------
+
+  // Return an array of the grammar scopes you handle, e.g. [ 'source.js' ]
+  protected abstract getGrammarScopes(): string[];
+
+  // Return the name of the language you support, e.g. 'JavaScript'
+  protected abstract getLanguageName(): string;
+
+  // Return the name of your server, e.g. 'Eclipse JDT'
+  protected abstract getServerName(): string;
+
+  // Start your server process
+  protected abstract startServerProcess(projectPath: string): LanguageServerProcess | Promise<LanguageServerProcess>;
+
+  // Start adapters that are not shared between servers
+  protected abstract startExclusiveAdapters(server: ActiveServer): void;
+
+  // Report busy status
+  protected abstract reportBusyWhile<T>(message: string, promiseGenerator: () => Promise<T>): Promise<T>;
+
+  // Handle editor switching to unsupported grammar
+  protected abstract unsupportedEditorGrammar(server: ActiveServer, editor: TextEditor): void;
+
+  // You might want to override these for different behavior
+  // ---------------------------------------------------------------------------
+
+  // Determine whether we should start a server for a given editor if we don't have one yet
+  protected shouldStartForEditor(editor: TextEditor): boolean {
+    return this.getGrammarScopes().includes(editor.getGrammar().scopeName);
+  }
+
+  // Return the parameters used to initialize a client - you may want to extend capabilities
+  protected getInitializeParams(projectPath: string, process: LanguageServerProcess): ls.InitializeParams {
+    return {
+      processId: process.pid,
+      rootPath: projectPath,
+      rootUri: Convert.pathToUri(projectPath),
+      capabilities: {
+        workspace: {
+          applyEdit: true,
+          workspaceEdit: {
+            documentChanges: true,
+          },
+          didChangeConfiguration: {
+            dynamicRegistration: false,
+          },
+          didChangeWatchedFiles: {
+            dynamicRegistration: false,
+          },
+          symbol: {
+            dynamicRegistration: false,
+          },
+          executeCommand: {
+            dynamicRegistration: false,
+          },
+        },
+        textDocument: {
+          synchronization: {
+            dynamicRegistration: false,
+            willSave: true,
+            willSaveWaitUntil: true,
+            didSave: true,
+          },
+          completion: {
+            dynamicRegistration: false,
+            completionItem: {
+              snippetSupport: true,
+              commitCharactersSupport: false,
+            },
+            contextSupport: true,
+          },
+          hover: {
+            dynamicRegistration: false,
+          },
+          signatureHelp: {
+            dynamicRegistration: false,
+          },
+          references: {
+            dynamicRegistration: false,
+          },
+          documentHighlight: {
+            dynamicRegistration: false,
+          },
+          documentSymbol: {
+            dynamicRegistration: false,
+          },
+          formatting: {
+            dynamicRegistration: false,
+          },
+          rangeFormatting: {
+            dynamicRegistration: false,
+          },
+          onTypeFormatting: {
+            dynamicRegistration: false,
+          },
+          definition: {
+            dynamicRegistration: false,
+          },
+          codeAction: {
+            dynamicRegistration: false,
+          },
+          codeLens: {
+            dynamicRegistration: false,
+          },
+          documentLink: {
+            dynamicRegistration: false,
+          },
+          rename: {
+            dynamicRegistration: false,
+          },
+        },
+        experimental: {},
+      },
+    };
+  }
+
+  // Early wire-up of listeners before initialize method is sent
+  protected preInitialization(_connection: LanguageClientConnection): void {}
+
+  // Late wire-up of listeners after initialize method has been sent
+  protected postInitialization(_server: ActiveServer): void {}
+
+  // Determine whether to use ipc, stdio or socket to connect to the server
+  protected getConnectionType(): ConnectionType {
+    return this.socket != null ? 'socket' : 'stdio';
+  }
+
+  // Return the name of your root configuration key
+  protected getRootConfigurationKey(): string {
+    return '';
+  }
+
+  // Optionally transform the configuration object before it is sent to the server
+  protected mapConfigurationObject(configuration: any): any {
+    return configuration;
+  }
+
+  // Helper methods that are useful for implementors
+  // ---------------------------------------------------------------------------
+
+  // Gets a LanguageClientConnection for a given TextEditor
+  protected async getConnectionForEditor(editor: TextEditor): Promise<LanguageClientConnection | null> {
+    const server = await this._serverManager.getServer(editor);
+    return server ? server.connection : null;
+  }
+
+  // Restart all active language servers for this language client in the workspace
+  protected async restartAllServers() {
+    await this._serverManager.restartAllServers();
+  }
+
+  // Default implementation of the rest of the AutoLanguageClient
+  // ---------------------------------------------------------------------------
+
+  // Activate does very little for perf reasons - hooks in via ServerManager for later 'activation'
+  public activate(): void {
+    this.name = `${this.getLanguageName()} (${this.getServerName()})`;
+    this.logger = this.getLogger();
+    this._serverManager = new ServerManager(
+      (p) => this.startServer(p),
+      this.logger,
+      (e) => this.shouldStartForEditor(e),
+      (filepath) => this.filterChangeWatchedFiles(filepath),
+      this.reportBusyWhile.bind(this),
+      this.getServerName(),
+      this.unsupportedEditorGrammar.bind(this),
+    );
+    this._serverManager.startListening();
+    process.on('exit', () => this.exitCleanup.bind(this));
+  }
+
+  private exitCleanup(): void {
+    this._serverManager.terminate();
+  }
+
+  // Deactivate disposes the resources we're using
+  public async deactivate(): Promise<any> {
+    this._isDeactivating = true;
+    this._disposable.dispose();
+    this._serverManager.stopListening();
+    await this._serverManager.stopAllServers();
+  }
+
+  protected spawnChildNode(args: string[], options: cp.SpawnOptions = {}): cp.ChildProcess {
+    this.logger.debug(`starting child Node "${args.join(' ')}"`);
+    options.env = options.env || Object.create(process.env);
+    options.env.ELECTRON_RUN_AS_NODE = '1';
+    options.env.ELECTRON_NO_ATTACH_CONSOLE = '1';
+    return cp.spawn(process.execPath, args, options);
+  }
+
+  // By default LSP logging is switched off but you can switch it on via the core.debugLSP setting
+  protected getLogger(): Logger {
+    return atom.config.get('core.debugLSP') ? new ConsoleLogger(this.name) : new NullLogger();
+  }
+
+  private async startServer(projectPath: string): Promise<ActiveServer> {
+    return this.reportBusyWhile(
+      `Starting ${this.getServerName()} for ${path.basename(projectPath)}`,
+      () => this.startServerInternal(projectPath),
+    );
+  }
+
+  // Starts the server by starting the process, then initializing the language server and starting adapters
+  private async startServerInternal(projectPath: string): Promise<ActiveServer> {
+    let process;
+    process = await this.startServerProcess(projectPath);
+    this.captureServerErrors(process, projectPath);
+    const connection = new LanguageClientConnection(this.createRpcConnection(process), this.logger);
+    this.preInitialization(connection);
+    const initializeParams = this.getInitializeParams(projectPath, process);
+    const initialization = connection.initialize(initializeParams);
+    this.reportBusyWhile(
+      `${this.getServerName()} initializing for ${path.basename(projectPath)}`,
+      () => initialization,
+    );
+    const initializeResponse = await initialization;
+    const newServer = {
+      projectPath,
+      process,
+      connection,
+      capabilities: initializeResponse.capabilities,
+      disposable: new CompositeDisposable(),
+    };
+    this.postInitialization(newServer);
+    connection.initialized();
+    connection.on('close', () => {
+      if (!this._isDeactivating) {
+        this._serverManager.stopServer(newServer);
+        if (!this._serverManager.hasServerReachedRestartLimit(newServer)) {
+          this.logger.debug(`Restarting language server for project '${newServer.projectPath}'`);
+          this._serverManager.startServer(projectPath);
+        } else {
+          this.logger.warn(`Language server has exceeded auto-restart limit for project '${newServer.projectPath}'`);
+          atom.notifications.addError(
+            // tslint:disable-next-line:max-line-length
+            `The ${this.name} language server has exited and exceeded the restart limit for project '${newServer.projectPath}'`);
+        }
+      }
+    });
+
+    const configurationKey = this.getRootConfigurationKey();
+    if (configurationKey) {
+      this._disposable.add(
+        atom.config.observe(configurationKey, (config) => {
+          const mappedConfig = this.mapConfigurationObject(config || {});
+          if (mappedConfig) {
+            connection.didChangeConfiguration({
+              settings: mappedConfig,
+            });
+          }
+        }));
+    }
+
+    this.startExclusiveAdapters(newServer);
+    return newServer;
+  }
+
+  private captureServerErrors(childProcess: LanguageServerProcess, projectPath: string): void {
+    childProcess.on('error', (err) => this.handleSpawnFailure(err));
+    childProcess.on('exit', (code, signal) => this.logger.debug(`exit: code ${code} signal ${signal}`));
+    childProcess.stderr.setEncoding('utf8');
+    childProcess.stderr.on('data', (chunk: Buffer) => {
+      const errorString = chunk.toString();
+      this.handleServerStderr(errorString, projectPath);
+      // Keep the last 5 lines for packages to use in messages
+      this.processStdErr = (this.processStdErr + errorString)
+        .split('\n')
+        .slice(-5)
+        .join('\n');
+    });
+  }
+
+  private handleSpawnFailure(err: any): void {
+    atom.notifications.addError(
+      `${this.getServerName()} language server for ${this.getLanguageName()} unable to start`,
+      {
+        dismissable: true,
+        description: err.toString(),
+      },
+    );
+  }
+
+  // Creates the RPC connection which can be ipc, socket or stdio
+  private createRpcConnection(process: LanguageServerProcess): rpc.MessageConnection {
+    let reader: rpc.MessageReader;
+    let writer: rpc.MessageWriter;
+    const connectionType = this.getConnectionType();
+    switch (connectionType) {
+      case 'ipc':
+        reader = new rpc.IPCMessageReader(process as cp.ChildProcess);
+        writer = new rpc.IPCMessageWriter(process as cp.ChildProcess);
+        break;
+      case 'socket':
+        reader = new rpc.SocketMessageReader(this.socket);
+        writer = new rpc.SocketMessageWriter(this.socket);
+        break;
+      case 'stdio':
+        reader = new rpc.StreamMessageReader(process.stdout);
+        writer = new rpc.StreamMessageWriter(process.stdin);
+        break;
+      default:
+        return Utils.assertUnreachable(connectionType);
+    }
+
+    return rpc.createMessageConnection(reader, writer, {
+      log: (..._args: any[]) => {},
+      warn: (..._args: any[]) => {},
+      info: (..._args: any[]) => {},
+      error: (...args: any[]) => {
+        this.logger.error(args);
+      },
+    });
+  }
+
+  public shouldSyncForEditor(editor: TextEditor, projectPath: string): boolean {
+    return this.isFileInProject(editor, projectPath) && this.shouldStartForEditor(editor);
+  }
+
+  protected isFileInProject(editor: TextEditor, projectPath: string): boolean {
+    return (editor.getURI() || '').startsWith(projectPath);
+  }
+
+  /**
+   * `didChangeWatchedFiles` message filtering, override for custom logic.
+   * @param filePath path of a file that has changed in the project path
+   * @return false => message will not be sent to the language server
+   */
+  protected filterChangeWatchedFiles(_filePath: string): boolean {
+    return true;
+  }
+
+  /**
+   * Called on language server stderr output.
+   * @param stderr a chunk of stderr from a language server instance
+   */
+  private handleServerStderr(stderr: string, _projectPath: string) {
+    stderr.split('\n').filter((l) => l).forEach((line) => this.logger.warn(`stderr ${line}`));
+  }
+}

--- a/lib/logger.ts
+++ b/lib/logger.ts
@@ -52,9 +52,9 @@ export class ConsoleLogger {
 }
 
 export class NullLogger {
-  public warn(...args: any[]): void {}
-  public error(...args: any[]): void {}
-  public info(...args: any[]): void {}
-  public log(...args: any[]): void {}
-  public debug(...args: any[]): void {}
+  public warn(..._args: any[]): void {}
+  public error(..._args: any[]): void {}
+  public info(..._args: any[]): void {}
+  public log(..._args: any[]): void {}
+  public debug(..._args: any[]): void {}
 }

--- a/lib/main.ts
+++ b/lib/main.ts
@@ -4,6 +4,7 @@
 // tslint:enable:no-reference
 
 import AutoLanguageClient from './auto-languageclient';
+import BaseLanguageClient from './base-languageclient';
 import Convert from './convert';
 import DownloadFile from './download-file';
 import LinterPushV2Adapter from './adapters/linter-push-v2-adapter';
@@ -11,6 +12,7 @@ import LinterPushV2Adapter from './adapters/linter-push-v2-adapter';
 export * from './auto-languageclient';
 export {
   AutoLanguageClient,
+  BaseLanguageClient,
   Convert,
   DownloadFile,
   LinterPushV2Adapter,

--- a/lib/server-manager.ts
+++ b/lib/server-manager.ts
@@ -103,7 +103,7 @@ export class ServerManager {
 
   private observeTextEditors(editor: TextEditor): void {
     // Track grammar changes for opened editors
-    const listener = editor.observeGrammar((grammar) => this._handleGrammarChange(editor));
+    const listener = editor.observeGrammar((_grammar) => this._handleGrammarChange(editor));
     this._disposable.add(editor.onDidDestroy(() => listener.dispose()));
     // Try to see if editor can have LS connected to it
     this._handleTextEditor(editor);

--- a/lib/server-manager.ts
+++ b/lib/server-manager.ts
@@ -61,7 +61,6 @@ export class ServerManager {
     private _changeWatchedFileFilter: (filePath: string) => boolean,
     private _reportBusyWhile: ReportBusyWhile,
     private _languageServerName: string,
-    private _unsupportedEditorGrammar: (server: ActiveServer, editor: TextEditor) => void,
   ) {
     this.updateNormalizedProjectPaths();
   }
@@ -118,8 +117,6 @@ export class ServerManager {
       const server = this._editorToServer.get(editor);
       // If LS is running for the unsupported editor then disconnect the editor from LS and shut down LS if necessary
       if (server) {
-        // LS is up for unsupported server
-        this._unsupportedEditorGrammar(server, editor);
         // Remove editor from the cache
         this._editorToServer.delete(editor);
         // Shut down LS if it's used by any other editor

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -16,8 +16,7 @@ export default class Utils {
    * Uses the non-word characters from the position's grammar scope.
    */
   public static getWordAtPosition(editor: TextEditor, position: Point): Range {
-    const scopeDescriptor = editor.scopeDescriptorForBufferPosition(position);
-    const nonWordCharacters = Utils.escapeRegExp(editor.getNonWordCharacters(scopeDescriptor));
+    const nonWordCharacters = Utils.escapeRegExp(editor.getNonWordCharacters(position));
     const range = Utils._getRegexpRangeAtPosition(
       editor.getBuffer(),
       position,

--- a/package.json
+++ b/package.json
@@ -35,6 +35,6 @@
     "mocha-appveyor-reporter": "^0.4.0",
     "sinon": "^2.0.0",
     "tslint": "^5.9.1",
-    "typescript": "^2.7.2"
+    "typescript": "~2.8.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "test": "npm run compile && npm run lint && atom --test build/test"
   },
   "dependencies": {
-    "@types/atom": "^1.24.1",
+    "@types/atom": "~1.25.0",
     "@types/node": "^8.0.41",
     "fuzzaldrin-plus": "^0.6.0",
     "vscode-jsonrpc": "^3.5.0",

--- a/test/adapters/autocomplete-adapter.test.ts
+++ b/test/adapters/autocomplete-adapter.test.ts
@@ -35,7 +35,7 @@ describe('AutoCompleteAdapter', () => {
     editor: createFakeEditor(),
     bufferPosition: new Point(123, 456),
     prefix: 'lab',
-    scopeDescriptor: 'some.scope',
+    scopeDescriptor: { getScopesArray() { return ['some.scope']; } },
     activatedManually: true,
   };
 
@@ -163,7 +163,7 @@ describe('AutoCompleteAdapter', () => {
         Array.from(
           autoCompleteAdapter.completionItemsToSuggestions(completionList, request, (c, a, r) => {
             a.text = c.label + ' ok';
-            a.displayText = r.scopeDescriptor;
+            a.displayText = r.scopeDescriptor.getScopesArray()[0];
           }));
 
       expect(results.length).equals(4);
@@ -218,7 +218,7 @@ describe('AutoCompleteAdapter', () => {
         editor: createFakeEditor(),
         bufferPosition: new Point(123, 456),
         prefix: 'def',
-        scopeDescriptor: 'some.scope',
+        scopeDescriptor: { getScopesArray() { return ['some.scope']; } },
       };
       sinon.stub(autocompleteRequest.editor, 'getTextInBufferRange').returns('replacementPrefix');
       const result: any = { };

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,8 +7,12 @@
         "declaration": true,
         "inlineSources": true,
         "inlineSourceMap": true,
-        "strictNullChecks": true,
+        "strict": true,
         "noImplicitAny": true,
+        "noFallthroughCasesInSwitch": true,
+        "noImplicitReturns": true,
+        "noUnusedLocals": true,
+        "noUnusedParameters": true,
         "baseUrl": "./"
     },
     "include": [

--- a/typings/atom/index.d.ts
+++ b/typings/atom/index.d.ts
@@ -4,7 +4,7 @@ declare module 'atom' {
   interface TextEditor {
     getURI(): string | null;
     getBuffer(): TextBuffer;
-    getNonWordCharacters(scope: ScopeDescriptor): string;
+    getNonWordCharacters(position: Point): string;
   }
 
   export interface ProjectFileEvent {

--- a/typings/atom/index.d.ts
+++ b/typings/atom/index.d.ts
@@ -50,7 +50,7 @@ declare module 'atom' {
   interface AutocompleteRequest {
     editor: TextEditor;
     bufferPosition: Point;
-    scopeDescriptor: string;
+    scopeDescriptor: ScopeDescriptor;
     prefix: string;
     activatedManually?: boolean;
   }


### PR DESCRIPTION
I was doing something strange with the code, namely, using it to simplify working with a language server but not actually using any adapters (because I was trying to adapt it to a completely different stack), and the code was getting increasingly monkey-patchey, to the point of hurting my brain (and pride).

So here I come with a proposal: can we split parts that are not directly dependent on adapters into `BaseLanguageClient` and export that?

I also enabled TypeScripts's strict mode and some optional checks, added some types and fixed a bug or two while at it.

There are more things on top of this that I did, namely cleaning up Atom typings and adding a prettier code formatter to the set-up (which I find saves a lot of keystrokes when tslint is set up to complain about formatting), but decided to split those out for the sake of simplicity. When (if) this is merged, I will create more PRs.

The main idea here is to untie adapters from `ActiveServer`, `ServerManager` and all `AutoLanguageClient` parts that don't depend on adapters directly (the latter are moved more or less verbatim to `BaseLanguageClient`). The only tricky parts are in `server-manager.ts`, specifically, `unsupportedEditorGrammar` is a bit of a hack (but let's face it, that part was a bit of a hack in the first place)

As a side effect, *some* properties that were marked `private` now became `protected`. I don't think this is a huge deal since there's no concept of `private` in JS in the first place, but let me know if you think otherwise.

There's one bugfix related to incorrect type for `TextEditor.getNonWordCharacters` -- just something I noticed in passing. Feel free to cherry-pick.

There's another type-related fix, where `scopeDescriptor` type in autocomplete-plus completion request isn't right, but it doesn't seem like it affects the actual code.