### PR TITLE
Make npm test run tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,8 +12,9 @@
     "watch": "tsc -watch",
     "lint": "tslint -c tslint.json 'lib/**/*.ts' 'test/**/*.ts' 'typings/**/*.d.ts'",
     "prepublish": "npm run clean && npm run compile",
-    "test": "npm run compile && npm run lint && atom --test test"
+    "test": "npm run compile && npm run lint && atom --test build/test"
   },
+  "atomTestRunner": "./test/runner",
   "dependencies": {
     "fuzzaldrin-plus": "^0.6.0",
     "vscode-jsonrpc": "4.0.0",
@@ -21,6 +22,7 @@
     "vscode-languageserver-types": "3.12.0"
   },
   "devDependencies": {
+    "@smashwilson/atom-mocha-test-runner": "^1.4.0",
     "@types/atom": "^1.31.0",
     "@types/chai": "^4.1.7",
     "@types/fuzzaldrin-plus": "0.6.0",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "watch": "tsc -watch",
     "lint": "tslint -c tslint.json 'lib/**/*.ts' 'test/**/*.ts' 'typings/**/*.d.ts'",
     "prepublish": "npm run clean && npm run compile",
-    "test": "npm run compile && npm run lint && atom --test build/test"
+    "test": "npm run compile && npm run lint && atom --test test"
   },
   "dependencies": {
     "fuzzaldrin-plus": "^0.6.0",

--- a/script/cibuild
+++ b/script/cibuild
@@ -103,4 +103,4 @@ echo "Running lint..."
 npm run lint
 
 echo "Running specs..."
-"$ATOM_SCRIPT_PATH" --test test
+npm test

--- a/script/cibuild
+++ b/script/cibuild
@@ -103,4 +103,4 @@ echo "Running lint..."
 npm run lint
 
 echo "Running specs..."
-npm test
+"$ATOM_SCRIPT_PATH" --test build/test

--- a/script/cibuild
+++ b/script/cibuild
@@ -103,4 +103,4 @@ echo "Running lint..."
 npm run lint
 
 echo "Running specs..."
-"$ATOM_SCRIPT_PATH" --test build/test
+"$ATOM_SCRIPT_PATH" --test test

--- a/test/runner.js
+++ b/test/runner.js
@@ -1,0 +1,14 @@
+const { TestRunnerParams } = require("atom");
+const { createRunner } = require('@smashwilson/atom-mocha-test-runner');
+
+module.exports = createRunner({
+    htmlTitle: `atom-languageclient Tests - pid ${process.pid}`,
+    reporter: process.env.MOCHA_REPORTER || 'list',
+  },
+  (mocha) => {
+    mocha.timeout(parseInt(process.env.MOCHA_TIMEOUT || '5000', 10));
+    if (process.env.APPVEYOR_API_URL) {
+      mocha.reporter(require('mocha-appveyor-reporter'));
+    }
+  },
+);


### PR DESCRIPTION
Noticed in https://github.com/atom/atom-languageclient/pull/254#issuecomment-466620889.

The test runner was removed in https://github.com/atom/atom-languageclient/commit/1251de86fa9f31f66eadff6e66d8e39c1a94c664 due to security vulnerabilities, which led to Atom trying to use the default Jasmine runner and not finding any `-spec` files. The new test runner, `@smashwilson/atom-mocha-test-runner`, does not have any vulnerabilities.