### PR TITLE
Provide new log filter mechanism and console logging defaults

### DIFF
--- a/lib/auto-languageclient.ts
+++ b/lib/auto-languageclient.ts
@@ -24,7 +24,7 @@ import { Socket } from 'net';
 import { LanguageClientConnection } from './languageclient';
 import {
   ConsoleLogger,
-  NullLogger,
+  FilteredLogger,
   Logger,
 } from './logger';
 import {
@@ -283,9 +283,10 @@ export default class AutoLanguageClient {
     return cp.spawn(process.execPath, args, options);
   }
 
-  // By default LSP logging is switched off but you can switch it on via the core.debugLSP setting
+  // LSP logging is only set for warnings & errors by default unless you turn on the core.debugLSP setting
   protected getLogger(): Logger {
-    return atom.config.get('core.debugLSP') ? new ConsoleLogger(this.name) : new NullLogger();
+    const filter = atom.config.get('core.debugLSP') ? FilteredLogger.DeveloperLevelFilter : FilteredLogger.UserLevelFilter;
+    return new FilteredLogger(new ConsoleLogger(this.name), filter);
   }
 
   // Starts the server by starting the process, then initializing the language server and starting adapters

--- a/lib/auto-languageclient.ts
+++ b/lib/auto-languageclient.ts
@@ -285,7 +285,9 @@ export default class AutoLanguageClient {
 
   // LSP logging is only set for warnings & errors by default unless you turn on the core.debugLSP setting
   protected getLogger(): Logger {
-    const filter = atom.config.get('core.debugLSP') ? FilteredLogger.DeveloperLevelFilter : FilteredLogger.UserLevelFilter;
+    const filter = atom.config.get('core.debugLSP')
+      ? FilteredLogger.DeveloperLevelFilter
+      : FilteredLogger.UserLevelFilter;
     return new FilteredLogger(new ConsoleLogger(this.name), filter);
   }
 

--- a/lib/logger.ts
+++ b/lib/logger.ts
@@ -72,27 +72,32 @@ export class FilteredLogger {
   }
 
   public warn(...args: any[]): void {
-    if (this._predicate('warn', args))
+    if (this._predicate('warn', args)) {
       this._logger.warn(args);
+    }
   }
 
   public error(...args: any[]): void {
-    if (this._predicate('error', args))
+    if (this._predicate('error', args)) {
       this._logger.error(args);
+    }
   }
 
   public info(...args: any[]): void {
-    if (this._predicate('info', args))
+    if (this._predicate('info', args)) {
       this._logger.info(args);
+    }
   }
 
   public debug(...args: any[]): void {
-    if (this._predicate('debug', args))
+    if (this._predicate('debug', args)) {
       this._logger.debug(args);
+    }
   }
 
   public log(...args: any[]): void {
-    if (this._predicate('log', args))
+    if (this._predicate('log', args)) {
       this._logger.log(args);
+    }
   }
 }

--- a/lib/logger.ts
+++ b/lib/logger.ts
@@ -15,23 +15,23 @@ export class ConsoleLogger {
     this.prefix = prefix;
   }
 
-  public warn(...args: any[]) {
+  public warn(...args: any[]): void {
     console.warn(...this.format(args));
   }
 
-  public error(...args: any[]) {
+  public error(...args: any[]): void {
     console.error(...this.format(args));
   }
 
-  public info(...args: any[]) {
+  public info(...args: any[]): void {
     console.info(...this.format(args));
   }
 
-  public debug(...args: any[]) {
+  public debug(...args: any[]): void {
     console.debug(...this.format(args));
   }
 
-  public log(...args: any[]) {
+  public log(...args: any[]): void {
     console.log(...this.format(args));
   }
 
@@ -57,4 +57,42 @@ export class NullLogger {
   public info(...args: any[]): void {}
   public log(...args: any[]): void {}
   public debug(...args: any[]): void {}
+}
+
+export class FilteredLogger {
+  private _logger: Logger;
+  private _predicate: (level: string, args: any[]) => boolean;
+
+  public static UserLevelFilter = (level: string, args: any[]) => level === 'warn' || level === 'error';
+  public static DeveloperLevelFilter = (level: string, args: any[]) => true;
+
+  constructor(logger: Logger, predicate?: (level: string, args: any[]) => boolean) {
+    this._logger = logger;
+    this._predicate = predicate || ((level, args) => true);
+  }
+
+  public warn(...args: any[]): void {
+    if (this._predicate('warn', args))
+      this._logger.warn(args);
+  }
+
+  public error(...args: any[]): void {
+    if (this._predicate('error', args))
+      this._logger.error(args);
+  }
+
+  public info(...args: any[]): void {
+    if (this._predicate('info', args))
+      this._logger.info(args);
+  }
+
+  public debug(...args: any[]): void {
+    if (this._predicate('debug', args))
+      this._logger.debug(args);
+  }
+
+  public log(...args: any[]): void {
+    if (this._predicate('log', args))
+      this._logger.log(args);
+  }
 }

--- a/lib/main.ts
+++ b/lib/main.ts
@@ -5,6 +5,7 @@
 
 import AutoLanguageClient from './auto-languageclient';
 import Convert from './convert';
+import {Logger, ConsoleLogger, FilteredLogger} from './logger';
 import DownloadFile from './download-file';
 import LinterPushV2Adapter from './adapters/linter-push-v2-adapter';
 
@@ -12,6 +13,9 @@ export * from './auto-languageclient';
 export {
   AutoLanguageClient,
   Convert,
+  Logger,
+  ConsoleLogger,
+  FilteredLogger,
   DownloadFile,
-  LinterPushV2Adapter,
+  LinterPushV2Adapter
 };

--- a/lib/main.ts
+++ b/lib/main.ts
@@ -5,7 +5,7 @@
 
 import AutoLanguageClient from './auto-languageclient';
 import Convert from './convert';
-import {Logger, ConsoleLogger, FilteredLogger} from './logger';
+import { Logger, ConsoleLogger, FilteredLogger } from './logger';
 import DownloadFile from './download-file';
 import LinterPushV2Adapter from './adapters/linter-push-v2-adapter';
 
@@ -17,5 +17,5 @@ export {
   ConsoleLogger,
   FilteredLogger,
   DownloadFile,
-  LinterPushV2Adapter
+  LinterPushV2Adapter,
 };


### PR DESCRIPTION
Right now it's all-or-nothing with the logging facilities via the `debugLSP` atom setting.

This introduces filterable logging so that:

a. We can log debug and warning to the console by default even when this setting is off
b. We will continue to log everything to the console when `debugLSP` is set to true
c. ide-x package authors can easily provide their own levels of filtering
d. ide-x package authors can provide their own interception of error messages to handle specific situations