### PR TITLE
Adds outline icon for Struct and EnumMember symbol kind

### DIFF
--- a/lib/adapters/outline-view-adapter.ts
+++ b/lib/adapters/outline-view-adapter.ts
@@ -214,6 +214,10 @@ export default class OutlineViewAdapter {
         return 'type-string';
       case SymbolKind.Variable:
         return 'type-variable';
+      case SymbolKind.Struct:
+        return 'type-class';
+      case SymbolKind.EnumMember:
+        return 'type-constant';
       default:
         return null;
     }


### PR DESCRIPTION
`Struct` is practically a `Class`, so I think using `type-class` would be fine. As of `EnumMember`, I think `type-constant` would make sense? But also open to other suggestions.