### PR TITLE
Compare actual notification message text to determine duplicates

### DIFF
--- a/lib/adapters/notifications-adapter.ts
+++ b/lib/adapters/notifications-adapter.ts
@@ -120,6 +120,7 @@ function addNotificationForMessage(
     const noteOptions = note.getOptions && note.getOptions() || {};
     return !noteDismissed &&
       note.getType() === messageTypeToString(messageType) &&
+      note.getMessage() === message &&
       noteOptions.detail === options.detail;
   }
   if (atom.notifications.getNotifications().some(isDuplicate)) {


### PR DESCRIPTION
Notifications deduplication compares only notification type and _details_, but not the message text. This lead to a problem where these two notifications were treated as equal:

<img width="396" alt="screen shot 2018-04-21 at 02 52 10" src="https://user-images.githubusercontent.com/766656/39078923-aae1e426-4511-11e8-97c3-bd0c6b4670a0.png">

and therefore the second one was never shown to the user.

Probably `options.detail` was meant to be used for comparison of the notifications text, but it's always the same: server name + project path, so it would treat as duplicates any messages of the same type from the same project/server.