### PR TITLE
Support null completions

### DIFF
--- a/lib/adapters/autocomplete-adapter.ts
+++ b/lib/adapters/autocomplete-adapter.ts
@@ -278,11 +278,11 @@ export default class AutocompleteAdapter {
   //
   // Returns a {Map} of AutoComplete+ suggestions ordered by the CompletionItems sortText.
   public completionItemsToSuggestions(
-    completionItems: CompletionItem[] | CompletionList,
+    completionItems: CompletionItem[] | CompletionList | null,
     request: ac.SuggestionsRequestedEvent,
     onDidConvertCompletionItem?: CompletionItemAdjuster,
   ): Map<ac.AnySuggestion, PossiblyResolvedCompletionItem> {
-    return new Map((Array.isArray(completionItems) ? completionItems : completionItems.items || [])
+    return new Map((Array.isArray(completionItems) ? completionItems : (completionItems && completionItems.items || []))
       .sort((a, b) => (a.sortText || a.label).localeCompare(b.sortText || b.label))
       .map<[ac.AnySuggestion, PossiblyResolvedCompletionItem]>(
         (s) => [

--- a/lib/languageclient.ts
+++ b/lib/languageclient.ts
@@ -241,7 +241,7 @@ export class LanguageClientConnection extends EventEmitter {
   // Returns a {Promise} containing either a {CompletionList} or an {Array} of {CompletionItem}s.
   public completion(
     params: lsp.TextDocumentPositionParams | CompletionParams,
-    cancellationToken?: jsonrpc.CancellationToken): Promise<lsp.CompletionItem[] | lsp.CompletionList> {
+    cancellationToken?: jsonrpc.CancellationToken): Promise<lsp.CompletionItem[] | lsp.CompletionList | null> {
     // Cancel prior request if necessary
     return this._sendRequest('textDocument/completion', params, cancellationToken);
   }


### PR DESCRIPTION
Adds on to the commit closing #246. The first solution didn't reach far enough, and the possibility of `completions` being null wans't reflected in the types.

This change should comprehensively support a null value.

(Also see [the response section](https://microsoft.github.io/language-server-protocol/specification#textDocument_completion) of the protocol to confirm `null` is a valid return value)