### PR TITLE
Implements DocumentSymbol outline support

### DIFF
--- a/lib/adapters/outline-view-adapter.ts
+++ b/lib/adapters/outline-view-adapter.ts
@@ -7,6 +7,7 @@ import {
   SymbolKind,
   ServerCapabilities,
   SymbolInformation,
+  DocumentSymbol,
 } from '../languageclient';
 import {
   Point,
@@ -42,15 +43,59 @@ export default class OutlineViewAdapter {
     const results = await Utils.doWithCancellationToken(connection, this._cancellationTokens, (cancellationToken) =>
       connection.documentSymbol({textDocument: Convert.editorToTextDocumentIdentifier(editor)}, cancellationToken),
     );
-    results.sort(
-      (a, b) =>
-        (a.location.range.start.line === b.location.range.start.line
-          ? a.location.range.start.character - b.location.range.start.character
-          : a.location.range.start.line - b.location.range.start.line),
-    );
-    return {
-      outlineTrees: OutlineViewAdapter.createOutlineTrees(results),
-    };
+
+    if ((results.length !== 0) &&
+        ((results[0] as DocumentSymbol).selectionRange !== undefined)) {
+      // If the server is giving back the newer DocumentSymbol format.
+      return {
+        outlineTrees: OutlineViewAdapter.createHierarchicalOutlineTrees(
+          results as DocumentSymbol[]),
+      };
+    } else {
+      // If the server is giving back the original SymbolInformation format.
+      return {
+        outlineTrees: OutlineViewAdapter.createOutlineTrees(
+          results as SymbolInformation[]),
+      };
+    }
+  }
+
+  // Public: Create an {Array} of {OutlineTree}s from the Array of {DocumentSymbol} recieved
+  // from the language server. This includes converting all the children nodes in the entire
+  // hierarchy.
+  //
+  // * `symbols` An {Array} of {DocumentSymbol}s received from the language server that
+  //             should be converted to an {Array} of {OutlineTree}.
+  //
+  // Returns an {Array} of {OutlineTree} containing the given symbols that the Outline View can display.
+  public static createHierarchicalOutlineTrees(symbols: DocumentSymbol[]): atomIde.OutlineTree[] {
+    // Sort all the incoming symbols
+    symbols.sort((a, b) => {
+      if (a.range.start.line !== b.range.start.line) {
+        return a.range.start.line - b.range.start.line;
+      }
+
+      if (a.range.start.character !== b.range.start.character) {
+        return a.range.start.character - b.range.start.character;
+      }
+
+      if (a.range.end.line !== b.range.end.line) {
+        return a.range.end.line - b.range.end.line;
+      }
+
+      return a.range.end.character - b.range.end.character;
+    });
+
+    return symbols.map((symbol) => {
+      const tree = OutlineViewAdapter.hierarchicalSymbolToOutline(symbol);
+
+      if (symbol.children != null) {
+        tree.children = OutlineViewAdapter.createHierarchicalOutlineTrees(
+          symbol.children);
+      }
+
+      return tree;
+    });
   }
 
   // Public: Create an {Array} of {OutlineTree}s from the Array of {SymbolInformation} recieved
@@ -62,6 +107,13 @@ export default class OutlineViewAdapter {
   //
   // Returns an {OutlineTree} containing the given symbols that the Outline View can display.
   public static createOutlineTrees(symbols: SymbolInformation[]): atomIde.OutlineTree[] {
+    symbols.sort(
+      (a, b) =>
+        (a.location.range.start.line === b.location.range.start.line
+          ? a.location.range.start.character - b.location.range.start.character
+          : a.location.range.start.line - b.location.range.start.line),
+    );
+
     // Temporarily keep containerName through the conversion process
     // Also filter out symbols without a name - it's part of the spec but some don't include it
     const allItems = symbols.filter((symbol) => symbol.name).map((symbol) => ({
@@ -145,6 +197,31 @@ export default class OutlineViewAdapter {
     }
 
     return parent || null;
+  }
+
+  // Public: Convert an individual {DocumentSymbol} from the language server
+  // to an {OutlineTree} for use by the Outline View. It does NOT recursively
+  // process the given symbol's children (if any).
+  //
+  // * `symbol` The {DocumentSymbol} to convert to an {OutlineTree}.
+  //
+  // Returns the {OutlineTree} corresponding to the given {DocumentSymbol}.
+  public static hierarchicalSymbolToOutline(symbol: DocumentSymbol): atomIde.OutlineTree {
+    const icon = OutlineViewAdapter.symbolKindToEntityKind(symbol.kind);
+
+    return {
+      tokenizedText: [
+        {
+          kind: OutlineViewAdapter.symbolKindToTokenKind(symbol.kind),
+          value: symbol.name,
+        },
+      ],
+      icon: icon != null ? icon : undefined,
+      representativeName: symbol.name,
+      startPosition: Convert.positionToPoint(symbol.selectionRange.start),
+      endPosition: Convert.positionToPoint(symbol.selectionRange.end),
+      children: [],
+    };
   }
 
   // Public: Convert an individual {SymbolInformation} from the language server

--- a/lib/adapters/outline-view-adapter.ts
+++ b/lib/adapters/outline-view-adapter.ts
@@ -44,8 +44,13 @@ export default class OutlineViewAdapter {
       connection.documentSymbol({textDocument: Convert.editorToTextDocumentIdentifier(editor)}, cancellationToken),
     );
 
-    if ((results.length !== 0) &&
-        ((results[0] as DocumentSymbol).selectionRange !== undefined)) {
+    if (results.length === 0) {
+      return {
+        outlineTrees: [],
+      };
+    }
+
+    if ((results[0] as DocumentSymbol).selectionRange !== undefined) {
       // If the server is giving back the newer DocumentSymbol format.
       return {
         outlineTrees: OutlineViewAdapter.createHierarchicalOutlineTrees(

--- a/lib/auto-languageclient.ts
+++ b/lib/auto-languageclient.ts
@@ -116,12 +116,15 @@ export default class AutoLanguageClient {
       processId: process.pid,
       rootPath: projectPath,
       rootUri: Convert.pathToUri(projectPath),
+      workspaceFolders: [],
       capabilities: {
         workspace: {
           applyEdit: true,
+          configuration: false,
           workspaceEdit: {
             documentChanges: true,
           },
+          workspaceFolders: false,
           didChangeConfiguration: {
             dynamicRegistration: false,
           },
@@ -189,6 +192,13 @@ export default class AutoLanguageClient {
           rename: {
             dynamicRegistration: false,
           },
+
+          // We do not support these features yet.
+          // Need to set to undefined to appease TypeScript weak type detection.
+          implementation: undefined,
+          typeDefinition: undefined,
+          colorProvider: undefined,
+          foldingRange: undefined,
         },
         experimental: {},
       },

--- a/lib/auto-languageclient.ts
+++ b/lib/auto-languageclient.ts
@@ -167,6 +167,7 @@ export default class AutoLanguageClient {
           },
           documentSymbol: {
             dynamicRegistration: false,
+            hierarchicalDocumentSymbolSupport: true,
           },
           formatting: {
             dynamicRegistration: false,

--- a/lib/languageclient.ts
+++ b/lib/languageclient.ts
@@ -308,7 +308,7 @@ export class LanguageClientConnection extends EventEmitter {
   public documentSymbol(
     params: lsp.DocumentSymbolParams,
     cancellationToken?: jsonrpc.CancellationToken,
-  ): Promise<lsp.SymbolInformation[]> {
+  ): Promise<lsp.SymbolInformation[] | lsp.DocumentSymbol[]> {
     return this._sendRequest('textDocument/documentSymbol', params);
   }
 

--- a/package.json
+++ b/package.json
@@ -18,9 +18,9 @@
     "@types/atom": "^1.28.0",
     "@types/node": "^8.0.41",
     "fuzzaldrin-plus": "^0.6.0",
-    "vscode-jsonrpc": "3.6.2",
-    "vscode-languageserver-protocol": "3.6.0-next.5",
-    "vscode-languageserver-types": "3.6.1"
+    "vscode-jsonrpc": "3.7.0-next.1",
+    "vscode-languageserver-protocol": "3.11.0",
+    "vscode-languageserver-types": "3.11.0"
   },
   "atomTestRunner": "./build/test/runner",
   "devDependencies": {


### PR DESCRIPTION
Closes #235 

This PR implements support for the new `DocumentSymbol` response format in the `textDocument$documentSymbol` LSP method.

With this PR, `atom-languageclient` will advertise to the language server that it supports the newer format. If it then receives a response in the new format from the server, it will render the response using the new routine. If the server sends back a response in the old format, the response will be rendered as before.

In order to support the new `DocumentSymbol` feature, `vscode-languageserver-*` dependency versions have been bumped. Several minor changes were required to fix up typing (see the first commit for those changes).

I added unit tests and made sure `npm test` passes. I also manually tested that both the old-format code path and the new-format code path work. It's my first time contributing to `atom-languageclient` so definitely let me know if I should test anything else :)