### PR TITLE
Do not use autocomplete cache unless explicit trigger character is set

### DIFF
--- a/lib/adapters/autocomplete-adapter.ts
+++ b/lib/adapters/autocomplete-adapter.ts
@@ -80,7 +80,7 @@ export default class AutocompleteAdapter {
     let suggestionMap = null;
 
     // Do we have complete cached suggestions that are still valid for this request
-    if (cache && !cache.isIncomplete && cache.triggerChar === triggerChar && cache.triggerPoint.isEqual(triggerPoint)) {
+    if (cache && !cache.isIncomplete && triggerChar !== '' && cache.triggerChar === triggerChar && cache.triggerPoint.isEqual(triggerPoint)) {
       suggestionMap = cache.suggestionMap;
     } else {
       // Our cached suggestions can't be used so obtain new ones from the language server

--- a/lib/adapters/autocomplete-adapter.ts
+++ b/lib/adapters/autocomplete-adapter.ts
@@ -80,7 +80,8 @@ export default class AutocompleteAdapter {
     let suggestionMap = null;
 
     // Do we have complete cached suggestions that are still valid for this request
-    if (cache && !cache.isIncomplete && triggerChar !== '' && cache.triggerChar === triggerChar && cache.triggerPoint.isEqual(triggerPoint)) {
+    if (cache && !cache.isIncomplete && triggerChar !== '' &&
+        cache.triggerChar === triggerChar && cache.triggerPoint.isEqual(triggerPoint)) {
       suggestionMap = cache.suggestionMap;
     } else {
       // Our cached suggestions can't be used so obtain new ones from the language server


### PR DESCRIPTION
During an autocomplete request if no explicit trigger character is set the cache should not be reused as we cannot tell from the trigger character alone (always "") if the prefix is the same. This manifests as a bug when a user changes the prefix after an autocomplete request has been serviced and the autocomplete results are not updated. 