### PR TITLE
support non project root language servers

### DIFF
--- a/lib/adapters/apply-edit-adapter.ts
+++ b/lib/adapters/apply-edit-adapter.ts
@@ -4,6 +4,7 @@ import {
   LanguageClientConnection,
   ApplyWorkspaceEditParams,
   ApplyWorkspaceEditResponse,
+  TextDocumentEdit,
 } from '../languageclient';
 import {
   TextBuffer,
@@ -49,7 +50,7 @@ export default class ApplyEditAdapter {
     if (params.edit.documentChanges) {
       changes = {};
       params.edit.documentChanges.forEach((change) => {
-        if (change && change.textDocument) {
+        if (TextDocumentEdit.is(change) && change.textDocument) {
           changes[change.textDocument.uri] = change.edits;
         }
       });

--- a/lib/auto-languageclient.ts
+++ b/lib/auto-languageclient.ts
@@ -227,6 +227,17 @@ export default class AutoLanguageClient {
     return configuration;
   }
 
+  // Determine the project path
+  protected async determineProjectPath(editor: TextEditor): Promise<string | null> {
+    const filePath = editor.getPath();
+    if (filePath == null) {
+      return null;
+    }
+    return atom.project.getDirectories()
+      .map((d) => Utils.normalizePath(d.getPath()))
+      .find((d) => filePath.startsWith(d)) || null;
+  }
+
   // Helper methods that are useful for implementors
   // ---------------------------------------------------------------------------
 
@@ -256,6 +267,7 @@ export default class AutoLanguageClient {
       (filepath) => this.filterChangeWatchedFiles(filepath),
       this.reportBusyWhile,
       this.getServerName(),
+      (e) => this.determineProjectPath(e),
     );
     this._serverManager.startListening();
     process.on('exit', () => this.exitCleanup.bind(this));

--- a/lib/server-manager.ts
+++ b/lib/server-manager.ts
@@ -9,7 +9,7 @@ import {
   FilesystemChangeEvent,
   TextEditor,
 } from 'atom';
-import { ReportBusyWhile } from './utils';
+import { normalizePath, ReportBusyWhile } from './utils';
 
 // Public: Defines the minimum surface area for an object that resembles a
 // ChildProcess.  This is used so that language packages with alternative
@@ -49,7 +49,6 @@ export class ServerManager {
   private _stoppingServers: ActiveServer[] = [];
   private _disposable: CompositeDisposable = new CompositeDisposable();
   private _editorToServer: Map<TextEditor, ActiveServer> = new Map();
-  private _normalizedProjectPaths: string[] = [];
   private _isStarted = false;
 
   constructor(
@@ -59,8 +58,8 @@ export class ServerManager {
     private _changeWatchedFileFilter: (filePath: string) => boolean,
     private _reportBusyWhile: ReportBusyWhile,
     private _languageServerName: string,
+    private _determineProjectPath: (editor: TextEditor) => Promise<string | null>,
   ) {
-    this.updateNormalizedProjectPaths();
   }
 
   public startListening(): void {
@@ -131,7 +130,7 @@ export class ServerManager {
     textEditor: TextEditor,
     { shouldStart }: { shouldStart?: boolean } = { shouldStart: false },
   ): Promise<ActiveServer | null> {
-    const finalProjectPath = this.determineProjectPath(textEditor);
+    const finalProjectPath = await this._determineProjectPath(textEditor);
     if (finalProjectPath == null) {
       // Files not yet saved have no path
       return null;
@@ -254,27 +253,10 @@ export class ServerManager {
     });
   }
 
-  public determineProjectPath(textEditor: TextEditor): string | null {
-    const filePath = textEditor.getPath();
-    if (filePath == null) {
-      return null;
-    }
-    return this._normalizedProjectPaths.find((d) => filePath.startsWith(d)) || null;
-  }
-
-  public updateNormalizedProjectPaths(): void {
-    this._normalizedProjectPaths = atom.project.getDirectories().map((d) => this.normalizePath(d.getPath()));
-  }
-
-  public normalizePath(projectPath: string): string {
-    return !projectPath.endsWith(path.sep) ? path.join(projectPath, path.sep) : projectPath;
-  }
-
   public async projectPathsChanged(projectPaths: string[]): Promise<void> {
-    const pathsSet = new Set(projectPaths.map(this.normalizePath));
+    const pathsSet = new Set(projectPaths.map(normalizePath));
     const serversToStop = this._activeServers.filter((s) => !pathsSet.has(s.projectPath));
     await Promise.all(serversToStop.map((s) => this.stopServer(s)));
-    this.updateNormalizedProjectPaths();
   }
 
   public projectFilesChanged(fileEvents: FilesystemChangeEvent): void {

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -1,3 +1,4 @@
+import * as path from 'path';
 import {
   Point,
   TextBuffer,
@@ -110,4 +111,8 @@ export function promiseWithTimeout<T>(ms: number, promise: Promise<T>): Promise<
       reject(err);
     });
   });
+}
+
+export function normalizePath(p: string): string {
+  return !p.endsWith(path.sep) ? path.join(p, path.sep) : p;
 }


### PR DESCRIPTION
fixes #233 

The only thing missing (IMO) was that language packages had to override  `determineProjectPath` so that they can provide an alternate language server root instead of the atom project root folder.

/cc @damieng 