### PR TITLE
[DO NOT MERGE] Global LS Command Registry to register/unregister and execute commands

### DIFF
--- a/lib/adapters/command-adapter.ts
+++ b/lib/adapters/command-adapter.ts
@@ -1,0 +1,116 @@
+import {LanguageClientConnection} from '../languageclient';
+import {ServerCapabilities} from 'vscode-languageserver-protocol';
+import {DisposableLike} from 'atom';
+import * as UUID from 'uuid/v4';
+
+const GLOBAL: any = global;
+
+export class CommandAdapter implements DisposableLike {
+
+    private registrations: Map<string, string[]>;
+
+    constructor(private connection: LanguageClientConnection) {
+        this.registrations = new Map();
+        connection.onRegisterCommand(registration => {
+            if (registration.registerOptions && Array.isArray(registration.registerOptions.commands)) {
+                this.registerCommands(registration.id, registration.registerOptions.commands);
+            }
+        });
+        connection.onUnregisterCommand(unregisteration => this.unregisterCommands(unregisteration.id));
+    }
+
+    initialize(capabilities: ServerCapabilities) {
+        if (capabilities.executeCommandProvider && Array.isArray(capabilities.executeCommandProvider.commands)) {
+            this.registerCommands(UUID(), capabilities.executeCommandProvider.commands)
+        }
+    }
+
+    registerCommands(id: string, commands: string[]): void{
+        const cmdRegistry = this.getLspCommandRegistry();
+        const registeredCommands = commands.filter(cmd => {
+           const handler = (params: any[]) => this.connection.executeCommand({
+               command: cmd,
+               arguments: params
+           });
+           if (cmdRegistry.register(cmd, handler)) {
+               return true;
+           } else {
+               console.error(`Trying to register duplicate command: "${cmd}"`)
+           }
+        });
+        if (this.registrations.has(id)) {
+            throw new Error(`Duplicate registration id: ${id}`);
+        }
+        this.registrations.set(id, registeredCommands);
+    }
+
+    executeCommand(id: string, params: any[]): Promise<any> {
+        return this.getLspCommandRegistry().execute(id, params);
+    }
+
+    unregisterCommands(id: string) {
+        if (this.registrations.has(id)) {
+            const commands = this.registrations.get(id);
+            const cmdRegistry = this.getLspCommandRegistry();
+            if (commands && Array.isArray(commands)) {
+                commands.forEach(command => cmdRegistry.unregister(command));
+            }
+            this.registrations.delete(id);
+        }
+    }
+
+    dispose() {
+        const cmdRegistry = this.getLspCommandRegistry();
+        this.registrations.forEach(commands => commands.forEach(command => cmdRegistry.unregister(command)));
+        this.registrations.clear();
+    }
+
+    private getLspCommandRegistry(): LspCommandRegistry {
+        if (!GLOBAL.lspCommandRegistry) {
+            GLOBAL.lspCommandRegistry = new LspCommandRegistryImpl();
+        }
+        return <LspCommandRegistry> GLOBAL.lspCommandRegistry;
+    }
+}
+
+export interface LspCommandRegistry {
+    register(command: string, handler: (params: any[]) => Promise<any>): boolean;
+    execute(command: string, params: any[]): Promise<any>;
+    unregister(command: string): boolean;
+}
+
+class LspCommandRegistryImpl implements LspCommandRegistry {
+
+    private commandIdToHandler: Map<string, (params: any[]) => Promise<any>>;
+
+    constructor() {
+        this.commandIdToHandler = new Map();
+    }
+
+    register(command: string, handler: (params: any[]) => Promise<any>): boolean {
+        if (this.commandIdToHandler.has(command)) {
+            return false;
+        } else {
+            this.commandIdToHandler.set(command, handler);
+            return true;
+        }
+    }
+
+    execute(command: string, params: any[]): Promise<any> {
+        if (this.commandIdToHandler.has(command)) {
+            const handler = this.commandIdToHandler.get(command);
+            if (handler) {
+                return handler(params);
+            } else {
+                throw new Error(`Command "${command}" has no handler`);
+            }
+        } else {
+            throw new Error(`Command "${command}" is not registered`);
+        }
+    }
+
+    unregister(command: string): boolean {
+        return this.commandIdToHandler.delete(command);
+    }
+
+}

--- a/lib/auto-languageclient.ts
+++ b/lib/auto-languageclient.ts
@@ -43,6 +43,7 @@ import {
   Range,
   TextEditor,
 } from 'atom';
+import {CommandAdapter} from './adapters/command-adapter';
 
 export { ActiveServer, LanguageClientConnection, LanguageServerProcess };
 export type ConnectionType = 'stdio' | 'socket' | 'ipc';
@@ -128,7 +129,7 @@ export default class AutoLanguageClient {
             dynamicRegistration: false,
           },
           executeCommand: {
-            dynamicRegistration: false,
+            dynamicRegistration: true,
           },
         },
         textDocument: {
@@ -424,6 +425,10 @@ export default class AutoLanguageClient {
       }
       server.disposable.add(server.signatureHelpAdapter);
     }
+
+    server.commands = new CommandAdapter(server.connection);
+    server.commands.initialize(server.capabilities);
+    server.disposable.add(server.commands);
   }
 
   public shouldSyncForEditor(editor: TextEditor, projectPath: string): boolean {

--- a/lib/server-manager.ts
+++ b/lib/server-manager.ts
@@ -14,6 +14,7 @@ import {
   ProjectFileEvent,
   TextEditor,
 } from 'atom';
+import {CommandAdapter} from './adapters/command-adapter';
 
 // Public: Defines the minimum surface area for an object that resembles a
 // ChildProcess.  This is used so that language packages with alternative
@@ -37,6 +38,7 @@ export interface ActiveServer {
   process: LanguageServerProcess;
   connection: ls.LanguageClientConnection;
   capabilities: ls.ServerCapabilities;
+  commands?: CommandAdapter;
   linterPushV2?: LinterPushV2Adapter;
   loggingConsole?: LoggingConsoleAdapter;
   docSyncAdapter?: DocumentSyncAdapter;

--- a/package.json
+++ b/package.json
@@ -17,10 +17,12 @@
   "dependencies": {
     "@types/atom": "^1.24.1",
     "@types/node": "^8.0.41",
+    "@types/uuid": "^3.4.3",
     "fuzzaldrin-plus": "^0.6.0",
     "vscode-jsonrpc": "^3.5.0",
     "vscode-languageserver-protocol": "3.6.0-next.5",
-    "vscode-languageserver-types": "^3.6.0-next.1"
+    "vscode-languageserver-types": "^3.6.0-next.1",
+    "uuid": "^3.2.1"
   },
   "atomTestRunner": "./build/test/runner",
   "devDependencies": {


### PR DESCRIPTION
Fixes #212 
Introduces global LS commands registry where commands are registered. Registry is shared between all LS clients and can be accessed to execute commands.
`AtomEnvironment` has `CommandRegistry` but it's unclear how to utilize it for LS client purposes... Seems like commands in Atom `CommandRegistry` are mainly for the UI (i.e. click or pick command in the command palette) since they don't take parameters...

Don't think this is the final solution for the problem, but maybe it's a starting point to gather some feedback and turn this into a shape of a PR that can be merged.