### PR TITLE
Prepare, not prepublish

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "compile": "tsc",
     "watch": "tsc -watch",
     "lint": "tslint -c tslint.json 'lib/**/*.ts' 'test/**/*.ts' 'typings/**/*.d.ts'",
-    "prepublish": "npm run clean && npm run compile",
+    "prepare": "npm run clean && npm run compile",
     "test": "npm run compile && npm run lint && atom --test build/test"
   },
   "atomTestRunner": "./test/runner",


### PR DESCRIPTION
`prepublish` has been deprecated since npm@5. Changing this means that `atom-languageclient` won't build successfully on versions earlier than that, but I don't see that as an issue considering Atom's infrastructure uses npm@6 at this point.