### PR TITLE
Remove uses of deprecated sinon.sandbox.create()

### DIFF
--- a/test/adapters/autocomplete-adapter.test.ts
+++ b/test/adapters/autocomplete-adapter.test.ts
@@ -23,13 +23,6 @@ describe('AutoCompleteAdapter', () => {
     };
   }
 
-  beforeEach(() => {
-    (global as any).sinon = sinon.sandbox.create();
-  });
-  afterEach(() => {
-    (global as any).sinon.restore();
-  });
-
   const request: ac.SuggestionsRequestedEvent = {
     editor: createFakeEditor(),
     bufferPosition: new Point(123, 456),

--- a/test/adapters/datatip-adapter.test.ts
+++ b/test/adapters/datatip-adapter.test.ts
@@ -11,12 +11,8 @@ describe('DatatipAdapter', () => {
   let connection: any;
 
   beforeEach(() => {
-    (global as any).sinon = sinon.sandbox.create();
     connection = new ls.LanguageClientConnection(createSpyConnection());
     fakeEditor = createFakeEditor();
-  });
-  afterEach(() => {
-    (global as any).sinon.restore();
   });
 
   describe('canAdapt', () => {

--- a/test/adapters/linter-push-v2-adapter.test.ts
+++ b/test/adapters/linter-push-v2-adapter.test.ts
@@ -8,13 +8,6 @@ import { Point, Range } from 'atom';
 import { createSpyConnection, createFakeEditor } from '../helpers.js';
 
 describe('LinterPushV2Adapter', () => {
-  beforeEach(() => {
-    (global as any).sinon = sinon.sandbox.create();
-  });
-  afterEach(() => {
-    (global as any).sinon.restore();
-  });
-
   describe('constructor', () => {
     it('subscribes to onPublishDiagnostics', () => {
       const languageClient = new ls.LanguageClientConnection(createSpyConnection());

--- a/test/adapters/outline-view-adapter.test.ts
+++ b/test/adapters/outline-view-adapter.test.ts
@@ -1,6 +1,5 @@
 import OutlineViewAdapter from '../../lib/adapters/outline-view-adapter';
 import * as ls from '../../lib/languageclient';
-import * as sinon from 'sinon';
 import { expect } from 'chai';
 import { Point } from 'atom';
 
@@ -12,13 +11,6 @@ describe('OutlineViewAdapter', () => {
   const createLocation = (a: any, b: any, c: any, d: any) => ({
     uri: '',
     range: createRange(a, b, c, d),
-  });
-
-  beforeEach(() => {
-    (global as any).sinon = sinon.sandbox.create();
-  });
-  afterEach(() => {
-    (global as any).sinon.restore();
   });
 
   describe('canAdapt', () => {

--- a/test/languageclient.test.ts
+++ b/test/languageclient.test.ts
@@ -5,13 +5,6 @@ import { createSpyConnection } from './helpers.js';
 import { NullLogger } from '../lib/logger';
 
 describe('LanguageClientConnection', () => {
-  beforeEach(() => {
-    (global as any).sinon = sinon.sandbox.create();
-  });
-  afterEach(() => {
-    (global as any).sinon.restore();
-  });
-
   it('listens to the RPC connection it is given', () => {
     const rpc = createSpyConnection();
 


### PR DESCRIPTION
In #256, I noticed that we were hitting a bunch of deprecation warnings when using sinon.