### PR TITLE
Refactors

### DIFF
--- a/lib/adapters/apply-edit-adapter.ts
+++ b/lib/adapters/apply-edit-adapter.ts
@@ -29,7 +29,7 @@ export default class ApplyEditAdapter {
     try {
       // Sort edits in reverse order to prevent edit conflicts.
       edits.sort((edit1, edit2) => -edit1.oldRange.compare(edit2.oldRange));
-      edits.reduce((previous, current) => {
+      edits.reduce((previous: atomIde.TextEdit | null, current) => {
         ApplyEditAdapter.validateEdit(buffer, current, previous);
         buffer.setTextInRange(current.oldRange, current.newText);
         return current;

--- a/lib/adapters/autocomplete-adapter.ts
+++ b/lib/adapters/autocomplete-adapter.ts
@@ -1,5 +1,5 @@
 import Convert from '../convert';
-import Utils from '../utils';
+import * as Utils from '../utils';
 import { CancellationTokenSource } from 'vscode-jsonrpc';
 import { ActiveServer } from '../server-manager';
 import { filter } from 'fuzzaldrin-plus';

--- a/lib/adapters/datatip-adapter.ts
+++ b/lib/adapters/datatip-adapter.ts
@@ -1,6 +1,6 @@
 import * as atomIde from 'atom-ide';
 import Convert from '../convert';
-import Utils from '../utils';
+import * as Utils from '../utils';
 import {
   Hover,
   LanguageClientConnection,

--- a/lib/adapters/definition-adapter.ts
+++ b/lib/adapters/definition-adapter.ts
@@ -1,6 +1,6 @@
 import * as atomIde from 'atom-ide';
 import Convert from '../convert';
-import Utils from '../utils';
+import * as Utils from '../utils';
 import {
   LanguageClientConnection,
   Location,

--- a/lib/adapters/document-sync-adapter.ts
+++ b/lib/adapters/document-sync-adapter.ts
@@ -25,13 +25,10 @@ import { BusySignalService } from 'atom-ide';
 // each end of changes, opening, closing and other events as well as sending and applying
 // changes either in whole or in part depending on what the language server supports.
 export default class DocumentSyncAdapter {
-  private _editorSelector: (editor: TextEditor) => boolean;
   private _disposable = new CompositeDisposable();
   public _documentSync: TextDocumentSyncOptions;
   private _editors: WeakMap<TextEditor, TextEditorSyncAdapter> = new WeakMap();
-  private _connection: LanguageClientConnection;
   private _versions: Map<string, number> = new Map();
-  private _busySignalService?: BusySignalService;
 
   // Public: Determine whether this adapter can be used to adapt a language server
   // based on the serverCapabilities matrix textDocumentSync capability either being Full or
@@ -68,12 +65,11 @@ export default class DocumentSyncAdapter {
   // * `editorSelector` A predicate function that takes a {TextEditor} and returns a {boolean}
   //                    indicating whether this adapter should care about the contents of the editor.
   constructor(
-    connection: LanguageClientConnection,
-    editorSelector: (editor: TextEditor) => boolean,
+    private _connection: LanguageClientConnection,
+    private _editorSelector: (editor: TextEditor) => boolean,
     documentSync?: TextDocumentSyncOptions | TextDocumentSyncKind,
-    busySignalService?: BusySignalService,
+    private _busySignalService?: BusySignalService,
   ) {
-    this._connection = connection;
     if (typeof documentSync === 'object') {
       this._documentSync = documentSync;
     } else {
@@ -81,8 +77,6 @@ export default class DocumentSyncAdapter {
         change: documentSync || TextDocumentSyncKind.Full,
       };
     }
-    this._editorSelector = editorSelector;
-    this._busySignalService = busySignalService;
     this._disposable.add(atom.textEditors.observe(this.observeTextEditor.bind(this)));
   }
 

--- a/lib/adapters/document-sync-adapter.ts
+++ b/lib/adapters/document-sync-adapter.ts
@@ -96,7 +96,7 @@ export default class DocumentSyncAdapter {
   //
   // * `editor` A {TextEditor} to consider for observation.
   public observeTextEditor(editor: TextEditor): void {
-    const listener = editor.observeGrammar((grammar) => this._handleGrammarChange(editor));
+    const listener = editor.observeGrammar((_grammar) => this._handleGrammarChange(editor));
     this._disposable.add(
       editor.onDidDestroy(() => {
         this._disposable.remove(listener);

--- a/lib/adapters/document-sync-adapter.ts
+++ b/lib/adapters/document-sync-adapter.ts
@@ -114,6 +114,7 @@ export default class DocumentSyncAdapter {
     if (sync != null && !this._editorSelector(editor)) {
       this._editors.delete(editor);
       this._disposable.remove(sync);
+      sync.didClose();
       sync.dispose();
     } else if (sync == null && this._editorSelector(editor)) {
       this._handleNewEditor(editor);

--- a/lib/adapters/document-sync-adapter.ts
+++ b/lib/adapters/document-sync-adapter.ts
@@ -18,7 +18,7 @@ import {
   TextEditEvent,
   TextEditor,
 } from 'atom';
-import Utils, { ReportBusyWhile } from '../utils';
+import * as Utils from '../utils';
 
 // Public: Synchronizes the documents between Atom and the language server by notifying
 // each end of changes, opening, closing and other events as well as sending and applying
@@ -67,7 +67,7 @@ export default class DocumentSyncAdapter {
     private _connection: LanguageClientConnection,
     private _editorSelector: (editor: TextEditor) => boolean,
     documentSync: TextDocumentSyncOptions | TextDocumentSyncKind | undefined,
-    private _reportBusyWhile: ReportBusyWhile,
+    private _reportBusyWhile: Utils.ReportBusyWhile,
   ) {
     if (typeof documentSync === 'object') {
       this._documentSync = documentSync;
@@ -157,7 +157,7 @@ export class TextEditorSyncAdapter {
     private _connection: LanguageClientConnection,
     private _documentSync: TextDocumentSyncOptions,
     private _versions: Map<string, number>,
-    private _reportBusyWhile: ReportBusyWhile,
+    private _reportBusyWhile: Utils.ReportBusyWhile,
   ) {
     this._fakeDidChangeWatchedFiles = atom.project.onDidChangeFiles == null;
 

--- a/lib/adapters/logging-console-adapter.ts
+++ b/lib/adapters/logging-console-adapter.ts
@@ -34,10 +34,6 @@ export default class LoggingConsoleAdapter {
     this._consoles.clear();
   }
 
-  private generateId(): string {
-    return new Date().toISOString();
-  }
-
   // Log a message using the Atom IDE UI Console API.
   //
   // * `params` The {LogMessageParams} received from the language server

--- a/lib/adapters/notifications-adapter.ts
+++ b/lib/adapters/notifications-adapter.ts
@@ -37,7 +37,7 @@ export default class NotificationsAdapter {
     name: string,
     projectPath: string,
   ): Promise<MessageActionItem | null> {
-    return new Promise((resolve, reject) => {
+    return new Promise((resolve, _reject) => {
       const options: NotificationOptions = {
         dismissable: true,
         detail: `${name} ${projectPath}`,

--- a/lib/adapters/outline-view-adapter.ts
+++ b/lib/adapters/outline-view-adapter.ts
@@ -1,6 +1,6 @@
 import * as atomIde from 'atom-ide';
 import Convert from '../convert';
-import Utils from '../utils';
+import * as Utils from '../utils';
 import { CancellationTokenSource } from 'vscode-jsonrpc';
 import {
   LanguageClientConnection,

--- a/lib/auto-languageclient.ts
+++ b/lib/auto-languageclient.ts
@@ -52,7 +52,7 @@ export type ConnectionType = 'stdio' | 'socket' | 'ipc';
 // implementing startServerProcess/getGrammarScopes/getLanguageName and
 // getServerName.
 export default class AutoLanguageClient {
-  private _disposable = new CompositeDisposable();
+  private _disposable!: CompositeDisposable;
   private _serverManager!: ServerManager;
   private _consoleDelegate?: atomIde.ConsoleService;
   private _linterDelegate?: linter.IndieDelegate;
@@ -231,6 +231,7 @@ export default class AutoLanguageClient {
 
   // Activate does very little for perf reasons - hooks in via ServerManager for later 'activation'
   public activate(): void {
+    this._disposable = new CompositeDisposable();
     this.name = `${this.getLanguageName()} (${this.getServerName()})`;
     this.logger = this.getLogger();
     this._serverManager = new ServerManager(

--- a/lib/auto-languageclient.ts
+++ b/lib/auto-languageclient.ts
@@ -53,27 +53,27 @@ export type ConnectionType = 'stdio' | 'socket' | 'ipc';
 // getServerName.
 export default class AutoLanguageClient {
   private _disposable = new CompositeDisposable();
-  private _serverManager: ServerManager;
-  private _consoleDelegate: atomIde.ConsoleService;
-  private _linterDelegate: linter.IndieDelegate;
-  private _signatureHelpRegistry: atomIde.SignatureHelpRegistry | null;
-  private _lastAutocompleteRequest: AutocompleteRequest;
-  private _isDeactivating: boolean;
+  private _serverManager!: ServerManager;
+  private _consoleDelegate?: atomIde.ConsoleService;
+  private _linterDelegate?: linter.IndieDelegate;
+  private _signatureHelpRegistry?: atomIde.SignatureHelpRegistry;
+  private _lastAutocompleteRequest?: AutocompleteRequest;
+  private _isDeactivating: boolean = false;
 
   // Available if consumeBusySignal is setup
-  protected busySignalService: atomIde.BusySignalService;
+  protected busySignalService?: atomIde.BusySignalService;
 
   protected processStdErr: string = '';
-  protected logger: Logger;
-  protected name: string;
-  protected socket: Socket;
+  protected logger!: Logger;
+  protected name!: string;
+  protected socket!: Socket;
 
   // Shared adapters that can take the RPC connection as required
-  protected autoComplete: AutocompleteAdapter;
-  protected datatip: DatatipAdapter;
-  protected definitions: DefinitionAdapter;
-  protected findReferences: FindReferencesAdapter;
-  protected outlineView: OutlineViewAdapter;
+  protected autoComplete?: AutocompleteAdapter;
+  protected datatip?: DatatipAdapter;
+  protected definitions?: DefinitionAdapter;
+  protected findReferences?: FindReferencesAdapter;
+  protected outlineView?: OutlineViewAdapter;
 
   // You must implement these so we know how to deal with your language and server
   // -------------------------------------------------------------------------
@@ -94,7 +94,7 @@ export default class AutoLanguageClient {
   }
 
   // Start your server process
-  protected startServerProcess(projectPath: string): LanguageServerProcess | Promise<LanguageServerProcess> {
+  protected startServerProcess(_projectPath: string): LanguageServerProcess | Promise<LanguageServerProcess> {
     throw Error('Must override startServerProcess to start language server process when extending AutoLanguageClient');
   }
 
@@ -192,10 +192,10 @@ export default class AutoLanguageClient {
   }
 
   // Early wire-up of listeners before initialize method is sent
-  protected preInitialization(connection: LanguageClientConnection): void {}
+  protected preInitialization(_connection: LanguageClientConnection): void {}
 
   // Late wire-up of listeners after initialize method has been sent
-  protected postInitialization(server: ActiveServer): void {}
+  protected postInitialization(_server: ActiveServer): void {}
 
   // Determine whether to use ipc, stdio or socket to connect to the server
   protected getConnectionType(): ConnectionType {
@@ -380,9 +380,9 @@ export default class AutoLanguageClient {
     }
 
     return rpc.createMessageConnection(reader, writer, {
-      log: (...args: any[]) => {},
-      warn: (...args: any[]) => {},
-      info: (...args: any[]) => {},
+      log: (..._args: any[]) => {},
+      warn: (..._args: any[]) => {},
+      info: (..._args: any[]) => {},
       error: (...args: any[]) => {
         this.logger.error(args);
       },
@@ -476,13 +476,13 @@ export default class AutoLanguageClient {
   }
 
   protected onDidConvertAutocomplete(
-    completionItem: ls.CompletionItem,
-    suggestion: AutocompleteSuggestion,
-    request: AutocompleteRequest,
+    _completionItem: ls.CompletionItem,
+    _suggestion: AutocompleteSuggestion,
+    _request: AutocompleteRequest,
   ): void {
   }
 
-  protected onDidInsertSuggestion(arg: AutocompleteDidInsert): void {}
+  protected onDidInsertSuggestion(_arg: AutocompleteDidInsert): void {}
 
   // Definitions via LS documentHighlight and gotoDefinition------------
   public provideDefinitions(): atomIde.DefinitionProvider {
@@ -673,7 +673,7 @@ export default class AutoLanguageClient {
       }
     }
     return new Disposable(() => {
-      this._signatureHelpRegistry = null;
+      this._signatureHelpRegistry = undefined;
     });
   }
 
@@ -687,7 +687,7 @@ export default class AutoLanguageClient {
    * @param filePath path of a file that has changed in the project path
    * @return false => message will not be sent to the language server
    */
-  protected filterChangeWatchedFiles(filePath: string): boolean {
+  protected filterChangeWatchedFiles(_filePath: string): boolean {
     return true;
   }
 
@@ -695,7 +695,7 @@ export default class AutoLanguageClient {
    * Called on language server stderr output.
    * @param stderr a chunk of stderr from a language server instance
    */
-  private handleServerStderr(stderr: string, projectPath: string) {
+  private handleServerStderr(stderr: string, _projectPath: string) {
     stderr.split('\n').filter((l) => l).forEach((line) => this.logger.warn(`stderr ${line}`));
   }
 }

--- a/lib/auto-languageclient.ts
+++ b/lib/auto-languageclient.ts
@@ -19,7 +19,7 @@ import LoggingConsoleAdapter from './adapters/logging-console-adapter';
 import NotificationsAdapter from './adapters/notifications-adapter';
 import OutlineViewAdapter from './adapters/outline-view-adapter';
 import SignatureHelpAdapter from './adapters/signature-help-adapter';
-import Utils, { ReportBusyWhile } from './utils';
+import * as Utils from './utils';
 import { Socket } from 'net';
 import { LanguageClientConnection } from './languageclient';
 import {
@@ -716,7 +716,7 @@ export default class AutoLanguageClient {
     return adapters && adapters[adapter];
   }
 
-  protected reportBusyWhile: ReportBusyWhile = async (title, f) => {
+  protected reportBusyWhile: Utils.ReportBusyWhile = async (title, f) => {
     if (this.busySignalService) {
       return this.busySignalService.reportBusyWhile(title, f);
     } else {
@@ -724,7 +724,7 @@ export default class AutoLanguageClient {
     }
   }
 
-  protected reportBusyWhileDefault: ReportBusyWhile = async (title, f) => {
+  protected reportBusyWhileDefault: Utils.ReportBusyWhile = async (title, f) => {
     this.logger.info(`[Started] ${title}`);
     let res;
     try {

--- a/lib/auto-languageclient.ts
+++ b/lib/auto-languageclient.ts
@@ -396,14 +396,14 @@ export default class AutoLanguageClient {
     NotificationsAdapter.attach(server.connection, this.name, server.projectPath);
 
     if (DocumentSyncAdapter.canAdapt(server.capabilities)) {
-      server.docSyncAdapter =
+      const docSyncAdapter =
         new DocumentSyncAdapter(
           server.connection,
           (editor) => this.shouldSyncForEditor(editor, server.projectPath),
           server.capabilities.textDocumentSync,
           this.busySignalService,
         );
-      server.disposable.add(server.docSyncAdapter);
+      server.disposable.add(docSyncAdapter);
     }
 
     server.linterPushV2 = new LinterPushV2Adapter(server.connection);

--- a/lib/auto-languageclient.ts
+++ b/lib/auto-languageclient.ts
@@ -696,7 +696,7 @@ export default class AutoLanguageClient {
    * Called on language server stderr output.
    * @param stderr a chunk of stderr from a language server instance
    */
-  private handleServerStderr(stderr: string, _projectPath: string) {
+  protected handleServerStderr(stderr: string, _projectPath: string) {
     stderr.split('\n').filter((l) => l).forEach((line) => this.logger.warn(`stderr ${line}`));
   }
 }

--- a/lib/logger.ts
+++ b/lib/logger.ts
@@ -52,9 +52,9 @@ export class ConsoleLogger {
 }
 
 export class NullLogger {
-  public warn(...args: any[]): void {}
-  public error(...args: any[]): void {}
-  public info(...args: any[]): void {}
-  public log(...args: any[]): void {}
-  public debug(...args: any[]): void {}
+  public warn(..._args: any[]): void {}
+  public error(..._args: any[]): void {}
+  public info(..._args: any[]): void {}
+  public log(..._args: any[]): void {}
+  public debug(..._args: any[]): void {}
 }

--- a/lib/server-manager.ts
+++ b/lib/server-manager.ts
@@ -49,30 +49,18 @@ export class ServerManager {
   private _stoppingServers: ActiveServer[] = [];
   private _disposable: CompositeDisposable = new CompositeDisposable();
   private _editorToServer: Map<TextEditor, ActiveServer> = new Map();
-  private _logger: Logger;
   private _normalizedProjectPaths: string[] = [];
-  private _startForEditor: (editor: TextEditor) => boolean;
-  private _startServer: (projectPath: string) => Promise<ActiveServer>;
-  private _changeWatchedFileFilter: (filePath: string) => boolean;
-  private _getBusySignalService: () => atomIde.BusySignalService | undefined;
-  private _languageServerName: string;
   private _isStarted = false;
 
   constructor(
-    startServer: (projectPath: string) => Promise<ActiveServer>,
-    logger: Logger,
-    startForEditor: (editor: TextEditor) => boolean,
-    changeWatchedFileFilter: (filePath: string) => boolean,
-    busySignalServiceGetter: () => atomIde.BusySignalService | undefined,
-    languageServerName: string,
+    private _startServer: (projectPath: string) => Promise<ActiveServer>,
+    private _logger: Logger,
+    private _startForEditor: (editor: TextEditor) => boolean,
+    private _changeWatchedFileFilter: (filePath: string) => boolean,
+    private _getBusySignalService: () => atomIde.BusySignalService | undefined,
+    private _languageServerName: string,
   ) {
-    this._languageServerName = languageServerName;
-    this._startServer = startServer;
-    this._logger = logger;
-    this._startForEditor = startForEditor;
     this.updateNormalizedProjectPaths();
-    this._changeWatchedFileFilter = changeWatchedFileFilter;
-    this._getBusySignalService = busySignalServiceGetter;
   }
 
   public startListening(): void {

--- a/lib/server-manager.ts
+++ b/lib/server-manager.ts
@@ -1,6 +1,3 @@
-import LinterPushV2Adapter from './adapters/linter-push-v2-adapter';
-import LoggingConsoleAdapter from './adapters/logging-console-adapter';
-import SignatureHelpAdapter from './adapters/signature-help-adapter';
 import Convert from './convert';
 import * as path from 'path';
 import * as stream from 'stream';
@@ -36,9 +33,6 @@ export interface ActiveServer {
   process: LanguageServerProcess;
   connection: ls.LanguageClientConnection;
   capabilities: ls.ServerCapabilities;
-  linterPushV2?: LinterPushV2Adapter;
-  loggingConsole?: LoggingConsoleAdapter;
-  signatureHelpAdapter?: SignatureHelpAdapter;
 }
 
 interface RestartCounter {

--- a/lib/server-manager.ts
+++ b/lib/server-manager.ts
@@ -1,4 +1,3 @@
-import DocumentSyncAdapter from './adapters/document-sync-adapter';
 import LinterPushV2Adapter from './adapters/linter-push-v2-adapter';
 import LoggingConsoleAdapter from './adapters/logging-console-adapter';
 import SignatureHelpAdapter from './adapters/signature-help-adapter';
@@ -39,7 +38,6 @@ export interface ActiveServer {
   capabilities: ls.ServerCapabilities;
   linterPushV2?: LinterPushV2Adapter;
   loggingConsole?: LoggingConsoleAdapter;
-  docSyncAdapter?: DocumentSyncAdapter;
   signatureHelpAdapter?: SignatureHelpAdapter;
 }
 
@@ -135,14 +133,6 @@ export class ServerManager {
       const server = this._editorToServer.get(editor);
       // If LS is running for the unsupported editor then disconnect the editor from LS and shut down LS if necessary
       if (server) {
-        // LS is up for unsupported server
-        if (server.docSyncAdapter) {
-          const syncAdapter = server.docSyncAdapter.getEditorSyncAdapter(editor);
-          if (syncAdapter) {
-            // Immitate editor close to disconnect LS from the editor
-            syncAdapter.didClose();
-          }
-        }
         // Remove editor from the cache
         this._editorToServer.delete(editor);
         // Shut down LS if it's used by any other editor

--- a/lib/server-manager.ts
+++ b/lib/server-manager.ts
@@ -62,7 +62,7 @@ export class ServerManager {
   private _startForEditor: (editor: TextEditor) => boolean;
   private _startServer: (projectPath: string) => Promise<ActiveServer>;
   private _changeWatchedFileFilter: (filePath: string) => boolean;
-  private _getBusySignalService: () => atomIde.BusySignalService | null;
+  private _getBusySignalService: () => atomIde.BusySignalService | undefined;
   private _languageServerName: string;
   private _isStarted = false;
 
@@ -71,7 +71,7 @@ export class ServerManager {
     logger: Logger,
     startForEditor: (editor: TextEditor) => boolean,
     changeWatchedFileFilter: (filePath: string) => boolean,
-    busySignalServiceGetter: () => atomIde.BusySignalService | null,
+    busySignalServiceGetter: () => atomIde.BusySignalService | undefined,
     languageServerName: string,
   ) {
     this._languageServerName = languageServerName;
@@ -103,7 +103,7 @@ export class ServerManager {
 
   private observeTextEditors(editor: TextEditor): void {
     // Track grammar changes for opened editors
-    const listener = editor.observeGrammar((grammar) => this._handleGrammarChange(editor));
+    const listener = editor.observeGrammar((_grammar) => this._handleGrammarChange(editor));
     this._disposable.add(editor.onDidDestroy(() => listener.dispose()));
     // Try to see if editor can have LS connected to it
     this._handleTextEditor(editor);

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -16,8 +16,7 @@ export default class Utils {
    * Uses the non-word characters from the position's grammar scope.
    */
   public static getWordAtPosition(editor: TextEditor, position: Point): Range {
-    const scopeDescriptor = editor.scopeDescriptorForBufferPosition(position);
-    const nonWordCharacters = Utils.escapeRegExp(editor.getNonWordCharacters(scopeDescriptor));
+    const nonWordCharacters = Utils.escapeRegExp(editor.getNonWordCharacters(position));
     const range = Utils._getRegexpRangeAtPosition(
       editor.getBuffer(),
       position,

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -15,101 +15,99 @@ export type ReportBusyWhile = <T>(
   f: () => Promise<T>,
 ) => Promise<T>;
 
-export default class Utils {
-  /**
-   * Obtain the range of the word at the given editor position.
-   * Uses the non-word characters from the position's grammar scope.
-   */
-  public static getWordAtPosition(editor: TextEditor, position: Point): Range {
-    const nonWordCharacters = Utils.escapeRegExp(editor.getNonWordCharacters(position));
-    const range = Utils._getRegexpRangeAtPosition(
-      editor.getBuffer(),
-      position,
-      new RegExp(`^[\t ]*$|[^\\s${nonWordCharacters}]+`, 'g'),
-    );
-    if (range == null) {
-      return new Range(position, position);
+/**
+ * Obtain the range of the word at the given editor position.
+ * Uses the non-word characters from the position's grammar scope.
+ */
+export function getWordAtPosition(editor: TextEditor, position: Point): Range {
+  const nonWordCharacters = escapeRegExp(editor.getNonWordCharacters(position));
+  const range = _getRegexpRangeAtPosition(
+    editor.getBuffer(),
+    position,
+    new RegExp(`^[\t ]*$|[^\\s${nonWordCharacters}]+`, 'g'),
+  );
+  if (range == null) {
+    return new Range(position, position);
+  }
+  return range;
+}
+
+export function escapeRegExp(string: string): string {
+  // From atom/underscore-plus.
+  return string.replace(/[-/\\^$*+?.()|[\]{}]/g, '\\$&');
+}
+
+function _getRegexpRangeAtPosition(buffer: TextBuffer, position: Point, wordRegex: RegExp): Range | null {
+  const {row, column} = position;
+  const rowRange = buffer.rangeForRow(row, false);
+  let matchData: BufferScanResult | undefined | null;
+  // Extract the expression from the row text.
+  buffer.scanInRange(wordRegex, rowRange, (data) => {
+    const {range} = data;
+    if (
+      position.isGreaterThanOrEqual(range.start) &&
+      // Range endpoints are exclusive.
+      position.isLessThan(range.end)
+    ) {
+      matchData = data;
+      data.stop();
+      return;
     }
-    return range;
-  }
-
-  public static escapeRegExp(string: string): string {
-    // From atom/underscore-plus.
-    return string.replace(/[-/\\^$*+?.()|[\]{}]/g, '\\$&');
-  }
-
-  private static _getRegexpRangeAtPosition(buffer: TextBuffer, position: Point, wordRegex: RegExp): Range | null {
-    const {row, column} = position;
-    const rowRange = buffer.rangeForRow(row, false);
-    let matchData: BufferScanResult | undefined | null;
-    // Extract the expression from the row text.
-    buffer.scanInRange(wordRegex, rowRange, (data) => {
-      const {range} = data;
-      if (
-        position.isGreaterThanOrEqual(range.start) &&
-        // Range endpoints are exclusive.
-        position.isLessThan(range.end)
-      ) {
-        matchData = data;
-        data.stop();
-        return;
-      }
-      // Stop the scan if the scanner has passed our position.
-      if (range.end.column > column) {
-        data.stop();
-      }
-    });
-    return matchData == null ? null : matchData.range;
-  }
-
-  /**
-   * For the given connection and cancellationTokens map, cancel the existing
-   * CancellationToken for that connection then create and store a new
-   * CancellationToken to be used for the current request.
-   */
-  public static cancelAndRefreshCancellationToken<T extends object>(
-    key: T,
-    cancellationTokens: WeakMap<T, CancellationTokenSource>): CancellationToken {
-
-    let cancellationToken = cancellationTokens.get(key);
-    if (cancellationToken !== undefined && !cancellationToken.token.isCancellationRequested) {
-      cancellationToken.cancel();
+    // Stop the scan if the scanner has passed our position.
+    if (range.end.column > column) {
+      data.stop();
     }
+  });
+  return matchData == null ? null : matchData.range;
+}
 
-    cancellationToken = new CancellationTokenSource();
-    cancellationTokens.set(key, cancellationToken);
-    return cancellationToken.token;
+/**
+ * For the given connection and cancellationTokens map, cancel the existing
+ * CancellationToken for that connection then create and store a new
+ * CancellationToken to be used for the current request.
+ */
+export function cancelAndRefreshCancellationToken<T extends object>(
+  key: T,
+  cancellationTokens: WeakMap<T, CancellationTokenSource>): CancellationToken {
+
+  let cancellationToken = cancellationTokens.get(key);
+  if (cancellationToken !== undefined && !cancellationToken.token.isCancellationRequested) {
+    cancellationToken.cancel();
   }
 
-  public static async doWithCancellationToken<T1 extends object, T2>(
-    key: T1,
-    cancellationTokens: WeakMap<T1, CancellationTokenSource>,
-    work: (token: CancellationToken) => Promise<T2>,
-  ): Promise<T2> {
-    const token = Utils.cancelAndRefreshCancellationToken(key, cancellationTokens);
-    const result: T2 = await work(token);
-    cancellationTokens.delete(key);
-    return result;
-  }
+  cancellationToken = new CancellationTokenSource();
+  cancellationTokens.set(key, cancellationToken);
+  return cancellationToken.token;
+}
 
-  public static assertUnreachable(_: never): never {
-    return _;
-  }
+export async function doWithCancellationToken<T1 extends object, T2>(
+  key: T1,
+  cancellationTokens: WeakMap<T1, CancellationTokenSource>,
+  work: (token: CancellationToken) => Promise<T2>,
+): Promise<T2> {
+  const token = cancelAndRefreshCancellationToken(key, cancellationTokens);
+  const result: T2 = await work(token);
+  cancellationTokens.delete(key);
+  return result;
+}
 
-  public static promiseWithTimeout<T>(ms: number, promise: Promise<T>): Promise<T> {
-    return new Promise((resolve, reject) => {
-      // create a timeout to reject promise if not resolved
-      const timer = setTimeout(() => {
-        reject(new Error(`Timeout after ${ms}ms`));
-      }, ms);
+export function assertUnreachable(_: never): never {
+  return _;
+}
 
-      promise.then((res) => {
-        clearTimeout(timer);
-        resolve(res);
-      }).catch((err) => {
-        clearTimeout(timer);
-        reject(err);
-      });
+export function promiseWithTimeout<T>(ms: number, promise: Promise<T>): Promise<T> {
+  return new Promise((resolve, reject) => {
+    // create a timeout to reject promise if not resolved
+    const timer = setTimeout(() => {
+      reject(new Error(`Timeout after ${ms}ms`));
+    }, ms);
+
+    promise.then((res) => {
+      clearTimeout(timer);
+      resolve(res);
+    }).catch((err) => {
+      clearTimeout(timer);
+      reject(err);
     });
-  }
+  });
 }

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -10,6 +10,11 @@ import {
   CancellationTokenSource,
 } from 'vscode-jsonrpc';
 
+export type ReportBusyWhile = <T>(
+  title: string,
+  f: () => Promise<T>,
+) => Promise<T>;
+
 export default class Utils {
   /**
    * Obtain the range of the word at the given editor position.

--- a/package.json
+++ b/package.json
@@ -35,6 +35,6 @@
     "mocha-appveyor-reporter": "^0.4.0",
     "sinon": "^2.0.0",
     "tslint": "^5.9.1",
-    "typescript": "^2.7.2"
+    "typescript": "~2.8.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "test": "npm run compile && npm run lint && atom --test build/test"
   },
   "dependencies": {
-    "@types/atom": "^1.24.1",
+    "@types/atom": "~1.25.0",
     "@types/node": "^8.0.41",
     "fuzzaldrin-plus": "^0.6.0",
     "vscode-jsonrpc": "^3.5.0",

--- a/test/adapters/autocomplete-adapter.test.ts
+++ b/test/adapters/autocomplete-adapter.test.ts
@@ -35,7 +35,7 @@ describe('AutoCompleteAdapter', () => {
     editor: createFakeEditor(),
     bufferPosition: new Point(123, 456),
     prefix: 'lab',
-    scopeDescriptor: 'some.scope',
+    scopeDescriptor: { getScopesArray() { return ['some.scope']; } },
     activatedManually: true,
   };
 
@@ -163,7 +163,7 @@ describe('AutoCompleteAdapter', () => {
         Array.from(
           autoCompleteAdapter.completionItemsToSuggestions(completionList, request, (c, a, r) => {
             a.text = c.label + ' ok';
-            a.displayText = r.scopeDescriptor;
+            a.displayText = r.scopeDescriptor.getScopesArray()[0];
           }));
 
       expect(results.length).equals(4);
@@ -218,7 +218,7 @@ describe('AutoCompleteAdapter', () => {
         editor: createFakeEditor(),
         bufferPosition: new Point(123, 456),
         prefix: 'def',
-        scopeDescriptor: 'some.scope',
+        scopeDescriptor: { getScopesArray() { return ['some.scope']; } },
       };
       sinon.stub(autocompleteRequest.editor, 'getTextInBufferRange').returns('replacementPrefix');
       const result: any = { };

--- a/test/adapters/document-sync-adapter.test.ts
+++ b/test/adapters/document-sync-adapter.test.ts
@@ -49,7 +49,7 @@ describe('DocumentSyncAdapter', () => {
 
   describe('constructor', () => {
     function create(textDocumentSync?: TextDocumentSyncKind | TextDocumentSyncOptions) {
-      return new DocumentSyncAdapter(null as any, () => false, textDocumentSync);
+      return new DocumentSyncAdapter(null as any, () => false, textDocumentSync, (_t, f) => f());
     }
 
     it('sets _documentSync.change correctly Incremental for v2 capabilities', () => {

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -1,4 +1,4 @@
-import Utils from '../lib/utils';
+import * as Utils from '../lib/utils';
 import { createFakeEditor } from './helpers';
 import { expect } from 'chai';
 import { Point } from 'atom';

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,8 +7,12 @@
         "declaration": true,
         "inlineSources": true,
         "inlineSourceMap": true,
-        "strictNullChecks": true,
+        "strict": true,
         "noImplicitAny": true,
+        "noFallthroughCasesInSwitch": true,
+        "noImplicitReturns": true,
+        "noUnusedLocals": true,
+        "noUnusedParameters": true,
         "baseUrl": "./"
     },
     "include": [

--- a/typings/atom/index.d.ts
+++ b/typings/atom/index.d.ts
@@ -4,7 +4,7 @@ declare module 'atom' {
   interface TextEditor {
     getURI(): string | null;
     getBuffer(): TextBuffer;
-    getNonWordCharacters(scope: ScopeDescriptor): string;
+    getNonWordCharacters(position: Point): string;
   }
 
   export interface ProjectFileEvent {

--- a/typings/atom/index.d.ts
+++ b/typings/atom/index.d.ts
@@ -50,7 +50,7 @@ declare module 'atom' {
   interface AutocompleteRequest {
     editor: TextEditor;
     bufferPosition: Point;
-    scopeDescriptor: string;
+    scopeDescriptor: ScopeDescriptor;
     prefix: string;
     activatedManually?: boolean;
   }


### PR DESCRIPTION
As discussed in #206, these are only those refactors I feel are not too controversial.

Commits I think might be *somewhat* controversial are: 

* https://github.com/atom/atom-languageclient/commit/d5f70903b0dd8674f0a413d93463a9ffecf6341e (
Handle unsupported grammar in DocumentSyncAdapter, not ServerManager) -- plain and simple, `ServerManager` handles something it's not responsible for; moving the relevant code makes things that much simpler.
* https://github.com/atom/atom-languageclient/commit/755172ce62506f1a724054fbd0b315f9fb2e480c (
Untangle adapters from ServerManager) -- again, `ServerManager` doesn't even touch adapters that are grafted onto it. I think a better architecture is to use loose coupling via `WeakMap` (even if it might be a bit slower, there are no performance-critical code paths there)
* https://github.com/atom/atom-languageclient/commit/d63fc9ef5124f5832d42428e85e16ac1235318a7 (Untie atomIde.BusySignalService from ServerManager and DocSyncAdapter) -- again, looser coupling. Everything that's done via `BusySignalService` interface could as well be done via a limited version of its `reportBusyWhile` method; hence, it seems like a saner choice to pass only that around.

Each of these changes is small enough. And at least if we agree that less tightly coupled code is generally "better", each I find to be more or less beneficial.

bff82a7 also adds a simple fallback for busy signal via `logger.info`.

If this seems like too much to review at once, reviewing commits one-by-one is also an option -- I tried to keep those more or less self-contained.