### PR TITLE
Fix logging array wrappers

### DIFF
--- a/lib/logger.ts
+++ b/lib/logger.ts
@@ -73,31 +73,31 @@ export class FilteredLogger {
 
   public warn(...args: any[]): void {
     if (this._predicate('warn', args)) {
-      this._logger.warn(args);
+      this._logger.warn(...args);
     }
   }
 
   public error(...args: any[]): void {
     if (this._predicate('error', args)) {
-      this._logger.error(args);
+      this._logger.error(...args);
     }
   }
 
   public info(...args: any[]): void {
     if (this._predicate('info', args)) {
-      this._logger.info(args);
+      this._logger.info(...args);
     }
   }
 
   public debug(...args: any[]): void {
     if (this._predicate('debug', args)) {
-      this._logger.debug(args);
+      this._logger.debug(...args);
     }
   }
 
   public log(...args: any[]): void {
     if (this._predicate('log', args)) {
-      this._logger.log(args);
+      this._logger.log(...args);
     }
   }
 }


### PR DESCRIPTION
Always worth remembering that even after all the typescript type safety, forgetting to write 3 dots can still screw stuff up :stuck_out_tongue_winking_eye:.

### Before
![before](https://user-images.githubusercontent.com/2331607/49182918-69f06f00-f353-11e8-8097-658df002faf9.png)

### After fix
![](https://user-images.githubusercontent.com/2331607/49182927-7248aa00-f353-11e8-8587-fca6ae2e2134.png)
