### PR TITLE
Use definition to indicate out-of-project files with server support

### DIFF
--- a/lib/auto-languageclient.ts
+++ b/lib/auto-languageclient.ts
@@ -318,7 +318,7 @@ export default class AutoLanguageClient {
         if (!defPath.startsWith(projectPath)) {
           newServer.additionalPaths.add(path.dirname(defPath));
         }
-      }
+      },
     };
     this.postInitialization(newServer);
     connection.initialized();
@@ -538,7 +538,7 @@ export default class AutoLanguageClient {
     );
 
     if (this.serversSupportDefinitionDestinations()) {
-      queryPromise.then(query => {
+      queryPromise.then((query) => {
         if (query) {
           for (const def of query.definitions) {
             server.considerDefinitionPath(def.path);

--- a/lib/server-manager.ts
+++ b/lib/server-manager.ts
@@ -269,9 +269,9 @@ export class ServerManager {
       return projectPath;
     }
 
-    let serverWithClaim = this._activeServers
-      .find(s => s.additionalPaths.has(path.dirname(filePath)));
-    return serverWithClaim && this.normalizePath(serverWithClaim.projectPath) || null
+    const serverWithClaim = this._activeServers
+      .find((s) => s.additionalPaths.has(path.dirname(filePath)));
+    return serverWithClaim && this.normalizePath(serverWithClaim.projectPath) || null;
   }
 
   public updateNormalizedProjectPaths(): void {

--- a/test/adapters/autocomplete-adapter.test.ts
+++ b/test/adapters/autocomplete-adapter.test.ts
@@ -20,6 +20,8 @@ describe('AutoCompleteAdapter', () => {
       disposable: new CompositeDisposable(),
       process: undefined as any,
       projectPath: '/',
+      additionalPaths: new Set(),
+      considerDefinitionPath: (_: string): void => {},
     };
   }
 


### PR DESCRIPTION
Language servers can support out of project files, ie RLS dependencies which cargo puts somewhere in `~/.cargo/`. However, currently ide-rust cannot support any LSP functionality for dependency sources or the rust std library because atom-languageclient does not know these files may be of interest to the RLS.

This change optionally uses `textDocument/definition` responses to imply a server's support of the returned out-of-project source directories.

When matching a the editor's file path to a server these implications are taken into account if we cannot otherwise find a server from the path.

The method `serversSupportDefinitionDestinations(): boolean` is overridden by the client concrete class to opt into this behaviour.

Fixes #244

Using this technique is very effective for ide-rust
![](https://user-images.githubusercontent.com/2331607/52712284-065a0300-2f8c-11e9-8735-e991ef47aa53.gif)


This feature is also available in my fork:
```json
"dependencies": {
  "atom-languageclient": "github:alexheretic/atom-languageclient#build",
}
```