### PR TITLE
Correctly dispose config observer when servers are closed

### DIFF
--- a/lib/auto-languageclient.ts
+++ b/lib/auto-languageclient.ts
@@ -320,7 +320,7 @@ export default class AutoLanguageClient {
 
     const configurationKey = this.getRootConfigurationKey();
     if (configurationKey) {
-      this._disposable.add(
+      newServer.disposable.add(
         atom.config.observe(configurationKey, (config) => {
           const mappedConfig = this.mapConfigurationObject(config || {});
           if (mappedConfig) {


### PR DESCRIPTION
Right now, config changes are observed until the package is deactivated.

This results in `Uncaught Error: Connection is disposed.` errors if the config is modified after the language server has been terminated, e.g., when closing all opened files. 

This bug was reported multiple times in the `ide-python` package: https://github.com/lgeiger/ide-python/issues/63, https://github.com/lgeiger/ide-python/issues/82

This PR adds the config observer to the server disposable in order to watch for changes only when the server is running.