### PR TITLE
Convert doc comments to TSDoc syntax

### DIFF
--- a/lib/adapters/apply-edit-adapter.ts
+++ b/lib/adapters/apply-edit-adapter.ts
@@ -10,9 +10,9 @@ import {
   TextEditor,
 } from 'atom';
 
-/**  Public: Adapts workspace/applyEdit commands to editors. */
+/** Public: Adapts workspace/applyEdit commands to editors. */
 export default class ApplyEditAdapter {
-  /**  Public: Attach to a {LanguageClientConnection} to receive edit events. */
+  /** Public: Attach to a {LanguageClientConnection} to receive edit events. */
   public static attach(connection: LanguageClientConnection) {
     connection.onApplyEdit((m) => ApplyEditAdapter.onApplyEdit(m));
   }
@@ -94,7 +94,7 @@ export default class ApplyEditAdapter {
     return { applied };
   }
 
-  /**  Private: Do some basic sanity checking on the edit ranges. */
+  /** Private: Do some basic sanity checking on the edit ranges. */
   private static validateEdit(
     buffer: TextBuffer,
     edit: atomIde.TextEdit,

--- a/lib/adapters/apply-edit-adapter.ts
+++ b/lib/adapters/apply-edit-adapter.ts
@@ -10,9 +10,9 @@ import {
   TextEditor,
 } from 'atom';
 
-// Public: Adapts workspace/applyEdit commands to editors.
+/**  Public: Adapts workspace/applyEdit commands to editors. */
 export default class ApplyEditAdapter {
-  // Public: Attach to a {LanguageClientConnection} to receive edit events.
+  /**  Public: Attach to a {LanguageClientConnection} to receive edit events. */
   public static attach(connection: LanguageClientConnection) {
     connection.onApplyEdit((m) => ApplyEditAdapter.onApplyEdit(m));
   }
@@ -94,7 +94,7 @@ export default class ApplyEditAdapter {
     return { applied };
   }
 
-  // Private: Do some basic sanity checking on the edit ranges.
+  /**  Private: Do some basic sanity checking on the edit ranges. */
   private static validateEdit(
     buffer: TextBuffer,
     edit: atomIde.TextEdit,

--- a/lib/adapters/autocomplete-adapter.ts
+++ b/lib/adapters/autocomplete-adapter.ts
@@ -64,10 +64,10 @@ export default class AutocompleteAdapter {
    * @param server An {ActiveServer} pointing to the language server to query.
    * @param request The {atom$AutocompleteRequest} to satisfy.
    * @param onDidConvertCompletionItem An optional function that takes a {CompletionItem},
-   *     an {atom$AutocompleteSuggestion} and a {atom$AutocompleteRequest}
-   *     allowing you to adjust converted items.
+   *   an {atom$AutocompleteSuggestion} and a {atom$AutocompleteRequest}
+   *   allowing you to adjust converted items.
    * @returns A {Promise} of an {Array} of {atom$AutocompleteSuggestion}s containing the
-   *          AutoComplete+ suggestions to display.
+   *   AutoComplete+ suggestions to display.
    */
   public async getSuggestions(
     server: ActiveServer,
@@ -187,9 +187,9 @@ export default class AutocompleteAdapter {
    * @param request An {Array} of {atom$AutocompleteSuggestion}s to locate the prefix, editor, bufferPosition etc.
    * @param triggerChars The {Array} of {string}s that can be trigger characters.
    * @returns A [{string}, boolean] where the string is the matching trigger character or an empty string
-   * if one was not matched, and the boolean is true if the trigger character is in request.prefix, and false
-   * if it is in the word before request.prefix. The boolean return value has no meaning if the string return
-   * value is an empty string.
+   *   if one was not matched, and the boolean is true if the trigger character is in request.prefix, and false
+   *   if it is in the word before request.prefix. The boolean return value has no meaning if the string return
+   *   value is an empty string.
    */
   public static getTriggerCharacter(
     request: ac.SuggestionsRequestedEvent,
@@ -242,9 +242,9 @@ export default class AutocompleteAdapter {
    * @param triggerCharacter The {string} containing the trigger character (empty if none).
    * @param triggerOnly A {boolean} representing whether this completion is triggered right after a trigger character.
    * @returns A {CompletionParams} with the keys:
-   *  * `textDocument` the language server protocol textDocument identification.
-   *  * `position` the position within the text document to display completion request for.
-   *  * `context` containing the trigger character and kind.
+   *   * `textDocument` the language server protocol textDocument identification.
+   *   * `position` the position within the text document to display completion request for.
+   *   * `context` containing the trigger character and kind.
    */
   public static createCompletionParams(
     request: ac.SuggestionsRequestedEvent,
@@ -265,7 +265,7 @@ export default class AutocompleteAdapter {
    * @param triggerCharacter The {string} containing the trigger character or '' if none.
    * @param triggerOnly A {boolean} representing whether this completion is triggered right after a trigger character.
    * @returns An {CompletionContext} that specifies the triggerKind and the triggerCharacter
-   *          if there is one.
+   *   if there is one.
    */
   public static createCompletionContext(triggerCharacter: string, triggerOnly: boolean): CompletionContext {
     if (triggerCharacter === '') {
@@ -282,7 +282,7 @@ export default class AutocompleteAdapter {
    * an array of ordered AutoComplete+ suggestions.
    *
    * @param completionItems An {Array} of {CompletionItem} objects or a {CompletionList} containing completion
-   *           items to be converted.
+   *   items to be converted.
    * @param request The {atom$AutocompleteRequest} to satisfy.
    * @param onDidConvertCompletionItem A function that takes a {CompletionItem}, an {atom$AutocompleteSuggestion}
    *   and a {atom$AutocompleteRequest} allowing you to adjust converted items.

--- a/lib/adapters/autocomplete-adapter.ts
+++ b/lib/adapters/autocomplete-adapter.ts
@@ -40,8 +40,10 @@ class PossiblyResolvedCompletionItem {
   }
 }
 
-// Public: Adapts the language server protocol "textDocument/completion" to the Atom
-// AutoComplete+ package.
+/**
+ * Public: Adapts the language server protocol "textDocument/completion" to the Atom
+ * AutoComplete+ package.
+ */
 export default class AutocompleteAdapter {
   public static canAdapt(serverCapabilities: ServerCapabilities): boolean {
     return serverCapabilities.completionProvider != null;
@@ -55,16 +57,18 @@ export default class AutocompleteAdapter {
   private _suggestionCache: WeakMap<ActiveServer, SuggestionCacheEntry> = new WeakMap();
   private _cancellationTokens: WeakMap<LanguageClientConnection, CancellationTokenSource> = new WeakMap();
 
-  // Public: Obtain suggestion list for AutoComplete+ by querying the language server using
-  // the `textDocument/completion` request.
-  //
-  // * `server` An {ActiveServer} pointing to the language server to query.
-  // * `request` The {atom$AutocompleteRequest} to satisfy.
-  // * `onDidConvertCompletionItem` An optional function that takes a {CompletionItem}, an {atom$AutocompleteSuggestion}
-  //   and a {atom$AutocompleteRequest} allowing you to adjust converted items.
-  //
-  // Returns a {Promise} of an {Array} of {atom$AutocompleteSuggestion}s containing the
-  // AutoComplete+ suggestions to display.
+  /**
+   * Public: Obtain suggestion list for AutoComplete+ by querying the language server using
+   * the `textDocument/completion` request.
+   *
+   * @param server An {ActiveServer} pointing to the language server to query.
+   * @param request The {atom$AutocompleteRequest} to satisfy.
+   * @param onDidConvertCompletionItem An optional function that takes a {CompletionItem},
+   *     an {atom$AutocompleteSuggestion} and a {atom$AutocompleteRequest}
+   *     allowing you to adjust converted items.
+   * @returns A {Promise} of an {Array} of {atom$AutocompleteSuggestion}s containing the
+   *          AutoComplete+ suggestions to display.
+   */
   public async getSuggestions(
     server: ActiveServer,
     request: ac.SuggestionsRequestedEvent,
@@ -142,16 +146,17 @@ export default class AutocompleteAdapter {
     return Array.from(suggestionMap.keys());
   }
 
-  // Public: Obtain a complete version of a suggestion with additional information
-  // the language server can provide by way of the `completionItem/resolve` request.
-  //
-  // * `server` An {ActiveServer} pointing to the language server to query.
-  // * `suggestion` An {atom$AutocompleteSuggestion} suggestion that should be resolved.
-  // * `request` An {Object} with the AutoComplete+ request to satisfy.
-  // * `onDidConvertCompletionItem` An optional function that takes a {CompletionItem}, an {atom$AutocompleteSuggestion}
-  //   and a {atom$AutocompleteRequest} allowing you to adjust converted items.
-  //
-  // Returns a {Promise} of an {atom$AutocompleteSuggestion} with the resolved AutoComplete+ suggestion.
+  /**
+   * Public: Obtain a complete version of a suggestion with additional information
+   * the language server can provide by way of the `completionItem/resolve` request.
+   *
+   * @param server An {ActiveServer} pointing to the language server to query.
+   * @param suggestion An {atom$AutocompleteSuggestion} suggestion that should be resolved.
+   * @param request An {Object} with the AutoComplete+ request to satisfy.
+   * @param onDidConvertCompletionItem An optional function that takes a {CompletionItem}, an
+   *   {atom$AutocompleteSuggestion} and a {atom$AutocompleteRequest} allowing you to adjust converted items.
+   * @returns A {Promise} of an {atom$AutocompleteSuggestion} with the resolved AutoComplete+ suggestion.
+   */
   public async completeSuggestion(
     server: ActiveServer,
     suggestion: ac.AnySuggestion,
@@ -174,17 +179,18 @@ export default class AutocompleteAdapter {
     return suggestion;
   }
 
-  // Public: Get the trigger character that caused the autocomplete (if any).  This is required because
-  // AutoComplete-plus does not have trigger characters.  Although the terminology is 'character' we treat
-  // them as variable length strings as this will almost certainly change in the future to support '->' etc.
-  //
-  // * `request` An {Array} of {atom$AutocompleteSuggestion}s to locate the prefix, editor, bufferPosition etc.
-  // * `triggerChars` The {Array} of {string}s that can be trigger characters.
-  //
-  // Returns a [{string}, boolean] where the string is the matching trigger character or an empty string
-  // if one was not matched, and the boolean is true if the trigger character is in request.prefix, and false
-  // if it is in the word before request.prefix. The boolean return value has no meaning if the string return
-  // value is an empty string.
+  /**
+   * Public: Get the trigger character that caused the autocomplete (if any).  This is required because
+   * AutoComplete-plus does not have trigger characters.  Although the terminology is 'character' we treat
+   * them as variable length strings as this will almost certainly change in the future to support '->' etc.
+   *
+   * @param request An {Array} of {atom$AutocompleteSuggestion}s to locate the prefix, editor, bufferPosition etc.
+   * @param triggerChars The {Array} of {string}s that can be trigger characters.
+   * @returns A [{string}, boolean] where the string is the matching trigger character or an empty string
+   * if one was not matched, and the boolean is true if the trigger character is in request.prefix, and false
+   * if it is in the word before request.prefix. The boolean return value has no meaning if the string return
+   * value is an empty string.
+   */
   public static getTriggerCharacter(
     request: ac.SuggestionsRequestedEvent,
     triggerChars: string[],
@@ -211,13 +217,14 @@ export default class AutocompleteAdapter {
     return ['', false];
   }
 
-  // Public: Create TextDocumentPositionParams to be sent to the language server
-  // based on the editor and position from the AutoCompleteRequest.
-  //
-  // * `request` The {atom$AutocompleteRequest} to obtain the editor from.
-  // * `triggerPoint` The {atom$Point} where the trigger started.
-  //
-  // Returns a {string} containing the prefix including the trigger character.
+  /**
+   * Public: Create TextDocumentPositionParams to be sent to the language server
+   * based on the editor and position from the AutoCompleteRequest.
+   *
+   * @param request The {atom$AutocompleteRequest} to obtain the editor from.
+   * @param triggerPoint The {atom$Point} where the trigger started.
+   * @returns A {string} containing the prefix including the trigger character.
+   */
   public static getPrefixWithTrigger(
     request: ac.SuggestionsRequestedEvent,
     triggerPoint: Point,
@@ -227,17 +234,18 @@ export default class AutocompleteAdapter {
       .getTextInRange([[triggerPoint.row, triggerPoint.column], request.bufferPosition]);
   }
 
-  // Public: Create {CompletionParams} to be sent to the language server
-  // based on the editor and position from the Autocomplete request etc.
-  //
-  // * `request` The {atom$AutocompleteRequest} containing the request details.
-  // * `triggerCharacter` The {string} containing the trigger character (empty if none).
-  // * `triggerOnly` A {boolean} representing whether this completion is triggered right after a trigger character.
-  //
-  // Returns an {CompletionParams} with the keys:
-  //  * `textDocument` the language server protocol textDocument identification.
-  //  * `position` the position within the text document to display completion request for.
-  //  * `context` containing the trigger character and kind.
+  /**
+   * Public: Create {CompletionParams} to be sent to the language server
+   * based on the editor and position from the Autocomplete request etc.
+   *
+   * @param request The {atom$AutocompleteRequest} containing the request details.
+   * @param triggerCharacter The {string} containing the trigger character (empty if none).
+   * @param triggerOnly A {boolean} representing whether this completion is triggered right after a trigger character.
+   * @returns A {CompletionParams} with the keys:
+   *  * `textDocument` the language server protocol textDocument identification.
+   *  * `position` the position within the text document to display completion request for.
+   *  * `context` containing the trigger character and kind.
+   */
   public static createCompletionParams(
     request: ac.SuggestionsRequestedEvent,
     triggerCharacter: string,
@@ -250,14 +258,15 @@ export default class AutocompleteAdapter {
     };
   }
 
-  // Public: Create {CompletionContext} to be sent to the language server
-  // based on the trigger character.
-  //
-  // * `triggerCharacter` The {string} containing the trigger character or '' if none.
-  // * `triggerOnly` A {boolean} representing whether this completion is triggered right after a trigger character.
-  //
-  // Returns an {CompletionContext} that specifies the triggerKind and the triggerCharacter
-  // if there is one.
+  /**
+   * Public: Create {CompletionContext} to be sent to the language server
+   * based on the trigger character.
+   *
+   * @param triggerCharacter The {string} containing the trigger character or '' if none.
+   * @param triggerOnly A {boolean} representing whether this completion is triggered right after a trigger character.
+   * @returns An {CompletionContext} that specifies the triggerKind and the triggerCharacter
+   *          if there is one.
+   */
   public static createCompletionContext(triggerCharacter: string, triggerOnly: boolean): CompletionContext {
     if (triggerCharacter === '') {
       return { triggerKind: CompletionTriggerKind.Invoked };
@@ -268,16 +277,17 @@ export default class AutocompleteAdapter {
     }
   }
 
-  // Public: Convert a language server protocol CompletionItem array or CompletionList to
-  // an array of ordered AutoComplete+ suggestions.
-  //
-  // * `completionItems` An {Array} of {CompletionItem} objects or a {CompletionList} containing completion
-  //           items to be converted.
-  // * `request` The {atom$AutocompleteRequest} to satisfy.
-  // * `onDidConvertCompletionItem` A function that takes a {CompletionItem}, an {atom$AutocompleteSuggestion}
-  //   and a {atom$AutocompleteRequest} allowing you to adjust converted items.
-  //
-  // Returns a {Map} of AutoComplete+ suggestions ordered by the CompletionItems sortText.
+  /**
+   * Public: Convert a language server protocol CompletionItem array or CompletionList to
+   * an array of ordered AutoComplete+ suggestions.
+   *
+   * @param completionItems An {Array} of {CompletionItem} objects or a {CompletionList} containing completion
+   *           items to be converted.
+   * @param request The {atom$AutocompleteRequest} to satisfy.
+   * @param onDidConvertCompletionItem A function that takes a {CompletionItem}, an {atom$AutocompleteSuggestion}
+   *   and a {atom$AutocompleteRequest} allowing you to adjust converted items.
+   * @returns A {Map} of AutoComplete+ suggestions ordered by the CompletionItems sortText.
+   */
   public completionItemsToSuggestions(
     completionItems: CompletionItem[] | CompletionList | null,
     request: ac.SuggestionsRequestedEvent,
@@ -295,15 +305,16 @@ export default class AutocompleteAdapter {
           new PossiblyResolvedCompletionItem(s, false)]));
   }
 
-  // Public: Convert a language server protocol CompletionItem to an AutoComplete+ suggestion.
-  //
-  // * `item` An {CompletionItem} containing a completion item to be converted.
-  // * `suggestion` A {atom$AutocompleteSuggestion} to have the conversion applied to.
-  // * `request` The {atom$AutocompleteRequest} to satisfy.
-  // * `onDidConvertCompletionItem` A function that takes a {CompletionItem}, an {atom$AutocompleteSuggestion}
-  //   and a {atom$AutocompleteRequest} allowing you to adjust converted items.
-  //
-  // Returns the {atom$AutocompleteSuggestion} passed in as suggestion with the conversion applied.
+  /**
+   * Public: Convert a language server protocol CompletionItem to an AutoComplete+ suggestion.
+   *
+   * @param item An {CompletionItem} containing a completion item to be converted.
+   * @param suggestion A {atom$AutocompleteSuggestion} to have the conversion applied to.
+   * @param request The {atom$AutocompleteRequest} to satisfy.
+   * @param onDidConvertCompletionItem A function that takes a {CompletionItem}, an {atom$AutocompleteSuggestion}
+   *   and a {atom$AutocompleteRequest} allowing you to adjust converted items.
+   * @returns The {atom$AutocompleteSuggestion} passed in as suggestion with the conversion applied.
+   */
   public static completionItemToSuggestion(
     item: CompletionItem,
     suggestion: Suggestion,
@@ -320,12 +331,13 @@ export default class AutocompleteAdapter {
     return suggestion;
   }
 
-  // Public: Convert the primary parts of a language server protocol CompletionItem to an AutoComplete+ suggestion.
-  //
-  // * `item` An {CompletionItem} containing the completion items to be merged into.
-  // * `suggestion` The {Suggestion} to merge the conversion into.
-  //
-  // Returns the {Suggestion} with details added from the {CompletionItem}.
+  /**
+   * Public: Convert the primary parts of a language server protocol CompletionItem to an AutoComplete+ suggestion.
+   *
+   * @param item An {CompletionItem} containing the completion items to be merged into.
+   * @param suggestion The {Suggestion} to merge the conversion into.
+   * @returns The {Suggestion} with details added from the {CompletionItem}.
+   */
   public static applyCompletionItemToSuggestion(
     item: CompletionItem,
     suggestion: TextSuggestion,
@@ -352,12 +364,14 @@ export default class AutocompleteAdapter {
     }
   }
 
-  // Public: Applies the textEdit part of a language server protocol CompletionItem to an
-  // AutoComplete+ Suggestion via the replacementPrefix and text properties.
-  //
-  // * `textEdit` A {TextEdit} from a CompletionItem to apply.
-  // * `editor` An Atom {TextEditor} used to obtain the necessary text replacement.
-  // * `suggestion` An {atom$AutocompleteSuggestion} to set the replacementPrefix and text properties of.
+  /**
+   * Public: Applies the textEdit part of a language server protocol CompletionItem to an
+   * AutoComplete+ Suggestion via the replacementPrefix and text properties.
+   *
+   * @param textEdit A {TextEdit} from a CompletionItem to apply.
+   * @param editor An Atom {TextEditor} used to obtain the necessary text replacement.
+   * @param suggestion An {atom$AutocompleteSuggestion} to set the replacementPrefix and text properties of.
+   */
   public static applyTextEditToSuggestion(
     textEdit: TextEdit | undefined,
     editor: TextEditor,
@@ -369,25 +383,27 @@ export default class AutocompleteAdapter {
     }
   }
 
-  // Public: Adds a snippet to the suggestion if the CompletionItem contains
-  // snippet-formatted text
-  //
-  // * `item` An {CompletionItem} containing the completion items to be merged into.
-  // * `suggestion` The {atom$AutocompleteSuggestion} to merge the conversion into.
-  //
+  /**
+   * Public: Adds a snippet to the suggestion if the CompletionItem contains
+   * snippet-formatted text
+   *
+   * @param item An {CompletionItem} containing the completion items to be merged into.
+   * @param suggestion The {atom$AutocompleteSuggestion} to merge the conversion into.
+   */
   public static applySnippetToSuggestion(item: CompletionItem, suggestion: SnippetSuggestion): void {
     if (item.insertTextFormat === InsertTextFormat.Snippet) {
       suggestion.snippet = item.textEdit != null ? item.textEdit.newText : (item.insertText || '');
     }
   }
 
-  // Public: Obtain the textual suggestion type required by AutoComplete+ that
-  // most closely maps to the numeric completion kind supplies by the language server.
-  //
-  // * `kind` A {Number} that represents the suggestion kind to be converted.
-  //
-  // Returns a {String} containing the AutoComplete+ suggestion type equivalent
-  // to the given completion kind.
+  /**
+   * Public: Obtain the textual suggestion type required by AutoComplete+ that
+   * most closely maps to the numeric completion kind supplies by the language server.
+   *
+   * @param kind A {Number} that represents the suggestion kind to be converted.
+   * @returns A {String} containing the AutoComplete+ suggestion type equivalent
+   *   to the given completion kind.
+   */
   public static completionKindToSuggestionType(kind: number | undefined): string {
     switch (kind) {
       case CompletionItemKind.Constant:

--- a/lib/adapters/code-action-adapter.ts
+++ b/lib/adapters/code-action-adapter.ts
@@ -19,7 +19,7 @@ import {
 export default class CodeActionAdapter {
   /**
    * @returns A {Boolean} indicating this adapter can adapt the server based on the
-   *    given serverCapabilities.
+   *   given serverCapabilities.
    */
   public static canAdapt(serverCapabilities: ServerCapabilities): boolean {
     return serverCapabilities.codeActionProvider === true;
@@ -34,7 +34,7 @@ export default class CodeActionAdapter {
    * @param editor The Atom {TextEditor} containing the diagnostics.
    * @param range The Atom {Range} to fetch code actions for.
    * @param diagnostics An {Array<atomIde$Diagnostic>} to fetch code actions for.
-   *                 This is typically a list of diagnostics intersecting `range`.
+   *   This is typically a list of diagnostics intersecting `range`.
    * @returns A {Promise} of an {Array} of {atomIde$CodeAction}s to display.
    */
   public static async getCodeActions(

--- a/lib/adapters/code-action-adapter.ts
+++ b/lib/adapters/code-action-adapter.ts
@@ -17,23 +17,26 @@ import {
 } from 'atom';
 
 export default class CodeActionAdapter {
-  // Returns a {Boolean} indicating this adapter can adapt the server based on the
-  // given serverCapabilities.
+  /**
+   * @returns A {Boolean} indicating this adapter can adapt the server based on the
+   *    given serverCapabilities.
+   */
   public static canAdapt(serverCapabilities: ServerCapabilities): boolean {
     return serverCapabilities.codeActionProvider === true;
   }
 
-  // Public: Retrieves code actions for a given editor, range, and context (diagnostics).
-  // Throws an error if codeActionProvider is not a registered capability.
-  //
-  // * `connection` A {LanguageClientConnection} to the language server that provides highlights.
-  // * `serverCapabilities` The {ServerCapabilities} of the language server that will be used.
-  // * `editor` The Atom {TextEditor} containing the diagnostics.
-  // * `range` The Atom {Range} to fetch code actions for.
-  // * `diagnostics` An {Array<atomIde$Diagnostic>} to fetch code actions for.
-  //                 This is typically a list of diagnostics intersecting `range`.
-  //
-  // Returns a {Promise} of an {Array} of {atomIde$CodeAction}s to display.
+  /**
+   * Public: Retrieves code actions for a given editor, range, and context (diagnostics).
+   * Throws an error if codeActionProvider is not a registered capability.
+   *
+   * @param connection A {LanguageClientConnection} to the language server that provides highlights.
+   * @param serverCapabilities The {ServerCapabilities} of the language server that will be used.
+   * @param editor The Atom {TextEditor} containing the diagnostics.
+   * @param range The Atom {Range} to fetch code actions for.
+   * @param diagnostics An {Array<atomIde$Diagnostic>} to fetch code actions for.
+   *                 This is typically a list of diagnostics intersecting `range`.
+   * @returns A {Promise} of an {Array} of {atomIde$CodeAction}s to display.
+   */
   public static async getCodeActions(
     connection: LanguageClientConnection,
     serverCapabilities: ServerCapabilities,

--- a/lib/adapters/code-format-adapter.ts
+++ b/lib/adapters/code-format-adapter.ts
@@ -188,8 +188,8 @@ export default class CodeFormatAdapter {
    * @param editor The Atom {TextEditor} containing the document to be formatted.
    * @param range The Atom {Range} containing the range of document that should be formatted.
    * @returns The {FormattingOptions} to be used containing the keys:
-   *  * `tabSize` The number of spaces a tab represents.
-   *  * `insertSpaces` {True} if spaces should be used, {False} for tab characters.
+   *   * `tabSize` The number of spaces a tab represents.
+   *   * `insertSpaces` {True} if spaces should be used, {False} for tab characters.
    */
   public static getFormatOptions(editor: TextEditor): FormattingOptions {
     return {

--- a/lib/adapters/code-format-adapter.ts
+++ b/lib/adapters/code-format-adapter.ts
@@ -14,17 +14,20 @@ import {
   Point,
 } from 'atom';
 
-// Public: Adapts the language server protocol "textDocument/completion" to the
-// Atom IDE UI Code-format package.
+/**
+ * Public: Adapts the language server protocol "textDocument/completion" to the
+ * Atom IDE UI Code-format package.
+ */
 export default class CodeFormatAdapter {
-  // Public: Determine whether this adapter can be used to adapt a language server
-  // based on the serverCapabilities matrix containing either a documentFormattingProvider
-  // or a documentRangeFormattingProvider.
-  //
-  // * `serverCapabilities` The {ServerCapabilities} of the language server to consider.
-  //
-  // Returns a {Boolean} indicating this adapter can adapt the server based on the
-  // given serverCapabilities.
+  /**
+   * Public: Determine whether this adapter can be used to adapt a language server
+   * based on the serverCapabilities matrix containing either a documentFormattingProvider
+   * or a documentRangeFormattingProvider.
+   *
+   * @param serverCapabilities The {ServerCapabilities} of the language server to consider.
+   * @returns A {Boolean} indicating this adapter can adapt the server based on the
+   *   given serverCapabilities.
+   */
   public static canAdapt(serverCapabilities: ServerCapabilities): boolean {
     return (
       serverCapabilities.documentRangeFormattingProvider === true ||
@@ -32,16 +35,17 @@ export default class CodeFormatAdapter {
     );
   }
 
-  // Public: Format text in the editor using the given language server connection and an optional range.
-  // If the server does not support range formatting then range will be ignored and the entire document formatted.
-  //
-  // * `connection` A {LanguageClientConnection} to the language server that will format the text.
-  // * `serverCapabilities` The {ServerCapabilities} of the language server that will be used.
-  // * `editor` The Atom {TextEditor} containing the text that will be formatted.
-  // * `range` The optional Atom {Range} containing the subset of the text to be formatted.
-  //
-  // Returns a {Promise} of an {Array} of {Object}s containing the AutoComplete+
-  // suggestions to display.
+  /**
+   * Public: Format text in the editor using the given language server connection and an optional range.
+   * If the server does not support range formatting then range will be ignored and the entire document formatted.
+   *
+   * @param connection A {LanguageClientConnection} to the language server that will format the text.
+   * @param serverCapabilities The {ServerCapabilities} of the language server that will be used.
+   * @param editor The Atom {TextEditor} containing the text that will be formatted.
+   * @param range The optional Atom {Range} containing the subset of the text to be formatted.
+   * @returns A {Promise} of an {Array} of {Object}s containing the AutoComplete+
+   *   suggestions to display.
+   */
   public static format(
     connection: LanguageClientConnection,
     serverCapabilities: ServerCapabilities,
@@ -59,13 +63,14 @@ export default class CodeFormatAdapter {
     throw new Error('Can not format document, language server does not support it');
   }
 
-  // Public: Format the entire document of an Atom {TextEditor} by using a given language server.
-  //
-  // * `connection` A {LanguageClientConnection} to the language server that will format the text.
-  // * `editor` The Atom {TextEditor} containing the document to be formatted.
-  //
-  // Returns a {Promise} of an {Array} of {TextEdit} objects that can be applied to the Atom TextEditor
-  // to format the document.
+  /**
+   * Public: Format the entire document of an Atom {TextEditor} by using a given language server.
+   *
+   * @param connection A {LanguageClientConnection} to the language server that will format the text.
+   * @param editor The Atom {TextEditor} containing the document to be formatted.
+   * @returns A {Promise} of an {Array} of {TextEdit} objects that can be applied to the Atom TextEditor
+   *   to format the document.
+   */
   public static async formatDocument(
     connection: LanguageClientConnection,
     editor: TextEditor,
@@ -74,13 +79,14 @@ export default class CodeFormatAdapter {
     return Convert.convertLsTextEdits(edits);
   }
 
-  // Public: Create {DocumentFormattingParams} to be sent to the language server when requesting an
-  // entire document is formatted.
-  //
-  // * `editor` The Atom {TextEditor} containing the document to be formatted.
-  //
-  // Returns {DocumentFormattingParams} containing the identity of the text document as well as
-  // options to be used in formatting the document such as tab size and tabs vs spaces.
+  /**
+   * Public: Create {DocumentFormattingParams} to be sent to the language server when requesting an
+   * entire document is formatted.
+   *
+   * @param editor The Atom {TextEditor} containing the document to be formatted.
+   * @returns A {DocumentFormattingParams} containing the identity of the text document as well as
+   *   options to be used in formatting the document such as tab size and tabs vs spaces.
+   */
   public static createDocumentFormattingParams(editor: TextEditor): DocumentFormattingParams {
     return {
       textDocument: Convert.editorToTextDocumentIdentifier(editor),
@@ -88,14 +94,15 @@ export default class CodeFormatAdapter {
     };
   }
 
-  // Public: Format a range within an Atom {TextEditor} by using a given language server.
-  //
-  // * `connection` A {LanguageClientConnection} to the language server that will format the text.
-  // * `range` The Atom {Range} containing the range of text that should be formatted.
-  // * `editor` The Atom {TextEditor} containing the document to be formatted.
-  //
-  // Returns a {Promise} of an {Array} of {TextEdit} objects that can be applied to the Atom TextEditor
-  // to format the document.
+  /**
+   * Public: Format a range within an Atom {TextEditor} by using a given language server.
+   *
+   * @param connection A {LanguageClientConnection} to the language server that will format the text.
+   * @param range The Atom {Range} containing the range of text that should be formatted.
+   * @param editor The Atom {TextEditor} containing the document to be formatted.
+   * @returns A {Promise} of an {Array} of {TextEdit} objects that can be applied to the Atom TextEditor
+   *   to format the document.
+   */
   public static async formatRange(
     connection: LanguageClientConnection,
     editor: TextEditor,
@@ -107,15 +114,16 @@ export default class CodeFormatAdapter {
     return Convert.convertLsTextEdits(edits);
   }
 
-  // Public: Create {DocumentRangeFormattingParams} to be sent to the language server when requesting an
-  // entire document is formatted.
-  //
-  // * `editor` The Atom {TextEditor} containing the document to be formatted.
-  // * `range` The Atom {Range} containing the range of text that should be formatted.
-  //
-  // Returns {DocumentRangeFormattingParams} containing the identity of the text document, the
-  // range of the text to be formatted as well as the options to be used in formatting the
-  // document such as tab size and tabs vs spaces.
+  /**
+   * Public: Create {DocumentRangeFormattingParams} to be sent to the language server when requesting an
+   * entire document is formatted.
+   *
+   * @param editor The Atom {TextEditor} containing the document to be formatted.
+   * @param range The Atom {Range} containing the range of text that should be formatted.
+   * @returns A {DocumentRangeFormattingParams} containing the identity of the text document, the
+   *   range of the text to be formatted as well as the options to be used in formatting the
+   *   document such as tab size and tabs vs spaces.
+   */
   public static createDocumentRangeFormattingParams(
     editor: TextEditor,
     range: Range,
@@ -127,15 +135,16 @@ export default class CodeFormatAdapter {
     };
   }
 
-  // Public: Format on type within an Atom {TextEditor} by using a given language server.
-  //
-  // * `connection` A {LanguageClientConnection} to the language server that will format the text.
-  // * `editor` The Atom {TextEditor} containing the document to be formatted.
-  // * `point` The {Point} at which the document to be formatted.
-  // * `character` A character that triggered formatting request.
-  //
-  // Returns a {Promise} of an {Array} of {TextEdit} objects that can be applied to the Atom TextEditor
-  // to format the document.
+  /**
+   * Public: Format on type within an Atom {TextEditor} by using a given language server.
+   *
+   * @param connection A {LanguageClientConnection} to the language server that will format the text.
+   * @param editor The Atom {TextEditor} containing the document to be formatted.
+   * @param point The {Point} at which the document to be formatted.
+   * @param character A character that triggered formatting request.
+   * @returns A {Promise} of an {Array} of {TextEdit} objects that can be applied to the Atom TextEditor
+   *   to format the document.
+   */
   public static async formatOnType(
     connection: LanguageClientConnection,
     editor: TextEditor,
@@ -148,16 +157,17 @@ export default class CodeFormatAdapter {
     return Convert.convertLsTextEdits(edits);
   }
 
-  // Public: Create {DocumentOnTypeFormattingParams} to be sent to the language server when requesting an
-  // entire document is formatted.
-  //
-  // * `editor` The Atom {TextEditor} containing the document to be formatted.
-  // * `point` The {Point} at which the document to be formatted.
-  // * `character` A character that triggered formatting request.
-  //
-  // Returns {DocumentOnTypeFormattingParams} containing the identity of the text document, the
-  // position of the text to be formatted, the character that triggered formatting request
-  // as well as the options to be used in formatting the document such as tab size and tabs vs spaces.
+  /**
+   * Public: Create {DocumentOnTypeFormattingParams} to be sent to the language server when requesting an
+   * entire document is formatted.
+   *
+   * @param editor The Atom {TextEditor} containing the document to be formatted.
+   * @param point The {Point} at which the document to be formatted.
+   * @param character A character that triggered formatting request.
+   * @returns A {DocumentOnTypeFormattingParams} containing the identity of the text document, the
+   *   position of the text to be formatted, the character that triggered formatting request
+   *   as well as the options to be used in formatting the document such as tab size and tabs vs spaces.
+   */
   public static createDocumentOnTypeFormattingParams(
     editor: TextEditor,
     point: Point,
@@ -171,15 +181,16 @@ export default class CodeFormatAdapter {
     };
   }
 
-  // Public: Create {DocumentRangeFormattingParams} to be sent to the language server when requesting an
-  // entire document is formatted.
-  //
-  // * `editor` The Atom {TextEditor} containing the document to be formatted.
-  // * `range` The Atom {Range} containing the range of document that should be formatted.
-  //
-  // Returns the {FormattingOptions} to be used containing the keys:
-  //  * `tabSize` The number of spaces a tab represents.
-  //  * `insertSpaces` {True} if spaces should be used, {False} for tab characters.
+  /**
+   * Public: Create {DocumentRangeFormattingParams} to be sent to the language server when requesting an
+   * entire document is formatted.
+   *
+   * @param editor The Atom {TextEditor} containing the document to be formatted.
+   * @param range The Atom {Range} containing the range of document that should be formatted.
+   * @returns The {FormattingOptions} to be used containing the keys:
+   *  * `tabSize` The number of spaces a tab represents.
+   *  * `insertSpaces` {True} if spaces should be used, {False} for tab characters.
+   */
   public static getFormatOptions(editor: TextEditor): FormattingOptions {
     return {
       tabSize: editor.getTabLength(),

--- a/lib/adapters/code-highlight-adapter.ts
+++ b/lib/adapters/code-highlight-adapter.ts
@@ -11,21 +11,24 @@ import {
 } from '../languageclient';
 
 export default class CodeHighlightAdapter {
-  // Returns a {Boolean} indicating this adapter can adapt the server based on the
-  // given serverCapabilities.
+  /**
+   * @returns A {Boolean} indicating this adapter can adapt the server based on the
+   * given serverCapabilities.
+   */
   public static canAdapt(serverCapabilities: ServerCapabilities): boolean {
     return serverCapabilities.documentHighlightProvider === true;
   }
 
-  // Public: Creates highlight markers for a given editor position.
-  // Throws an error if documentHighlightProvider is not a registered capability.
-  //
-  // * `connection` A {LanguageClientConnection} to the language server that provides highlights.
-  // * `serverCapabilities` The {ServerCapabilities} of the language server that will be used.
-  // * `editor` The Atom {TextEditor} containing the text to be highlighted.
-  // * `position` The Atom {Point} to fetch highlights for.
-  //
-  // Returns a {Promise} of an {Array} of {Range}s to be turned into highlights.
+  /**
+   * Public: Creates highlight markers for a given editor position.
+   * Throws an error if documentHighlightProvider is not a registered capability.
+   *
+   * @param connection A {LanguageClientConnection} to the language server that provides highlights.
+   * @param serverCapabilities The {ServerCapabilities} of the language server that will be used.
+   * @param editor The Atom {TextEditor} containing the text to be highlighted.
+   * @param position The Atom {Point} to fetch highlights for.
+   * @returns A {Promise} of an {Array} of {Range}s to be turned into highlights.
+   */
   public static async highlight(
     connection: LanguageClientConnection,
     serverCapabilities: ServerCapabilities,

--- a/lib/adapters/datatip-adapter.ts
+++ b/lib/adapters/datatip-adapter.ts
@@ -24,7 +24,7 @@ export default class DatatipAdapter {
    *
    * @param serverCapabilities The {ServerCapabilities} of the language server to consider.
    * @returns A {Boolean} indicating adapter can adapt the server based on the
-   * given serverCapabilities.
+   *   given serverCapabilities.
    */
   public static canAdapt(serverCapabilities: ServerCapabilities): boolean {
     return serverCapabilities.hoverProvider === true;
@@ -35,7 +35,7 @@ export default class DatatipAdapter {
    * the language server.
    *
    * @param connection A {LanguageClientConnection} to the language server that will be queried
-   *                for the hover text/datatip.
+   *   for the hover text/datatip.
    * @param editor The Atom {TextEditor} containing the text the Datatip should relate to.
    * @param point The Atom {Point} containing the point within the text the Datatip should relate to.
    * @returns A {Promise} containing the {Datatip} to display or {null} if no Datatip is available.

--- a/lib/adapters/datatip-adapter.ts
+++ b/lib/adapters/datatip-adapter.ts
@@ -13,29 +13,33 @@ import {
   TextEditor,
 } from 'atom';
 
-// Public: Adapts the language server protocol "textDocument/hover" to the
-// Atom IDE UI Datatip package.
+/**
+ * Public: Adapts the language server protocol "textDocument/hover" to the
+ * Atom IDE UI Datatip package.
+ */
 export default class DatatipAdapter {
-  // Public: Determine whether this adapter can be used to adapt a language server
-  // based on the serverCapabilities matrix containing a hoverProvider.
-  //
-  // * `serverCapabilities` The {ServerCapabilities} of the language server to consider.
-  //
-  // Returns a {Boolean} indicating adapter can adapt the server based on the
-  // given serverCapabilities.
+  /**
+   * Public: Determine whether this adapter can be used to adapt a language server
+   * based on the serverCapabilities matrix containing a hoverProvider.
+   *
+   * @param serverCapabilities The {ServerCapabilities} of the language server to consider.
+   * @returns A {Boolean} indicating adapter can adapt the server based on the
+   * given serverCapabilities.
+   */
   public static canAdapt(serverCapabilities: ServerCapabilities): boolean {
     return serverCapabilities.hoverProvider === true;
   }
 
-  // Public: Get the Datatip for this {Point} in a {TextEditor} by querying
-  // the language server.
-  //
-  // * `connection` A {LanguageClientConnection} to the language server that will be queried
-  //                for the hover text/datatip.
-  // * `editor` The Atom {TextEditor} containing the text the Datatip should relate to.
-  // * `point` The Atom {Point} containing the point within the text the Datatip should relate to.
-  //
-  // Returns a {Promise} containing the {Datatip} to display or {null} if no Datatip is available.
+  /**
+   * Public: Get the Datatip for this {Point} in a {TextEditor} by querying
+   * the language server.
+   *
+   * @param connection A {LanguageClientConnection} to the language server that will be queried
+   *                for the hover text/datatip.
+   * @param editor The Atom {TextEditor} containing the text the Datatip should relate to.
+   * @param point The Atom {Point} containing the point within the text the Datatip should relate to.
+   * @returns A {Promise} containing the {Datatip} to display or {null} if no Datatip is available.
+   */
   public async getDatatip(
     connection: LanguageClientConnection,
     editor: TextEditor,

--- a/lib/adapters/definition-adapter.ts
+++ b/lib/adapters/definition-adapter.ts
@@ -39,7 +39,7 @@ export default class DefinitionAdapter {
    * @param languageName The name of the programming language.
    * @param editor The Atom {TextEditor} containing the symbol and potential highlights.
    * @param point The Atom {Point} containing the position of the text that represents the symbol
-   *           for which the definition and highlights should be provided.
+   *   for which the definition and highlights should be provided.
    * @returns A {Promise} indicating adapter can adapt the server based on the
    *   given serverCapabilities.
    */
@@ -76,7 +76,7 @@ export default class DefinitionAdapter {
    * Public: Normalize the locations so a single {Location} becomes an {Array} of just
    * one. The language server protocol return either as the protocol evolved between v1 and v2.
    *
-   * @param locationResult Either a single {Location} object or an {Array} of {Locations}
+   * @param locationResult Either a single {Location} object or an {Array} of {Locations}.
    * @returns An {Array} of {Location}s or {null} if the locationResult was null.
    */
   public static normalizeLocations(locationResult: Location | Location[]): Location[] | null {

--- a/lib/adapters/definition-adapter.ts
+++ b/lib/adapters/definition-adapter.ts
@@ -12,33 +12,37 @@ import {
   Range,
 } from 'atom';
 
-// Public: Adapts the language server definition provider to the
-// Atom IDE UI Definitions package for 'Go To Definition' functionality.
+/**
+ * Public: Adapts the language server definition provider to the
+ * Atom IDE UI Definitions package for 'Go To Definition' functionality.
+ */
 export default class DefinitionAdapter {
-  // Public: Determine whether this adapter can be used to adapt a language server
-  // based on the serverCapabilities matrix containing a definitionProvider.
-  //
-  // * `serverCapabilities` The {ServerCapabilities} of the language server to consider.
-  //
-  // Returns a {Boolean} indicating adapter can adapt the server based on the
-  // given serverCapabilities.
+  /**
+   * Public: Determine whether this adapter can be used to adapt a language server
+   * based on the serverCapabilities matrix containing a definitionProvider.
+   *
+   * @param serverCapabilities The {ServerCapabilities} of the language server to consider.
+   * @returns A {Boolean} indicating adapter can adapt the server based on the
+   *   given serverCapabilities.
+   */
   public static canAdapt(serverCapabilities: ServerCapabilities): boolean {
     return serverCapabilities.definitionProvider === true;
   }
 
-  // Public: Get the definitions for a symbol at a given {Point} within a
-  // {TextEditor} including optionally highlighting all other references
-  // within the document if the langauge server also supports highlighting.
-  //
-  // * `connection` A {LanguageClientConnection} to the language server that will provide definitions and highlights.
-  // * `serverCapabilities` The {ServerCapabilities} of the language server that will be used.
-  // * `languageName` The name of the programming language.
-  // * `editor` The Atom {TextEditor} containing the symbol and potential highlights.
-  // * `point` The Atom {Point} containing the position of the text that represents the symbol
-  //           for which the definition and highlights should be provided.
-  //
-  // Returns a {Promise} indicating adapter can adapt the server based on the
-  // given serverCapabilities.
+  /**
+   * Public: Get the definitions for a symbol at a given {Point} within a
+   * {TextEditor} including optionally highlighting all other references
+   * within the document if the langauge server also supports highlighting.
+   *
+   * @param connection A {LanguageClientConnection} to the language server that will provide definitions and highlights.
+   * @param serverCapabilities The {ServerCapabilities} of the language server that will be used.
+   * @param languageName The name of the programming language.
+   * @param editor The Atom {TextEditor} containing the symbol and potential highlights.
+   * @param point The Atom {Point} containing the position of the text that represents the symbol
+   *           for which the definition and highlights should be provided.
+   * @returns A {Promise} indicating adapter can adapt the server based on the
+   *   given serverCapabilities.
+   */
   public async getDefinition(
     connection: LanguageClientConnection,
     serverCapabilities: ServerCapabilities,
@@ -68,12 +72,13 @@ export default class DefinitionAdapter {
     };
   }
 
-  // Public: Normalize the locations so a single {Location} becomes an {Array} of just
-  // one. The language server protocol return either as the protocol evolved between v1 and v2.
-  //
-  // * `locationResult` either a single {Location} object or an {Array} of {Locations}
-  //
-  // Returns an {Array} of {Location}s or {null} if the locationResult was null.
+  /**
+   * Public: Normalize the locations so a single {Location} becomes an {Array} of just
+   * one. The language server protocol return either as the protocol evolved between v1 and v2.
+   *
+   * @param locationResult Either a single {Location} object or an {Array} of {Locations}
+   * @returns An {Array} of {Location}s or {null} if the locationResult was null.
+   */
   public static normalizeLocations(locationResult: Location | Location[]): Location[] | null {
     if (locationResult == null) {
       return null;
@@ -81,12 +86,13 @@ export default class DefinitionAdapter {
     return (Array.isArray(locationResult) ? locationResult : [locationResult]).filter((d) => d.range.start != null);
   }
 
-  // Public: Convert an {Array} of {Location} objects into an Array of {Definition}s.
-  //
-  // * `locations` An {Array} of {Location} objects to be converted.
-  // * `languageName` The name of the language these objects are written in.
-  //
-  // Returns an {Array} of {Definition}s that represented the converted {Location}s.
+  /**
+   * Public: Convert an {Array} of {Location} objects into an Array of {Definition}s.
+   *
+   * @param locations An {Array} of {Location} objects to be converted.
+   * @param languageName The name of the language these objects are written in.
+   * @returns An {Array} of {Definition}s that represented the converted {Location}s.
+   */
   public static convertLocationsToDefinitions(locations: Location[], languageName: string): atomIde.Definition[] {
     return locations.map((d) => ({
       path: Convert.uriToPath(d.uri),

--- a/lib/adapters/document-sync-adapter.ts
+++ b/lib/adapters/document-sync-adapter.ts
@@ -20,23 +20,26 @@ import {
 } from 'atom';
 import * as Utils from '../utils';
 
-// Public: Synchronizes the documents between Atom and the language server by notifying
-// each end of changes, opening, closing and other events as well as sending and applying
-// changes either in whole or in part depending on what the language server supports.
+/**
+ * Public: Synchronizes the documents between Atom and the language server by notifying
+ * each end of changes, opening, closing and other events as well as sending and applying
+ * changes either in whole or in part depending on what the language server supports.
+ */
 export default class DocumentSyncAdapter {
   private _disposable = new CompositeDisposable();
   public _documentSync: TextDocumentSyncOptions;
   private _editors: WeakMap<TextEditor, TextEditorSyncAdapter> = new WeakMap();
   private _versions: Map<string, number> = new Map();
 
-  // Public: Determine whether this adapter can be used to adapt a language server
-  // based on the serverCapabilities matrix textDocumentSync capability either being Full or
-  // Incremental.
-  //
-  // * `serverCapabilities` The {ServerCapabilities} of the language server to consider.
-  //
-  // Returns a {Boolean} indicating adapter can adapt the server based on the
-  // given serverCapabilities.
+  /**
+   * Public: Determine whether this adapter can be used to adapt a language server
+   * based on the serverCapabilities matrix textDocumentSync capability either being Full or
+   * Incremental.
+   *
+   * @param serverCapabilities The {ServerCapabilities} of the language server to consider.
+   * @returns A {Boolean} indicating adapter can adapt the server based on the
+   *   given serverCapabilities.
+   */
   public static canAdapt(serverCapabilities: ServerCapabilities): boolean {
     return this.canAdaptV2(serverCapabilities) || this.canAdaptV3(serverCapabilities);
   }
@@ -57,12 +60,14 @@ export default class DocumentSyncAdapter {
     );
   }
 
-  // Public: Create a new {DocumentSyncAdapter} for the given language server.
-  //
-  // * `connection` A {LanguageClientConnection} to the language server to be kept in sync.
-  // * `documentSync` The document syncing options.
-  // * `editorSelector` A predicate function that takes a {TextEditor} and returns a {boolean}
-  //                    indicating whether this adapter should care about the contents of the editor.
+  /**
+   * Public: Create a new {DocumentSyncAdapter} for the given language server.
+   *
+   * @param connection A {LanguageClientConnection} to the language server to be kept in sync.
+   * @param documentSync The document syncing options.
+   * @param editorSelector A predicate function that takes a {TextEditor} and returns a {boolean}
+   *                    indicating whether this adapter should care about the contents of the editor.
+   */
   constructor(
     private _connection: LanguageClientConnection,
     private _editorSelector: (editor: TextEditor) => boolean,
@@ -84,10 +89,12 @@ export default class DocumentSyncAdapter {
     this._disposable.dispose();
   }
 
-  // Examine a {TextEditor} and decide if we wish to observe it. If so ensure that we stop observing it
-  // when it is closed or otherwise destroyed.
-  //
-  // * `editor` A {TextEditor} to consider for observation.
+  /**
+   * Examine a {TextEditor} and decide if we wish to observe it. If so ensure that we stop observing it
+   * when it is closed or otherwise destroyed.
+   *
+   * @param editor A {TextEditor} to consider for observation.
+   */
   public observeTextEditor(editor: TextEditor): void {
     const listener = editor.observeGrammar((_grammar) => this._handleGrammarChange(editor));
     this._disposable.add(
@@ -141,17 +148,19 @@ export default class DocumentSyncAdapter {
   }
 }
 
-// Public: Keep a single {TextEditor} in sync with a given language server.
+/**  Public: Keep a single {TextEditor} in sync with a given language server. */
 export class TextEditorSyncAdapter {
   private _disposable = new CompositeDisposable();
   private _currentUri: string;
   private _fakeDidChangeWatchedFiles: boolean;
 
-  // Public: Create a {TextEditorSyncAdapter} in sync with a given language server.
-  //
-  // * `editor` A {TextEditor} to keep in sync.
-  // * `connection` A {LanguageClientConnection} to a language server to keep in sync.
-  // * `documentSync` The document syncing options.
+  /**
+   * Public: Create a {TextEditorSyncAdapter} in sync with a given language server.
+   *
+   * @param editor A {TextEditor} to keep in sync.
+   * @param connection A {LanguageClientConnection} to a language server to keep in sync.
+   * @param documentSync The document syncing options.
+   */
   constructor(
     private _editor: TextEditor,
     private _connection: LanguageClientConnection,
@@ -189,8 +198,10 @@ export class TextEditorSyncAdapter {
     }
   }
 
-  // The change tracking disposable listener that will ensure that changes are sent to the
-  // language server as appropriate.
+  /**
+   * The change tracking disposable listener that will ensure that changes are sent to the
+   * language server as appropriate.
+   */
   public setupChangeTracking(documentSync: TextDocumentSyncOptions): Disposable | null {
     switch (documentSync.change) {
       case TextDocumentSyncKind.Full:
@@ -201,19 +212,23 @@ export class TextEditorSyncAdapter {
     return null;
   }
 
-  // Dispose this adapter ensuring any resources are freed and events unhooked.
+  /**  Dispose this adapter ensuring any resources are freed and events unhooked. */
   public dispose(): void {
     this._disposable.dispose();
   }
 
-  // Get the languageId field that will be sent to the language server by simply
-  // using the grammar name.
+  /**
+   * Get the languageId field that will be sent to the language server by simply
+   * using the grammar name.
+   */
   public getLanguageId(): string {
     return this._editor.getGrammar().name;
   }
 
-  // Public: Create a {VersionedTextDocumentIdentifier} for the document observed by
-  // this adapter including both the Uri and the current Version.
+  /**
+   * Public: Create a {VersionedTextDocumentIdentifier} for the document observed by
+   * this adapter including both the Uri and the current Version.
+   */
   public getVersionedTextDocumentIdentifier(): VersionedTextDocumentIdentifier {
     return {
       uri: this.getEditorUri(),
@@ -221,8 +236,10 @@ export class TextEditorSyncAdapter {
     };
   }
 
-  // Public: Send the entire document to the language server. This is used when
-  // operating in Full (1) sync mode.
+  /**
+   * Public: Send the entire document to the language server. This is used when
+   * operating in Full (1) sync mode.
+   */
   public sendFullChanges(): void {
     if (!this._isPrimaryAdapter()) { return; } // Multiple editors, we are not first
 
@@ -233,14 +250,16 @@ export class TextEditorSyncAdapter {
     });
   }
 
-  // Public: Send the incremental text changes to the language server. This is used
-  // when operating in Incremental (2) sync mode.
-  //
-  // * `event` The event fired by Atom to indicate the document has stopped changing
-  //           including a list of changes since the last time this event fired for this
-  //           text editor.
-  // Note: The order of changes in the event is guaranteed top to bottom.  Language server
-  // expects this in reverse.
+  /**
+   * Public: Send the incremental text changes to the language server. This is used
+   * when operating in Incremental (2) sync mode.
+   *
+   * @param event The event fired by Atom to indicate the document has stopped changing
+   *              including a list of changes since the last time this event fired for this
+   *              text editor.
+   * Note: The order of changes in the event is guaranteed top to bottom.  Language server
+   * expects this in reverse.
+   */
   public sendIncrementalChanges(event: BufferStoppedChangingEvent): void {
     if (event.changes.length > 0) {
       if (!this._isPrimaryAdapter()) { return; } // Multiple editors, we are not first
@@ -253,12 +272,12 @@ export class TextEditorSyncAdapter {
     }
   }
 
-  // Public: Convert an Atom {TextEditEvent} to a language server {TextDocumentContentChangeEvent}
-  // object.
-  //
-  // * `change` The Atom {TextEditEvent} to convert.
-  //
-  // Returns a {TextDocumentContentChangeEvent} that represents the converted {TextEditEvent}.
+  /**
+   * Public: Convert an Atom {TextEditEvent} to a language server {TextDocumentContentChangeEvent} object.
+   *
+   * @param change The Atom {TextEditEvent} to convert.
+   * @returns A {TextDocumentContentChangeEvent} that represents the converted {TextEditEvent}.
+   */
   public static textEditToContentChange(change: TextChange): TextDocumentContentChangeEvent {
     return {
       range: Convert.atomRangeToLSRange(change.oldRange),
@@ -283,8 +302,10 @@ export class TextEditorSyncAdapter {
     this._versions.set(filePath, this._getVersion(filePath) + 1);
   }
 
-  // Ensure when the document is opened we send notification to the language server
-  // so it can load it in and keep track of diagnostics etc.
+  /**
+   * Ensure when the document is opened we send notification to the language server
+   * so it can load it in and keep track of diagnostics etc.
+   */
   private didOpen(): void {
     const filePath = this._editor.getPath();
     if (filePath == null) { return; } // Not yet saved
@@ -305,8 +326,10 @@ export class TextEditorSyncAdapter {
     return this._versions.get(filePath) || 1;
   }
 
-  // Called when the {TextEditor} is closed and sends the 'didCloseTextDocument' notification to
-  // the connected language server.
+  /**
+   * Called when the {TextEditor} is closed and sends the 'didCloseTextDocument' notification to
+   * the connected language server.
+   */
   public didClose(): void {
     if (this._editor.getPath() == null) { return; } // Not yet saved
 
@@ -318,8 +341,10 @@ export class TextEditorSyncAdapter {
     this._connection.didCloseTextDocument({ textDocument: { uri: this.getEditorUri() } });
   }
 
-  // Called just before the {TextEditor} saves and sends the 'willSaveTextDocument' notification to
-  // the connected language server.
+  /**
+   * Called just before the {TextEditor} saves and sends the 'willSaveTextDocument' notification to
+   * the connected language server.
+   */
   public willSave(): void {
     if (!this._isPrimaryAdapter()) { return; }
 
@@ -330,8 +355,10 @@ export class TextEditorSyncAdapter {
     });
   }
 
-  // Called just before the {TextEditor} saves, sends the 'willSaveWaitUntilTextDocument' request to
-  // the connected language server and waits for the response before saving the buffer.
+  /**
+   * Called just before the {TextEditor} saves, sends the 'willSaveWaitUntilTextDocument' request to
+   * the connected language server and waits for the response before saving the buffer.
+   */
   public async willSaveWaitUntil(): Promise<void> {
     if (!this._isPrimaryAdapter()) { return Promise.resolve(); }
 
@@ -365,10 +392,12 @@ export class TextEditorSyncAdapter {
     return withBusySignal || applyEditsOrTimeout;
   }
 
-  // Called when the {TextEditor} saves and sends the 'didSaveTextDocument' notification to
-  // the connected language server.
-  // Note: Right now this also sends the `didChangeWatchedFiles` notification as well but that
-  // will be sent from elsewhere soon.
+  /**
+   * Called when the {TextEditor} saves and sends the 'didSaveTextDocument' notification to
+   * the connected language server.
+   * Note: Right now this also sends the `didChangeWatchedFiles` notification as well but that
+   * will be sent from elsewhere soon.
+   */
   public didSave(): void {
     if (!this._isPrimaryAdapter()) { return; }
 
@@ -416,7 +445,7 @@ export class TextEditorSyncAdapter {
     }
   }
 
-  // Public: Obtain the current {TextEditor} path and convert it to a Uri.
+  /**  Public: Obtain the current {TextEditor} path and convert it to a Uri. */
   public getEditorUri(): string {
     return Convert.pathToUri(this._editor.getPath() || '');
   }

--- a/lib/adapters/document-sync-adapter.ts
+++ b/lib/adapters/document-sync-adapter.ts
@@ -66,7 +66,7 @@ export default class DocumentSyncAdapter {
    * @param connection A {LanguageClientConnection} to the language server to be kept in sync.
    * @param documentSync The document syncing options.
    * @param editorSelector A predicate function that takes a {TextEditor} and returns a {boolean}
-   *                    indicating whether this adapter should care about the contents of the editor.
+   *   indicating whether this adapter should care about the contents of the editor.
    */
   constructor(
     private _connection: LanguageClientConnection,
@@ -84,7 +84,7 @@ export default class DocumentSyncAdapter {
     this._disposable.add(atom.textEditors.observe(this.observeTextEditor.bind(this)));
   }
 
-  // Dispose this adapter ensuring any resources are freed and events unhooked.
+  /** Dispose this adapter ensuring any resources are freed and events unhooked. */
   public dispose(): void {
     this._disposable.dispose();
   }
@@ -148,7 +148,7 @@ export default class DocumentSyncAdapter {
   }
 }
 
-/**  Public: Keep a single {TextEditor} in sync with a given language server. */
+/** Public: Keep a single {TextEditor} in sync with a given language server. */
 export class TextEditorSyncAdapter {
   private _disposable = new CompositeDisposable();
   private _currentUri: string;
@@ -212,7 +212,7 @@ export class TextEditorSyncAdapter {
     return null;
   }
 
-  /**  Dispose this adapter ensuring any resources are freed and events unhooked. */
+  /** Dispose this adapter ensuring any resources are freed and events unhooked. */
   public dispose(): void {
     this._disposable.dispose();
   }
@@ -255,9 +255,9 @@ export class TextEditorSyncAdapter {
    * when operating in Incremental (2) sync mode.
    *
    * @param event The event fired by Atom to indicate the document has stopped changing
-   *              including a list of changes since the last time this event fired for this
-   *              text editor.
-   * Note: The order of changes in the event is guaranteed top to bottom.  Language server
+   *   including a list of changes since the last time this event fired for this
+   *   text editor.
+   * NOTE: The order of changes in the event is guaranteed top to bottom.  Language server
    * expects this in reverse.
    */
   public sendIncrementalChanges(event: BufferStoppedChangingEvent): void {
@@ -445,7 +445,7 @@ export class TextEditorSyncAdapter {
     }
   }
 
-  /**  Public: Obtain the current {TextEditor} path and convert it to a Uri. */
+  /** Public: Obtain the current {TextEditor} path and convert it to a Uri. */
   public getEditorUri(): string {
     return Convert.pathToUri(this._editor.getPath() || '');
   }

--- a/lib/adapters/find-references-adapter.ts
+++ b/lib/adapters/find-references-adapter.ts
@@ -11,30 +11,34 @@ import {
   ReferenceParams,
 } from '../languageclient';
 
-// Public: Adapts the language server definition provider to the
-// Atom IDE UI Definitions package for 'Go To Definition' functionality.
+/**
+ * Public: Adapts the language server definition provider to the
+ * Atom IDE UI Definitions package for 'Go To Definition' functionality.
+ */
 export default class FindReferencesAdapter {
-  // Public: Determine whether this adapter can be used to adapt a language server
-  // based on the serverCapabilities matrix containing a referencesProvider.
-  //
-  // * `serverCapabilities` The {ServerCapabilities} of the language server to consider.
-  //
-  // Returns a {Boolean} indicating adapter can adapt the server based on the
-  // given serverCapabilities.
+  /**
+   * Public: Determine whether this adapter can be used to adapt a language server
+   * based on the serverCapabilities matrix containing a referencesProvider.
+   *
+   * @param serverCapabilities The {ServerCapabilities} of the language server to consider.
+   * @returns A {Boolean} indicating adapter can adapt the server based on the
+   *   given serverCapabilities.
+   */
   public static canAdapt(serverCapabilities: ServerCapabilities): boolean {
     return serverCapabilities.referencesProvider === true;
   }
 
-  // Public: Get the references for a specific symbol within the document as represented by
-  // the {TextEditor} and {Point} within it via the language server.
-  //
-  // * `connection` A {LanguageClientConnection} to the language server that will be queried
-  //                for the references.
-  // * `editor` The Atom {TextEditor} containing the text the references should relate to.
-  // * `point` The Atom {Point} containing the point within the text the references should relate to.
-  //
-  // Returns a {Promise} containing a {FindReferencesReturn} with all the references the language server
-  // could find.
+  /**
+   * Public: Get the references for a specific symbol within the document as represented by
+   * the {TextEditor} and {Point} within it via the language server.
+   *
+   * @param connection A {LanguageClientConnection} to the language server that will be queried
+   *                for the references.
+   * @param editor The Atom {TextEditor} containing the text the references should relate to.
+   * @param point The Atom {Point} containing the point within the text the references should relate to.
+   * @returns A {Promise} containing a {FindReferencesReturn} with all the references the language server
+   *   could find.
+   */
   public async getReferences(
     connection: LanguageClientConnection,
     editor: TextEditor,
@@ -57,12 +61,13 @@ export default class FindReferencesAdapter {
     };
   }
 
-  // Public: Create a {ReferenceParams} from a given {TextEditor} for a specific {Point}.
-  //
-  // * `editor` A {TextEditor} that represents the document.
-  // * `point` A {Point} within the document.
-  //
-  // Returns a {ReferenceParams} built from the given parameters.
+  /**
+   * Public: Create a {ReferenceParams} from a given {TextEditor} for a specific {Point}.
+   *
+   * @param editor A {TextEditor} that represents the document.
+   * @param point A {Point} within the document.
+   * @returns A {ReferenceParams} built from the given parameters.
+   */
   public static createReferenceParams(editor: TextEditor, point: Point): ReferenceParams {
     return {
       textDocument: Convert.editorToTextDocumentIdentifier(editor),
@@ -71,11 +76,12 @@ export default class FindReferencesAdapter {
     };
   }
 
-  // Public: Convert a {Location} into a {Reference}.
-  //
-  // * `location` A {Location} to convert.
-  //
-  // Returns a {Reference} equivalent to the given {Location}.
+  /**
+   * Public: Convert a {Location} into a {Reference}.
+   *
+   * @param location A {Location} to convert.
+   * @returns A {Reference} equivalent to the given {Location}.
+   */
   public static locationToReference(location: Location): atomIde.Reference {
     return {
       uri: Convert.uriToPath(location.uri),
@@ -84,7 +90,7 @@ export default class FindReferencesAdapter {
     };
   }
 
-  // Public: Get a symbol name from a {TextEditor} for a specific {Point} in the document.
+  /**  Public: Get a symbol name from a {TextEditor} for a specific {Point} in the document. */
   public static getReferencedSymbolName(
     editor: TextEditor,
     point: Point,

--- a/lib/adapters/find-references-adapter.ts
+++ b/lib/adapters/find-references-adapter.ts
@@ -33,7 +33,7 @@ export default class FindReferencesAdapter {
    * the {TextEditor} and {Point} within it via the language server.
    *
    * @param connection A {LanguageClientConnection} to the language server that will be queried
-   *                for the references.
+   *   for the references.
    * @param editor The Atom {TextEditor} containing the text the references should relate to.
    * @param point The Atom {Point} containing the point within the text the references should relate to.
    * @returns A {Promise} containing a {FindReferencesReturn} with all the references the language server
@@ -90,7 +90,7 @@ export default class FindReferencesAdapter {
     };
   }
 
-  /**  Public: Get a symbol name from a {TextEditor} for a specific {Point} in the document. */
+  /** Public: Get a symbol name from a {TextEditor} for a specific {Point} in the document. */
   public static getReferencedSymbolName(
     editor: TextEditor,
     point: Point,

--- a/lib/adapters/linter-push-v2-adapter.ts
+++ b/lib/adapters/linter-push-v2-adapter.ts
@@ -9,29 +9,35 @@ import {
   PublishDiagnosticsParams,
 } from '../languageclient';
 
-// Public: Listen to diagnostics messages from the language server and publish them
-// to the user by way of the Linter Push (Indie) v2 API supported by Atom IDE UI.
+/**
+ * Public: Listen to diagnostics messages from the language server and publish them
+ * to the user by way of the Linter Push (Indie) v2 API supported by Atom IDE UI.
+ */
 export default class LinterPushV2Adapter {
   private _diagnosticMap: Map<string, linter.Message[]> = new Map();
   private _diagnosticCodes: Map<string, Map<string, DiagnosticCode | null>> = new Map();
   private _indies: Set<linter.IndieDelegate> = new Set();
 
-  // Public: Create a new {LinterPushV2Adapter} that will listen for diagnostics
-  // via the supplied {LanguageClientConnection}.
-  //
-  // * `connection` A {LanguageClientConnection} to the language server that will provide diagnostics.
+  /**
+   * Public: Create a new {LinterPushV2Adapter} that will listen for diagnostics
+   * via the supplied {LanguageClientConnection}.
+   *
+   * @param connection A {LanguageClientConnection} to the language server that will provide diagnostics.
+   */
   constructor(connection: LanguageClientConnection) {
     connection.onPublishDiagnostics(this.captureDiagnostics.bind(this));
   }
 
-  // Dispose this adapter ensuring any resources are freed and events unhooked.
+  /**  Dispose this adapter ensuring any resources are freed and events unhooked. */
   public dispose(): void {
     this.detachAll();
   }
 
-  // Public: Attach this {LinterPushV2Adapter} to a given {V2IndieDelegate} registry.
-  //
-  // * `indie` A {V2IndieDelegate} that wants to receive messages.
+  /**
+   * Public: Attach this {LinterPushV2Adapter} to a given {V2IndieDelegate} registry.
+   *
+   * @param indie A {V2IndieDelegate} that wants to receive messages.
+   */
   public attach(indie: linter.IndieDelegate): void {
     this._indies.add(indie);
     this._diagnosticMap.forEach((value, key) => indie.setMessages(key, value));
@@ -40,17 +46,19 @@ export default class LinterPushV2Adapter {
     });
   }
 
-  // Public: Remove all {V2IndieDelegate} registries attached to this adapter and clear them.
+  /**  Public: Remove all {V2IndieDelegate} registries attached to this adapter and clear them. */
   public detachAll(): void {
     this._indies.forEach((i) => i.clearMessages());
     this._indies.clear();
   }
 
-  // Public: Capture the diagnostics sent from a langguage server, convert them to the
-  // Linter V2 format and forward them on to any attached {V2IndieDelegate}s.
-  //
-  // * `params` The {PublishDiagnosticsParams} received from the language server that should
-  //            be captured and forwarded on to any attached {V2IndieDelegate}s.
+  /**
+   * Public: Capture the diagnostics sent from a langguage server, convert them to the
+   * Linter V2 format and forward them on to any attached {V2IndieDelegate}s.
+   *
+   * @param params The {PublishDiagnosticsParams} received from the language server that should
+   *               be captured and forwarded on to any attached {V2IndieDelegate}s.
+   */
   public captureDiagnostics(params: PublishDiagnosticsParams): void {
     const path = Convert.uriToPath(params.uri);
     const codeMap = new Map();
@@ -64,13 +72,14 @@ export default class LinterPushV2Adapter {
     this._indies.forEach((i) => i.setMessages(path, messages));
   }
 
-  // Public: Convert a single {Diagnostic} received from a language server into a single
-  // {V2Message} expected by the Linter V2 API.
-  //
-  // * `path` A string representing the path of the file the diagnostic belongs to.
-  // * `diagnostics` A {Diagnostic} object received from the language server.
-  //
-  // Returns a {V2Message} equivalent to the {Diagnostic} object supplied by the language server.
+  /**
+   * Public: Convert a single {Diagnostic} received from a language server into a single
+   * {V2Message} expected by the Linter V2 API.
+   *
+   * @param path A string representing the path of the file the diagnostic belongs to.
+   * @param diagnostics A {Diagnostic} object received from the language server.
+   * @returns A {V2Message} equivalent to the {Diagnostic} object supplied by the language server.
+   */
   public diagnosticToV2Message(path: string, diagnostic: Diagnostic): linter.Message {
     return {
       location: {
@@ -83,12 +92,13 @@ export default class LinterPushV2Adapter {
     };
   }
 
-  // Public: Convert a diagnostic severity number obtained from the language server into
-  // the textual equivalent for a Linter {V2Message}.
-  //
-  // * `severity` A number representing the severity of the diagnostic.
-  //
-  // Returns a string of 'error', 'warning' or 'info' depending on the severity.
+  /**
+   * Public: Convert a diagnostic severity number obtained from the language server into
+   * the textual equivalent for a Linter {V2Message}.
+   *
+   * @param severity A number representing the severity of the diagnostic.
+   * @returns A string of 'error', 'warning' or 'info' depending on the severity.
+   */
   public static diagnosticSeverityToSeverity(severity: number): 'error' | 'warning' | 'info' {
     switch (severity) {
       case DiagnosticSeverity.Error:
@@ -102,10 +112,12 @@ export default class LinterPushV2Adapter {
     }
   }
 
-  // Private: Get the recorded diagnostic code for a range/message.
-  // Diagnostic codes are tricky because there's no suitable place in the Linter API for them.
-  // For now, we'll record the original code for each range/message combination and retrieve it
-  // when needed (e.g. for passing back into code actions)
+  /**
+   * Private: Get the recorded diagnostic code for a range/message.
+   * Diagnostic codes are tricky because there's no suitable place in the Linter API for them.
+   * For now, we'll record the original code for each range/message combination and retrieve it
+   * when needed (e.g. for passing back into code actions)
+   */
   public getDiagnosticCode(editor: atom.TextEditor, range: atom.Range, text: string): DiagnosticCode | null {
     const path = editor.getPath();
     if (path != null) {

--- a/lib/adapters/linter-push-v2-adapter.ts
+++ b/lib/adapters/linter-push-v2-adapter.ts
@@ -28,7 +28,7 @@ export default class LinterPushV2Adapter {
     connection.onPublishDiagnostics(this.captureDiagnostics.bind(this));
   }
 
-  /**  Dispose this adapter ensuring any resources are freed and events unhooked. */
+  /** Dispose this adapter ensuring any resources are freed and events unhooked. */
   public dispose(): void {
     this.detachAll();
   }
@@ -46,7 +46,7 @@ export default class LinterPushV2Adapter {
     });
   }
 
-  /**  Public: Remove all {V2IndieDelegate} registries attached to this adapter and clear them. */
+  /** Public: Remove all {V2IndieDelegate} registries attached to this adapter and clear them. */
   public detachAll(): void {
     this._indies.forEach((i) => i.clearMessages());
     this._indies.clear();
@@ -57,7 +57,7 @@ export default class LinterPushV2Adapter {
    * Linter V2 format and forward them on to any attached {V2IndieDelegate}s.
    *
    * @param params The {PublishDiagnosticsParams} received from the language server that should
-   *               be captured and forwarded on to any attached {V2IndieDelegate}s.
+   *   be captured and forwarded on to any attached {V2IndieDelegate}s.
    */
   public captureDiagnostics(params: PublishDiagnosticsParams): void {
     const path = Convert.uriToPath(params.uri);

--- a/lib/adapters/logging-console-adapter.ts
+++ b/lib/adapters/logging-console-adapter.ts
@@ -5,7 +5,7 @@ import {
   MessageType,
 } from '../languageclient';
 
-/**  Adapts Atom's user notifications to those of the language server protocol. */
+/** Adapts Atom's user notifications to those of the language server protocol. */
 export default class LoggingConsoleAdapter {
   private _consoles: Set<ConsoleApi> = new Set();
 
@@ -19,7 +19,7 @@ export default class LoggingConsoleAdapter {
     connection.onLogMessage(this.logMessage.bind(this));
   }
 
-  /**  Dispose this adapter ensuring any resources are freed and events unhooked. */
+  /** Dispose this adapter ensuring any resources are freed and events unhooked. */
   public dispose(): void {
     this.detachAll();
   }
@@ -33,7 +33,7 @@ export default class LoggingConsoleAdapter {
     this._consoles.add(console);
   }
 
-  /**  Public: Remove all {ConsoleApi}'s attached to this adapter. */
+  /** Public: Remove all {ConsoleApi}'s attached to this adapter. */
   public detachAll(): void {
     this._consoles.clear();
   }
@@ -42,7 +42,7 @@ export default class LoggingConsoleAdapter {
    * Log a message using the Atom IDE UI Console API.
    *
    * @param params The {LogMessageParams} received from the language server
-   *               indicating the details of the message to be loggedd.
+   *   indicating the details of the message to be loggedd.
    */
   private logMessage(params: LogMessageParams): void {
     switch (params.type) {

--- a/lib/adapters/logging-console-adapter.ts
+++ b/lib/adapters/logging-console-adapter.ts
@@ -5,39 +5,45 @@ import {
   MessageType,
 } from '../languageclient';
 
-// Adapts Atom's user notifications to those of the language server protocol.
+/**  Adapts Atom's user notifications to those of the language server protocol. */
 export default class LoggingConsoleAdapter {
   private _consoles: Set<ConsoleApi> = new Set();
 
-  // Create a new {LoggingConsoleAdapter} that will listen for log messages
-  // via the supplied {LanguageClientConnection}.
-  //
-  // * `connection` A {LanguageClientConnection} to the language server that will provide log messages.
+  /**
+   * Create a new {LoggingConsoleAdapter} that will listen for log messages
+   * via the supplied {LanguageClientConnection}.
+   *
+   * @param connection A {LanguageClientConnection} to the language server that will provide log messages.
+   */
   constructor(connection: LanguageClientConnection) {
     connection.onLogMessage(this.logMessage.bind(this));
   }
 
-  // Dispose this adapter ensuring any resources are freed and events unhooked.
+  /**  Dispose this adapter ensuring any resources are freed and events unhooked. */
   public dispose(): void {
     this.detachAll();
   }
 
-  // Public: Attach this {LoggingConsoleAdapter} to a given {ConsoleApi}.
-  //
-  // * `console` A {ConsoleApi} that wants to receive messages.
+  /**
+   * Public: Attach this {LoggingConsoleAdapter} to a given {ConsoleApi}.
+   *
+   * @param console A {ConsoleApi} that wants to receive messages.
+   */
   public attach(console: ConsoleApi): void {
     this._consoles.add(console);
   }
 
-  // Public: Remove all {ConsoleApi}'s attached to this adapter.
+  /**  Public: Remove all {ConsoleApi}'s attached to this adapter. */
   public detachAll(): void {
     this._consoles.clear();
   }
 
-  // Log a message using the Atom IDE UI Console API.
-  //
-  // * `params` The {LogMessageParams} received from the language server
-  //            indicating the details of the message to be loggedd.
+  /**
+   * Log a message using the Atom IDE UI Console API.
+   *
+   * @param params The {LogMessageParams} received from the language server
+   *               indicating the details of the message to be loggedd.
+   */
   private logMessage(params: LogMessageParams): void {
     switch (params.type) {
       case MessageType.Error: {

--- a/lib/adapters/notifications-adapter.ts
+++ b/lib/adapters/notifications-adapter.ts
@@ -11,7 +11,7 @@ import {
   NotificationExt,
 } from 'atom';
 
-/**  Public: Adapts Atom's user notifications to those of the language server protocol. */
+/** Public: Adapts Atom's user notifications to those of the language server protocol. */
 export default class NotificationsAdapter {
   /**
    * Public: Attach to a {LanguageClientConnection} to recieve events indicating
@@ -30,9 +30,9 @@ export default class NotificationsAdapter {
    * Public: Show a notification message with buttons using the Atom notifications API.
    *
    * @param params The {ShowMessageRequestParams} received from the language server
-   *               indicating the details of the notification to be displayed.
+   *   indicating the details of the notification to be displayed.
    * @param name   The name of the language server so the user can identify the
-   *               context of the message.
+   *   context of the message.
    * @param projectPath The path of the current project.
    */
   public static onShowMessageRequest(
@@ -74,9 +74,9 @@ export default class NotificationsAdapter {
    * Public: Show a notification message using the Atom notifications API.
    *
    * @param params The {ShowMessageParams} received from the language server
-   *               indicating the details of the notification to be displayed.
+   *   indicating the details of the notification to be displayed.
    * @param name   The name of the language server so the user can identify the
-   *               context of the message.
+   *   context of the message.
    * @param projectPath The path of the current project.
    */
   public static onShowMessage(

--- a/lib/adapters/notifications-adapter.ts
+++ b/lib/adapters/notifications-adapter.ts
@@ -11,10 +11,12 @@ import {
   NotificationExt,
 } from 'atom';
 
-// Public: Adapts Atom's user notifications to those of the language server protocol.
+/**  Public: Adapts Atom's user notifications to those of the language server protocol. */
 export default class NotificationsAdapter {
-  // Public: Attach to a {LanguageClientConnection} to recieve events indicating
-  // when user notifications should be displayed.
+  /**
+   * Public: Attach to a {LanguageClientConnection} to recieve events indicating
+   * when user notifications should be displayed.
+   */
   public static attach(
     connection: LanguageClientConnection,
     name: string,
@@ -24,13 +26,15 @@ export default class NotificationsAdapter {
     connection.onShowMessageRequest((m) => NotificationsAdapter.onShowMessageRequest(m, name, projectPath));
   }
 
-  // Public: Show a notification message with buttons using the Atom notifications API.
-  //
-  // * `params` The {ShowMessageRequestParams} received from the language server
-  //            indicating the details of the notification to be displayed.
-  // * `name`   The name of the language server so the user can identify the
-  //            context of the message.
-  // * `projectPath`   The path of the current project.
+  /**
+   * Public: Show a notification message with buttons using the Atom notifications API.
+   *
+   * @param params The {ShowMessageRequestParams} received from the language server
+   *               indicating the details of the notification to be displayed.
+   * @param name   The name of the language server so the user can identify the
+   *               context of the message.
+   * @param projectPath The path of the current project.
+   */
   public static onShowMessageRequest(
     params: ShowMessageRequestParams,
     name: string,
@@ -66,13 +70,15 @@ export default class NotificationsAdapter {
     });
   }
 
-  // Public: Show a notification message using the Atom notifications API.
-  //
-  // * `params` The {ShowMessageParams} received from the language server
-  //            indicating the details of the notification to be displayed.
-  // * `name`   The name of the language server so the user can identify the
-  //            context of the message.
-  // * `projectPath`   The path of the current project.
+  /**
+   * Public: Show a notification message using the Atom notifications API.
+   *
+   * @param params The {ShowMessageParams} received from the language server
+   *               indicating the details of the notification to be displayed.
+   * @param name   The name of the language server so the user can identify the
+   *               context of the message.
+   * @param projectPath The path of the current project.
+   */
   public static onShowMessage(
     params: ShowMessageParams,
     name: string,
@@ -84,12 +90,13 @@ export default class NotificationsAdapter {
     });
   }
 
-  // Public: Convert a {MessageActionItem} from the language server into an
-  // equivalent {NotificationButton} within Atom.
-  //
-  // * `actionItem` The {MessageActionItem} to be converted.
-  //
-  // Returns a {NotificationButton} equivalent to the {MessageActionItem} given.
+  /**
+   * Public: Convert a {MessageActionItem} from the language server into an
+   * equivalent {NotificationButton} within Atom.
+   *
+   * @param actionItem The {MessageActionItem} to be converted.
+   * @returns A {NotificationButton} equivalent to the {MessageActionItem} given.
+   */
   public static actionItemToNotificationButton(
     actionItem: MessageActionItem,
   ) {

--- a/lib/adapters/outline-view-adapter.ts
+++ b/lib/adapters/outline-view-adapter.ts
@@ -14,31 +14,35 @@ import {
   TextEditor,
 } from 'atom';
 
-// Public: Adapts the documentSymbolProvider of the language server to the Outline View
-// supplied by Atom IDE UI.
+/**
+ * Public: Adapts the documentSymbolProvider of the language server to the Outline View
+ * supplied by Atom IDE UI.
+ */
 export default class OutlineViewAdapter {
 
   private _cancellationTokens: WeakMap<LanguageClientConnection, CancellationTokenSource> = new WeakMap();
 
-  // Public: Determine whether this adapter can be used to adapt a language server
-  // based on the serverCapabilities matrix containing a documentSymbolProvider.
-  //
-  // * `serverCapabilities` The {ServerCapabilities} of the language server to consider.
-  //
-  // Returns a {Boolean} indicating adapter can adapt the server based on the
-  // given serverCapabilities.
+  /**
+   * Public: Determine whether this adapter can be used to adapt a language server
+   * based on the serverCapabilities matrix containing a documentSymbolProvider.
+   *
+   * @param serverCapabilities The {ServerCapabilities} of the language server to consider.
+   * @returns A {Boolean} indicating adapter can adapt the server based on the
+   *   given serverCapabilities.
+   */
   public static canAdapt(serverCapabilities: ServerCapabilities): boolean {
     return serverCapabilities.documentSymbolProvider === true;
   }
 
-  // Public: Obtain the Outline for document via the {LanguageClientConnection} as identified
-  // by the {TextEditor}.
-  //
-  // * `connection` A {LanguageClientConnection} to the language server that will be queried
-  //                for the outline.
-  // * `editor` The Atom {TextEditor} containing the text the Outline should represent.
-  //
-  // Returns a {Promise} containing the {Outline} of this document.
+  /**
+   * Public: Obtain the Outline for document via the {LanguageClientConnection} as identified
+   * by the {TextEditor}.
+   *
+   * @param connection A {LanguageClientConnection} to the language server that will be queried
+   *                   for the outline.
+   * @param editor The Atom {TextEditor} containing the text the Outline should represent.
+   * @returns A {Promise} containing the {Outline} of this document.
+   */
   public async getOutline(connection: LanguageClientConnection, editor: TextEditor): Promise<atomIde.Outline | null> {
     const results = await Utils.doWithCancellationToken(connection, this._cancellationTokens, (cancellationToken) =>
       connection.documentSymbol({ textDocument: Convert.editorToTextDocumentIdentifier(editor) }, cancellationToken),
@@ -65,14 +69,15 @@ export default class OutlineViewAdapter {
     }
   }
 
-  // Public: Create an {Array} of {OutlineTree}s from the Array of {DocumentSymbol} recieved
-  // from the language server. This includes converting all the children nodes in the entire
-  // hierarchy.
-  //
-  // * `symbols` An {Array} of {DocumentSymbol}s received from the language server that
-  //             should be converted to an {Array} of {OutlineTree}.
-  //
-  // Returns an {Array} of {OutlineTree} containing the given symbols that the Outline View can display.
+  /**
+   * Public: Create an {Array} of {OutlineTree}s from the Array of {DocumentSymbol} recieved
+   * from the language server. This includes converting all the children nodes in the entire
+   * hierarchy.
+   *
+   * @param symbols An {Array} of {DocumentSymbol}s received from the language server that
+   *                should be converted to an {Array} of {OutlineTree}.
+   * @returns An {Array} of {OutlineTree} containing the given symbols that the Outline View can display.
+   */
   public static createHierarchicalOutlineTrees(symbols: DocumentSymbol[]): atomIde.OutlineTree[] {
     // Sort all the incoming symbols
     symbols.sort((a, b) => {
@@ -103,14 +108,15 @@ export default class OutlineViewAdapter {
     });
   }
 
-  // Public: Create an {Array} of {OutlineTree}s from the Array of {SymbolInformation} recieved
-  // from the language server. This includes determining the appropriate child and parent
-  // relationships for the hierarchy.
-  //
-  // * `symbols` An {Array} of {SymbolInformation}s received from the language server that
-  //             should be converted to an {OutlineTree}.
-  //
-  // Returns an {OutlineTree} containing the given symbols that the Outline View can display.
+  /**
+   * Public: Create an {Array} of {OutlineTree}s from the Array of {SymbolInformation} recieved
+   * from the language server. This includes determining the appropriate child and parent
+   * relationships for the hierarchy.
+   *
+   * @param symbols An {Array} of {SymbolInformation}s received from the language server that
+   *                should be converted to an {OutlineTree}.
+   * @returns An {OutlineTree} containing the given symbols that the Outline View can display.
+   */
   public static createOutlineTrees(symbols: SymbolInformation[]): atomIde.OutlineTree[] {
     symbols.sort(
       (a, b) =>
@@ -204,13 +210,14 @@ export default class OutlineViewAdapter {
     return parent || null;
   }
 
-  // Public: Convert an individual {DocumentSymbol} from the language server
-  // to an {OutlineTree} for use by the Outline View. It does NOT recursively
-  // process the given symbol's children (if any).
-  //
-  // * `symbol` The {DocumentSymbol} to convert to an {OutlineTree}.
-  //
-  // Returns the {OutlineTree} corresponding to the given {DocumentSymbol}.
+  /**
+   * Public: Convert an individual {DocumentSymbol} from the language server
+   * to an {OutlineTree} for use by the Outline View. It does NOT recursively
+   * process the given symbol's children (if any).
+   *
+   * @param symbol The {DocumentSymbol} to convert to an {OutlineTree}.
+   * @returns The {OutlineTree} corresponding to the given {DocumentSymbol}.
+   */
   public static hierarchicalSymbolToOutline(symbol: DocumentSymbol): atomIde.OutlineTree {
     const icon = OutlineViewAdapter.symbolKindToEntityKind(symbol.kind);
 
@@ -229,12 +236,13 @@ export default class OutlineViewAdapter {
     };
   }
 
-  // Public: Convert an individual {SymbolInformation} from the language server
-  // to an {OutlineTree} for use by the Outline View.
-  //
-  // * `symbol` The {SymbolInformation} to convert to an {OutlineTree}.
-  //
-  // Returns the {OutlineTree} equivalent to the given {SymbolInformation}.
+  /**
+   * Public: Convert an individual {SymbolInformation} from the language server
+   * to an {OutlineTree} for use by the Outline View.
+   *
+   * @param symbol The {SymbolInformation} to convert to an {OutlineTree}.
+   * @returns The {OutlineTree} equivalent to the given {SymbolInformation}.
+   */
   public static symbolToOutline(symbol: SymbolInformation): atomIde.OutlineTree {
     const icon = OutlineViewAdapter.symbolKindToEntityKind(symbol.kind);
     return {
@@ -252,12 +260,13 @@ export default class OutlineViewAdapter {
     };
   }
 
-  // Public: Convert a symbol kind into an outline entity kind used to determine
-  // the styling such as the appropriate icon in the Outline View.
-  //
-  // * `symbol` The numeric symbol kind received from the language server.
-  //
-  // Returns a string representing the equivalent OutlineView entity kind.
+  /**
+   * Public: Convert a symbol kind into an outline entity kind used to determine
+   * the styling such as the appropriate icon in the Outline View.
+   *
+   * @param symbol The numeric symbol kind received from the language server.
+   * @returns A string representing the equivalent OutlineView entity kind.
+   */
   public static symbolKindToEntityKind(symbol: number): string | null {
     switch (symbol) {
       case SymbolKind.Array:
@@ -305,12 +314,13 @@ export default class OutlineViewAdapter {
     }
   }
 
-  // Public: Convert a symbol kind to the appropriate token kind used to syntax
-  // highlight the symbol name in the Outline View.
-  //
-  // * `symbol` The numeric symbol kind received from the language server.
-  //
-  // Returns a string representing the equivalent syntax token kind.
+  /**
+   * Public: Convert a symbol kind to the appropriate token kind used to syntax
+   * highlight the symbol name in the Outline View.
+   *
+   * @param symbol The numeric symbol kind received from the language server.
+   * @returns A string representing the equivalent syntax token kind.
+   */
   public static symbolKindToTokenKind(symbol: number): atomIde.TokenKind {
     switch (symbol) {
       case SymbolKind.Class:

--- a/lib/adapters/outline-view-adapter.ts
+++ b/lib/adapters/outline-view-adapter.ts
@@ -39,7 +39,7 @@ export default class OutlineViewAdapter {
    * by the {TextEditor}.
    *
    * @param connection A {LanguageClientConnection} to the language server that will be queried
-   *                   for the outline.
+   *   for the outline.
    * @param editor The Atom {TextEditor} containing the text the Outline should represent.
    * @returns A {Promise} containing the {Outline} of this document.
    */
@@ -75,7 +75,7 @@ export default class OutlineViewAdapter {
    * hierarchy.
    *
    * @param symbols An {Array} of {DocumentSymbol}s received from the language server that
-   *                should be converted to an {Array} of {OutlineTree}.
+   *   should be converted to an {Array} of {OutlineTree}.
    * @returns An {Array} of {OutlineTree} containing the given symbols that the Outline View can display.
    */
   public static createHierarchicalOutlineTrees(symbols: DocumentSymbol[]): atomIde.OutlineTree[] {
@@ -114,7 +114,7 @@ export default class OutlineViewAdapter {
    * relationships for the hierarchy.
    *
    * @param symbols An {Array} of {SymbolInformation}s received from the language server that
-   *                should be converted to an {OutlineTree}.
+   *   should be converted to an {OutlineTree}.
    * @returns An {OutlineTree} containing the given symbols that the Outline View can display.
    */
   public static createOutlineTrees(symbols: SymbolInformation[]): atomIde.OutlineTree[] {

--- a/lib/adapters/signature-help-adapter.ts
+++ b/lib/adapters/signature-help-adapter.ts
@@ -27,7 +27,7 @@ export default class SignatureHelpAdapter {
 
   /**
    * @returns A {Boolean} indicating this adapter can adapt the server based on the
-   * given serverCapabilities.
+   *   given serverCapabilities.
    */
   public static canAdapt(serverCapabilities: ServerCapabilities): boolean {
     return serverCapabilities.signatureHelpProvider != null;
@@ -56,7 +56,7 @@ export default class SignatureHelpAdapter {
     );
   }
 
-  /**  Public: Retrieves signature help for a given editor and position. */
+  /** Public: Retrieves signature help for a given editor and position. */
   public getSignatureHelp(editor: TextEditor, point: Point): Promise<SignatureHelp | null> {
     return this._connection.signatureHelp(Convert.editorToTextDocumentPositionParams(editor, point));
   }

--- a/lib/adapters/signature-help-adapter.ts
+++ b/lib/adapters/signature-help-adapter.ts
@@ -25,8 +25,10 @@ export default class SignatureHelpAdapter {
     this._grammarScopes = grammarScopes;
   }
 
-  // Returns a {Boolean} indicating this adapter can adapt the server based on the
-  // given serverCapabilities.
+  /**
+   * @returns A {Boolean} indicating this adapter can adapt the server based on the
+   * given serverCapabilities.
+   */
   public static canAdapt(serverCapabilities: ServerCapabilities): boolean {
     return serverCapabilities.signatureHelpProvider != null;
   }
@@ -54,7 +56,7 @@ export default class SignatureHelpAdapter {
     );
   }
 
-  // Public: Retrieves signature help for a given editor and position.
+  /**  Public: Retrieves signature help for a given editor and position. */
   public getSignatureHelp(editor: TextEditor, point: Point): Promise<SignatureHelp | null> {
     return this._connection.signatureHelp(Convert.editorToTextDocumentPositionParams(editor, point));
   }

--- a/lib/auto-languageclient.ts
+++ b/lib/auto-languageclient.ts
@@ -51,7 +51,7 @@ export interface ServerAdapters {
 }
 
 /**
- * AutoLanguageClient provides a simple way to have all the supported
+ * Public: AutoLanguageClient provides a simple way to have all the supported
  * Atom-IDE services wired up entirely for you by just subclassing it and
  * implementing at least
  * - `startServerProcess`
@@ -69,9 +69,7 @@ export default class AutoLanguageClient {
   private _isDeactivating: boolean = false;
   private _serverAdapters = new WeakMap<ActiveServer, ServerAdapters>();
 
-  /**
-   * Available if consumeBusySignal is setup
-   */
+  /** Available if consumeBusySignal is setup */
   protected busySignalService?: atomIde.BusySignalService;
 
   protected processStdErr: string = '';
@@ -89,30 +87,22 @@ export default class AutoLanguageClient {
   // You must implement these so we know how to deal with your language and server
   // -------------------------------------------------------------------------
 
-  /**
-   * Return an array of the grammar scopes you handle, e.g. [ 'source.js' ]
-   */
+  /** Return an array of the grammar scopes you handle, e.g. [ 'source.js' ] */
   protected getGrammarScopes(): string[] {
     throw Error('Must implement getGrammarScopes when extending AutoLanguageClient');
   }
 
-  /**
-   * Return the name of the language you support, e.g. 'JavaScript'
-   */
+  /** Return the name of the language you support, e.g. 'JavaScript' */
   protected getLanguageName(): string {
     throw Error('Must implement getLanguageName when extending AutoLanguageClient');
   }
 
-  /**
-   * Return the name of your server, e.g. 'Eclipse JDT'
-   */
+  /** Return the name of your server, e.g. 'Eclipse JDT' */
   protected getServerName(): string {
     throw Error('Must implement getServerName when extending AutoLanguageClient');
   }
 
-  /**
-   * Start your server process
-   */
+  /** Start your server process */
   protected startServerProcess(_projectPath: string): LanguageServerProcess | Promise<LanguageServerProcess> {
     throw Error('Must override startServerProcess to start language server process when extending AutoLanguageClient');
   }
@@ -120,16 +110,12 @@ export default class AutoLanguageClient {
   // You might want to override these for different behavior
   // ---------------------------------------------------------------------------
 
-  /**
-   * (Optional) Determine whether we should start a server for a given editor if we don't have one yet
-   */
+  /** (Optional) Determine whether we should start a server for a given editor if we don't have one yet */
   protected shouldStartForEditor(editor: TextEditor): boolean {
     return this.getGrammarScopes().includes(editor.getGrammar().scopeName);
   }
 
-  /**
-   * (Optional) Return the parameters used to initialize a client - you may want to extend capabilities
-   */
+  /** (Optional) Return the parameters used to initialize a client - you may want to extend capabilities */
   protected getInitializeParams(projectPath: string, process: LanguageServerProcess): ls.InitializeParams {
     return {
       processId: process.pid,
@@ -225,33 +211,23 @@ export default class AutoLanguageClient {
     };
   }
 
-  /**
-   * (Optional) Early wire-up of listeners before initialize method is sent
-   */
+  /** (Optional) Early wire-up of listeners before initialize method is sent */
   protected preInitialization(_connection: LanguageClientConnection): void { }
 
-  /**
-   * (Optional) Late wire-up of listeners after initialize method has been sent
-   */
+  /** (Optional) Late wire-up of listeners after initialize method has been sent */
   protected postInitialization(_server: ActiveServer): void { }
 
-  /**
-   * (Optional) Determine whether to use ipc, stdio or socket to connect to the server
-   */
+  /** (Optional) Determine whether to use ipc, stdio or socket to connect to the server */
   protected getConnectionType(): ConnectionType {
     return this.socket != null ? 'socket' : 'stdio';
   }
 
-  /**
-   * (Optional) Return the name of your root configuration key
-   */
+  /** (Optional) Return the name of your root configuration key */
   protected getRootConfigurationKey(): string {
     return '';
   }
 
-  /**
-   * (Optional) Transform the configuration object before it is sent to the server
-   */
+  /** (Optional) Transform the configuration object before it is sent to the server */
   protected mapConfigurationObject(configuration: any): any {
     return configuration;
   }
@@ -259,17 +235,13 @@ export default class AutoLanguageClient {
   // Helper methods that are useful for implementors
   // ---------------------------------------------------------------------------
 
-  /**
-   * Gets a LanguageClientConnection for a given TextEditor
-   */
+  /** Gets a LanguageClientConnection for a given TextEditor */
   protected async getConnectionForEditor(editor: TextEditor): Promise<LanguageClientConnection | null> {
     const server = await this._serverManager.getServer(editor);
     return server ? server.connection : null;
   }
 
-  /**
-   * Restart all active language servers for this language client in the workspace
-   */
+  /** Restart all active language servers for this language client in the workspace */
   protected async restartAllServers() {
     await this._serverManager.restartAllServers();
   }
@@ -277,9 +249,7 @@ export default class AutoLanguageClient {
   // Default implementation of the rest of the AutoLanguageClient
   // ---------------------------------------------------------------------------
 
-  /**
-   * Activate does very little for perf reasons - hooks in via ServerManager for later 'activation'
-   */
+  /** Activate does very little for perf reasons - hooks in via ServerManager for later 'activation' */
   public activate(): void {
     this._disposable = new CompositeDisposable();
     this.name = `${this.getLanguageName()} (${this.getServerName()})`;
@@ -300,9 +270,7 @@ export default class AutoLanguageClient {
     this._serverManager.terminate();
   }
 
-  /**
-   * Deactivate disposes the resources we're using
-   */
+  /** Deactivate disposes the resources we're using */
   public async deactivate(): Promise<any> {
     this._isDeactivating = true;
     this._disposable.dispose();
@@ -320,9 +288,7 @@ export default class AutoLanguageClient {
     return cp.spawn(process.execPath, args, options);
   }
 
-  /**
-   * LSP logging is only set for warnings & errors by default unless you turn on the core.debugLSP setting
-   */
+  /** LSP logging is only set for warnings & errors by default unless you turn on the core.debugLSP setting */
   protected getLogger(): Logger {
     const filter = atom.config.get('core.debugLSP')
       ? FilteredLogger.DeveloperLevelFilter
@@ -330,9 +296,7 @@ export default class AutoLanguageClient {
     return new FilteredLogger(new ConsoleLogger(this.name), filter);
   }
 
-  /**
-   * Starts the server by starting the process, then initializing the language server and starting adapters
-   */
+  /** Starts the server by starting the process, then initializing the language server and starting adapters */
   private async startServer(projectPath: string): Promise<ActiveServer> {
     const process = await this.reportBusyWhile(
       `Starting ${this.getServerName()} for ${path.basename(projectPath)}`,
@@ -414,9 +378,7 @@ export default class AutoLanguageClient {
     );
   }
 
-  /**
-   * Creates the RPC connection which can be ipc, socket or stdio
-   */
+  /** Creates the RPC connection which can be ipc, socket or stdio */
   private createRpcConnection(process: LanguageServerProcess): rpc.MessageConnection {
     let reader: rpc.MessageReader;
     let writer: rpc.MessageWriter;
@@ -448,9 +410,7 @@ export default class AutoLanguageClient {
     });
   }
 
-  /**
-   * Start adapters that are not shared between servers
-   */
+  /** Start adapters that are not shared between servers */
   private startExclusiveAdapters(server: ActiveServer): void {
     ApplyEditAdapter.attach(server.connection);
     NotificationsAdapter.attach(server.connection, this.name, server.projectPath);

--- a/lib/convert.ts
+++ b/lib/convert.ts
@@ -13,14 +13,17 @@ import {
   TextEdit,
 } from 'atom-ide';
 
-// Public: Class that contains a number of helper methods for general conversions
-// between the language server protocol and Atom/Atom packages.
+/**
+ * Public: Class that contains a number of helper methods for general conversions
+ * between the language server protocol and Atom/Atom packages.
+ */
 export default class Convert {
-  // Public: Convert a path to a Uri.
-  //
-  // * `filePath` A file path to convert to a Uri.
-  //
-  // Returns the Uri corresponding to the path. e.g. file:///a/b/c.txt
+  /**
+   * Public: Convert a path to a Uri.
+   *
+   * @param filePath A file path to convert to a Uri.
+   * @returns the Uri corresponding to the path. e.g. file:///a/b/c.txt
+   */
   public static pathToUri(filePath: string): string {
     let newPath = filePath.replace(/\\/g, '/');
     if (newPath[0] !== '/') {
@@ -29,13 +32,14 @@ export default class Convert {
     return encodeURI(`file://${newPath}`).replace(/[?#]/g, encodeURIComponent);
   }
 
-  // Public: Convert a Uri to a path.
-  //
-  // * `uri` A Uri to convert to a file path.
-  //
-  // Returns a file path corresponding to the Uri. e.g. /a/b/c.txt
-  // If the Uri does not begin file: then it is returned as-is to allow Atom
-  // to deal with http/https sources in the future.
+  /**
+   * Public: Convert a Uri to a path.
+   *
+   * @param uri A Uri to convert to a file path.
+   * @returns A file path corresponding to the Uri. e.g. /a/b/c.txt
+   * If the Uri does not begin file: then it is returned as-is to allow Atom
+   * to deal with http/https sources in the future.
+   */
   public static uriToPath(uri: string): string {
     const url = URL.parse(uri);
     if (url.protocol !== 'file:' || url.path === undefined) {
@@ -53,38 +57,43 @@ export default class Convert {
     return filePath;
   }
 
-  // Public: Convert an Atom {Point} to a language server {Position}.
-  //
-  // * `point` An Atom {Point} to convert from.
-  //
-  // Returns the {Position} representation of the Atom {PointObject}.
+  /**
+   * Public: Convert an Atom {Point} to a language server {Position}.
+   *
+   * @param point An Atom {Point} to convert from.
+   *
+   * Returns the {Position} representation of the Atom {PointObject}.
+   */
   public static pointToPosition(point: Point): ls.Position {
     return { line: point.row, character: point.column };
   }
 
-  // Public: Convert a language server {Position} into an Atom {PointObject}.
-  //
-  // * 'position' A language server {Position} to convert from.
-  //
-  // Returns the Atom {PointObject} representation of the given {Position}.
+  /**
+   * Public: Convert a language server {Position} into an Atom {PointObject}.
+   *
+   * @param position A language server {Position} to convert from.
+   * @returns The Atom {PointObject} representation of the given {Position}.
+   */
   public static positionToPoint(position: ls.Position): Point {
     return new Point(position.line, position.character);
   }
 
-  // Public: Convert a language server {Range} into an Atom {Range}.
-  //
-  // * 'range' A language server {Range} to convert from.
-  //
-  // Returns the Atom {Range} representation of the given language server {Range}.
+  /**
+   * Public: Convert a language server {Range} into an Atom {Range}.
+   *
+   * @param range A language server {Range} to convert from.
+   * @returns The Atom {Range} representation of the given language server {Range}.
+   */
   public static lsRangeToAtomRange(range: ls.Range): Range {
     return new Range(Convert.positionToPoint(range.start), Convert.positionToPoint(range.end));
   }
 
-  // Public: Convert an Atom {Range} into an language server {Range}.
-  //
-  // * 'range' An Atom {Range} to convert from.
-  //
-  // Returns the language server {Range} representation of the given Atom {Range}.
+  /**
+   * Public: Convert an Atom {Range} into an language server {Range}.
+   *
+   * @param range An Atom {Range} to convert from.
+   * @returns The language server {Range} representation of the given Atom {Range}.
+   */
   public static atomRangeToLSRange(range: Range): ls.Range {
     return {
       start: Convert.pointToPosition(range.start),
@@ -92,24 +101,26 @@ export default class Convert {
     };
   }
 
-  // Public: Create a {TextDocumentIdentifier} from an Atom {TextEditor}.
-  //
-  // * `editor` A {TextEditor} that will be used to form the uri property.
-  //
-  // Returns a {TextDocumentIdentifier} that has a `uri` property with the Uri for the
-  // given editor's path.
+  /**
+   * Public: Create a {TextDocumentIdentifier} from an Atom {TextEditor}.
+   *
+   * @param editor A {TextEditor} that will be used to form the uri property.
+   * @returns A {TextDocumentIdentifier} that has a `uri` property with the Uri for the
+   * given editor's path.
+   */
   public static editorToTextDocumentIdentifier(editor: TextEditor): ls.TextDocumentIdentifier {
     return { uri: Convert.pathToUri(editor.getPath() || '') };
   }
 
-  // Public: Create a {TextDocumentPositionParams} from a {TextEditor} and optional {Point}.
-  //
-  // * `editor` A {TextEditor} that will be used to form the uri property.
-  // * `point`  An optional {Point} that will supply the position property. If not specified
-  //            the current cursor position will be used.
-  //
-  // Returns a {TextDocumentPositionParams} that has textDocument property with the editors {TextDocumentIdentifier}
-  // and a position property with the supplied point (or current cursor position when not specified).
+  /**
+   * Public: Create a {TextDocumentPositionParams} from a {TextEditor} and optional {Point}.
+   *
+   * @param editor A {TextEditor} that will be used to form the uri property.
+   * @param point An optional {Point} that will supply the position property. If not specified
+   *            the current cursor position will be used.
+   * @returns A {TextDocumentPositionParams} that has textDocument property with the editors {TextDocumentIdentifier}
+   * and a position property with the supplied point (or current cursor position when not specified).
+   */
   public static editorToTextDocumentPositionParams(
     editor: TextEditor,
     point?: Point,
@@ -120,26 +131,28 @@ export default class Convert {
     };
   }
 
-  // Public: Create a string of scopes for the atom text editor using the data-grammar selector from an
-  // {Array} of grammarScope strings.
-  //
-  // * `grammarScopes` An {Array} of grammar scope string to convert from.
-  //
-  // Returns a single comma-separated list of CSS selectors targetting the grammars of Atom text editors.
-  // e.g. `['c', 'cpp']` => `'atom-text-editor[data-grammar='c'], atom-text-editor[data-grammar='cpp']`
+  /**
+   * Public: Create a string of scopes for the atom text editor using the data-grammar
+   * selector from an {Array} of grammarScope strings.
+   *
+   * @param grammarScopes An {Array} of grammar scope string to convert from.
+   * @returns A single comma-separated list of CSS selectors targetting the grammars of Atom text editors.
+   * e.g. `['c', 'cpp']` => `'atom-text-editor[data-grammar='c'], atom-text-editor[data-grammar='cpp']`
+   */
   public static grammarScopesToTextEditorScopes(grammarScopes: string[]): string {
     return grammarScopes
       .map((g) => `atom-text-editor[data-grammar="${Convert.encodeHTMLAttribute(g.replace(/\./g, ' '))}"]`)
       .join(', ');
   }
 
-  // Public: Encode a string so that it can be safely used within a HTML attribute - i.e. replacing all quoted
-  // values with their HTML entity encoded versions.  e.g. `Hello"` becomes `Hello&quot;`
-  //
-  // * 's' A string to be encoded.
-  //
-  // Returns a string that is HTML attribute encoded by replacing &, <, >, " and ' with their HTML entity
-  // named equivalents.
+  /**
+   * Public: Encode a string so that it can be safely used within a HTML attribute - i.e. replacing all quoted
+   * values with their HTML entity encoded versions.  e.g. `Hello"` becomes `Hello&quot;`
+   *
+   * @param s A string to be encoded.
+   * @returns A string that is HTML attribute encoded by replacing &, <, >, " and ' with their HTML entity
+   * named equivalents.
+   */
   public static encodeHTMLAttribute(s: string): string {
     const attributeMap: { [key: string]: string } = {
       '&': '&amp;',
@@ -151,14 +164,15 @@ export default class Convert {
     return s.replace(/[&<>'"]/g, (c) => attributeMap[c]);
   }
 
-  // Public: Convert an Atom File Event as received from atom.project.onDidChangeFiles and convert
-  // it into an Array of Language Server Protocol {FileEvent} objects. Normally this will be a 1-to-1
-  // but renames will be represented by a deletion and a subsequent creation as LSP does not know about
-  // renames.
-  //
-  // * 'fileEvent' An {atom$ProjectFileEvent} to be converted.
-  //
-  // Returns an array of LSP {ls.FileEvent} objects that equivalent conversions to the fileEvent parameter.
+  /**
+   * Public: Convert an Atom File Event as received from atom.project.onDidChangeFiles and convert
+   * it into an Array of Language Server Protocol {FileEvent} objects. Normally this will be a 1-to-1
+   * but renames will be represented by a deletion and a subsequent creation as LSP does not know about
+   * renames.
+   *
+   * @param fileEvent An {atom$ProjectFileEvent} to be converted.
+   * @returns An array of LSP {ls.FileEvent} objects that equivalent conversions to the fileEvent parameter.
+   */
   public static atomFileEventToLSFileEvents(fileEvent: FilesystemChange): ls.FileEvent[] {
     switch (fileEvent.action) {
       case 'created':
@@ -204,22 +218,24 @@ export default class Convert {
     }
   }
 
-  // Public: Convert an array of language server protocol {TextEdit} objects to an
-  // equivalent array of Atom {TextEdit} objects.
-  //
-  // * `textEdits` The language server protocol {TextEdit} objects to convert.
-  //
-  // Returns an {Array} of Atom {TextEdit} objects.
+  /**
+   * Public: Convert an array of language server protocol {TextEdit} objects to an
+   * equivalent array of Atom {TextEdit} objects.
+   *
+   * @param textEdits The language server protocol {TextEdit} objects to convert.
+   * @returns An {Array} of Atom {TextEdit} objects.
+   */
   public static convertLsTextEdits(textEdits: ls.TextEdit[] | null): TextEdit[] {
     return (textEdits || []).map(Convert.convertLsTextEdit);
   }
 
-  // Public: Convert a language server protocol {TextEdit} object to the
-  // Atom equivalent {TextEdit}.
-  //
-  // * `textEdits` The language server protocol {TextEdit} objects to convert.
-  //
-  // Returns an Atom {TextEdit} object.
+  /**
+   * Public: Convert a language server protocol {TextEdit} object to the
+   * Atom equivalent {TextEdit}.
+   *
+   * @param textEdits The language server protocol {TextEdit} objects to convert.
+   * @returns An Atom {TextEdit} object.
+   */
   public static convertLsTextEdit(textEdit: ls.TextEdit): TextEdit {
     return {
       oldRange: Convert.lsRangeToAtomRange(textEdit.range),

--- a/lib/convert.ts
+++ b/lib/convert.ts
@@ -22,7 +22,7 @@ export default class Convert {
    * Public: Convert a path to a Uri.
    *
    * @param filePath A file path to convert to a Uri.
-   * @returns the Uri corresponding to the path. e.g. file:///a/b/c.txt
+   * @returns The Uri corresponding to the path. e.g. file:///a/b/c.txt
    */
   public static pathToUri(filePath: string): string {
     let newPath = filePath.replace(/\\/g, '/');
@@ -37,8 +37,8 @@ export default class Convert {
    *
    * @param uri A Uri to convert to a file path.
    * @returns A file path corresponding to the Uri. e.g. /a/b/c.txt
-   * If the Uri does not begin file: then it is returned as-is to allow Atom
-   * to deal with http/https sources in the future.
+   *   If the Uri does not begin file: then it is returned as-is to allow Atom
+   *   to deal with http/https sources in the future.
    */
   public static uriToPath(uri: string): string {
     const url = URL.parse(uri);
@@ -61,8 +61,7 @@ export default class Convert {
    * Public: Convert an Atom {Point} to a language server {Position}.
    *
    * @param point An Atom {Point} to convert from.
-   *
-   * Returns the {Position} representation of the Atom {PointObject}.
+   * @returns The {Position} representation of the Atom {PointObject}.
    */
   public static pointToPosition(point: Point): ls.Position {
     return { line: point.row, character: point.column };
@@ -106,7 +105,7 @@ export default class Convert {
    *
    * @param editor A {TextEditor} that will be used to form the uri property.
    * @returns A {TextDocumentIdentifier} that has a `uri` property with the Uri for the
-   * given editor's path.
+   *   given editor's path.
    */
   public static editorToTextDocumentIdentifier(editor: TextEditor): ls.TextDocumentIdentifier {
     return { uri: Convert.pathToUri(editor.getPath() || '') };
@@ -117,9 +116,9 @@ export default class Convert {
    *
    * @param editor A {TextEditor} that will be used to form the uri property.
    * @param point An optional {Point} that will supply the position property. If not specified
-   *            the current cursor position will be used.
+   *   the current cursor position will be used.
    * @returns A {TextDocumentPositionParams} that has textDocument property with the editors {TextDocumentIdentifier}
-   * and a position property with the supplied point (or current cursor position when not specified).
+   *   and a position property with the supplied point (or current cursor position when not specified).
    */
   public static editorToTextDocumentPositionParams(
     editor: TextEditor,
@@ -137,7 +136,8 @@ export default class Convert {
    *
    * @param grammarScopes An {Array} of grammar scope string to convert from.
    * @returns A single comma-separated list of CSS selectors targetting the grammars of Atom text editors.
-   * e.g. `['c', 'cpp']` => `'atom-text-editor[data-grammar='c'], atom-text-editor[data-grammar='cpp']`
+   *   e.g. `['c', 'cpp']` =>
+   *   `'atom-text-editor[data-grammar='c'], atom-text-editor[data-grammar='cpp']`
    */
   public static grammarScopesToTextEditorScopes(grammarScopes: string[]): string {
     return grammarScopes
@@ -146,12 +146,12 @@ export default class Convert {
   }
 
   /**
-   * Public: Encode a string so that it can be safely used within a HTML attribute - i.e. replacing all quoted
-   * values with their HTML entity encoded versions.  e.g. `Hello"` becomes `Hello&quot;`
+   * Public: Encode a string so that it can be safely used within a HTML attribute - i.e. replacing all
+   * quoted values with their HTML entity encoded versions.  e.g. `Hello"` becomes `Hello&quot;`
    *
    * @param s A string to be encoded.
    * @returns A string that is HTML attribute encoded by replacing &, <, >, " and ' with their HTML entity
-   * named equivalents.
+   *   named equivalents.
    */
   public static encodeHTMLAttribute(s: string): string {
     const attributeMap: { [key: string]: string } = {

--- a/lib/download-file.ts
+++ b/lib/download-file.ts
@@ -1,16 +1,17 @@
 import * as fs from 'fs';
 
-// Public: Download a file and store it on a file system using streaming with appropriate progress callback.
-//
-// * `sourceUrl`        Url to download from.
-// * `targetFile`       File path to save to.
-// * `progressCallback` Callback function that will be given a {ByteProgressCallback} object containing
-//                      both bytesDone and percent.
-// * `length`           File length in bytes if you want percentage progress indication and the server is
-//                      unable to provide a Content-Length header and whitelist CORS access via a
-//                      `Access-Control-Expose-Headers "content-length"` header.
-//
-// Returns a {Promise} that will accept when complete.
+/**
+ * Public: Download a file and store it on a file system using streaming with appropriate progress callback.
+ *
+ * @param sourceUrl        Url to download from.
+ * @param targetFile       File path to save to.
+ * @param progressCallback Callback function that will be given a {ByteProgressCallback} object containing
+ *                         both bytesDone and percent.
+ * @param length           File length in bytes if you want percentage progress indication and the server is
+ *                         unable to provide a Content-Length header and whitelist CORS access via a
+ *                         `Access-Control-Expose-Headers "content-length"` header.
+ * @returns A {Promise} that will accept when complete.
+ */
 export default (async function downloadFile(
   sourceUrl: string,
   targetFile: string,
@@ -39,15 +40,16 @@ export default (async function downloadFile(
   writer.end();
 });
 
-// Stream from a {ReadableStreamReader} to a {WriteStream} with progress callback.
-//
-// * `length`           File length in bytes.
-// * `reader`           {ReadableStreamReader} to read from.
-// * `writer`           {WriteStream} to write to.
-// * `progressCallback` Callback function that will be given a {ByteProgressCallback} object containing
-//                      both bytesDone and percent.
-//
-// Returns a {Promise} that will accept when complete.
+/**
+ * Stream from a {ReadableStreamReader} to a {WriteStream} with progress callback.
+ *
+ * @param length           File length in bytes.
+ * @param reader           A {ReadableStreamReader} to read from.
+ * @param writer           A {WriteStream} to write to.
+ * @param progressCallback Callback function that will be given a {ByteProgressCallback} object containing
+ *                         both bytesDone and percent.
+ * @returns A {Promise} that will accept when complete.
+ */
 async function streamWithProgress(
   length: number,
   reader: ReadableStreamReader,
@@ -79,6 +81,8 @@ async function streamWithProgress(
   }
 }
 
-// Public: Progress callback function signature indicating the bytesDone and
-// optional percentage when length is known.
+/**
+ * Public: Progress callback function signature indicating the bytesDone and
+ * optional percentage when length is known.
+ */
 export type ByteProgressCallback = (bytesDone: number, percent?: number) => void;

--- a/lib/download-file.ts
+++ b/lib/download-file.ts
@@ -3,13 +3,13 @@ import * as fs from 'fs';
 /**
  * Public: Download a file and store it on a file system using streaming with appropriate progress callback.
  *
- * @param sourceUrl        Url to download from.
- * @param targetFile       File path to save to.
+ * @param sourceUrl Url to download from.
+ * @param targetFile File path to save to.
  * @param progressCallback Callback function that will be given a {ByteProgressCallback} object containing
- *                         both bytesDone and percent.
- * @param length           File length in bytes if you want percentage progress indication and the server is
- *                         unable to provide a Content-Length header and whitelist CORS access via a
- *                         `Access-Control-Expose-Headers "content-length"` header.
+ *   both bytesDone and percent.
+ * @param length File length in bytes if you want percentage progress indication and the server is
+ *   unable to provide a Content-Length header and whitelist CORS access via a
+ *   `Access-Control-Expose-Headers "content-length"` header.
  * @returns A {Promise} that will accept when complete.
  */
 export default (async function downloadFile(
@@ -43,11 +43,11 @@ export default (async function downloadFile(
 /**
  * Stream from a {ReadableStreamReader} to a {WriteStream} with progress callback.
  *
- * @param length           File length in bytes.
- * @param reader           A {ReadableStreamReader} to read from.
- * @param writer           A {WriteStream} to write to.
+ * @param length File length in bytes.
+ * @param reader A {ReadableStreamReader} to read from.
+ * @param writer A {WriteStream} to write to.
  * @param progressCallback Callback function that will be given a {ByteProgressCallback} object containing
- *                         both bytesDone and percent.
+ *   both bytesDone and percent.
  * @returns A {Promise} that will accept when complete.
  */
 async function streamWithProgress(

--- a/lib/languageclient.ts
+++ b/lib/languageclient.ts
@@ -29,8 +29,10 @@ export type RequestCallback<T extends keyof KnownRequests> =
   (param: U) => Promise<V> :
   never;
 
-// TypeScript wrapper around JSONRPC to implement Microsoft Language Server Protocol v3
-// https://github.com/Microsoft/language-server-protocol/blob/master/protocol.md
+/**
+ * TypeScript wrapper around JSONRPC to implement Microsoft Language Server Protocol v3
+ * https://github.com/Microsoft/language-server-protocol/blob/master/protocol.md
+ */
 export class LanguageClientConnection extends EventEmitter {
   private _rpc: jsonrpc.MessageConnection;
   private _log: Logger;
@@ -67,178 +69,216 @@ export class LanguageClientConnection extends EventEmitter {
     this._rpc.dispose();
   }
 
-  // Public: Initialize the language server with necessary {InitializeParams}.
-  //
-  // * `params` The {InitializeParams} containing processId, rootPath, options and
-  //            server capabilities.
-  //
-  // Returns a {Promise} containing the {InitializeResult} with details of the server's
-  // capabilities.
+  /**
+   * Public: Initialize the language server with necessary {InitializeParams}.
+   *
+   * @param params The {InitializeParams} containing processId, rootPath, options and
+   * @returns A {Promise} containing the {InitializeResult} with details of the server's
+   * capabilities.
+   */
   public initialize(params: lsp.InitializeParams): Promise<lsp.InitializeResult> {
     return this._sendRequest('initialize', params);
   }
 
-  // Public: Send an `initialized` notification to the language server.
+  /**
+   * Public: Send an `initialized` notification to the language server.
+   */
   public initialized(): void {
     this._sendNotification('initialized', {});
   }
 
-  // Public: Send a `shutdown` request to the language server.
+  /**
+   * Public: Send a `shutdown` request to the language server.
+   */
   public shutdown(): Promise<void> {
     return this._sendRequest('shutdown');
   }
 
-  // Public: Send an `exit` notification to the language server.
+  /**
+   * Public: Send an `exit` notification to the language server.
+   */
   public exit(): void {
     this._sendNotification('exit');
   }
 
-  // Public: Register a callback for a custom message.
-  //
-  // * `method`   A string containing the name of the message to listen for.
-  // * `callback` The function to be called when the message is received.
-  //              The payload from the message is passed to the function.
+  /**
+   * Public: Register a callback for a custom message.
+   *
+   * @param method   A string containing the name of the message to listen for.
+   * @param callback The function to be called when the message is received.
+   *                 The payload from the message is passed to the function.
+   */
   public onCustom(method: string, callback: (obj: object) => void): void {
     this._onNotification({ method }, callback);
   }
 
-  // Public: Send a custom request
-  //
-  // * `method`   A string containing the name of the request message.
-  // * `params`   The method's parameters
+  /**
+   * Public: Send a custom request
+   *
+   * @param method A string containing the name of the request message.
+   * @param params The method's parameters
+   */
   public sendCustomRequest(method: string, params?: any[] | object): Promise<any | null> {
     return this._sendRequest(method, params);
   }
 
-  // Public: Send a custom notification
-  //
-  // * `method`   A string containing the name of the notification message.
-  // * `params`  The method's parameters
+  /**
+   * Public: Send a custom notification
+   *
+   * @param method A string containing the name of the notification message.
+   * @param params The method's parameters
+   */
   public sendCustomNotification(method: string, params?: any[] | object): void {
     this._sendNotification(method, params);
   }
 
-  // Public: Register a callback for the `window/showMessage` message.
-  //
-  // * `callback` The function to be called when the `window/showMessage` message is
-  //              received with {ShowMessageParams} being passed.
+  /**
+   * Public: Register a callback for the `window/showMessage` message.
+   *
+   * @param callback The function to be called when the `window/showMessage` message is
+   *                 received with {ShowMessageParams} being passed.
+   */
   public onShowMessage(callback: (params: lsp.ShowMessageParams) => void): void {
     this._onNotification({ method: 'window/showMessage' }, callback);
   }
 
-  // Public: Register a callback for the `window/showMessageRequest` message.
-  //
-  // * `callback` The function to be called when the `window/showMessageRequest` message is
-  //              received with {ShowMessageRequestParam}' being passed.
-  // Returns a {Promise} containing the {MessageActionItem}.
+  /**
+   * Public: Register a callback for the `window/showMessageRequest` message.
+   *
+   * @param callback The function to be called when the `window/showMessageRequest` message is
+   * @returns A {Promise} containing the {MessageActionItem}.
+   */
   public onShowMessageRequest(callback: (params: lsp.ShowMessageRequestParams)
     => Promise<lsp.MessageActionItem | null>): void {
     this._onRequest({ method: 'window/showMessageRequest' }, callback);
   }
 
-  // Public: Register a callback for the `window/logMessage` message.
-  //
-  // * `callback` The function to be called when the `window/logMessage` message is
-  //              received with {LogMessageParams} being passed.
+  /**
+   * Public: Register a callback for the `window/logMessage` message.
+   *
+   * @param callback The function to be called when the `window/logMessage` message is
+   *                 received with {LogMessageParams} being passed.
+   */
   public onLogMessage(callback: (params: lsp.LogMessageParams) => void): void {
     this._onNotification({ method: 'window/logMessage' }, callback);
   }
 
-  // Public: Register a callback for the `telemetry/event` message.
-  //
-  // * `callback` The function to be called when the `telemetry/event` message is
-  //              received with any parameters received being passed on.
+  /**
+   * Public: Register a callback for the `telemetry/event` message.
+   *
+   * @param callback The function to be called when the `telemetry/event` message is
+   *                 received with any parameters received being passed on.
+   */
   public onTelemetryEvent(callback: (...args: any[]) => void): void {
     this._onNotification({ method: 'telemetry/event' }, callback);
   }
 
-  // Public: Register a callback for the `workspace/applyEdit` message.
-  //
-  // * `callback` The function to be called when the `workspace/applyEdit` message is
-  //              received with {ApplyWorkspaceEditParams} being passed.
-  // Returns a {Promise} containing the {ApplyWorkspaceEditResponse}.
+  /**
+   * Public: Register a callback for the `workspace/applyEdit` message.
+   *
+   * @param callback The function to be called when the `workspace/applyEdit` message is
+   * @returns A {Promise} containing the {ApplyWorkspaceEditResponse}.
+   */
   public onApplyEdit(callback: (params: lsp.ApplyWorkspaceEditParams) =>
     Promise<lsp.ApplyWorkspaceEditResponse>): void {
     this._onRequest({ method: 'workspace/applyEdit' }, callback);
   }
 
-  // Public: Send a `workspace/didChangeConfiguration` notification.
-  //
-  // * `params` The {DidChangeConfigurationParams} containing the new configuration.
+  /**
+   * Public: Send a `workspace/didChangeConfiguration` notification.
+   *
+   * @param params The {DidChangeConfigurationParams} containing the new configuration.
+   */
   public didChangeConfiguration(params: lsp.DidChangeConfigurationParams): void {
     this._sendNotification('workspace/didChangeConfiguration', params);
   }
 
-  // Public: Send a `textDocument/didOpen` notification.
-  //
-  // * `params` The {DidOpenTextDocumentParams} containing the opened text document details.
+  /**
+   * Public: Send a `textDocument/didOpen` notification.
+   *
+   * @param params The {DidOpenTextDocumentParams} containing the opened text document details.
+   */
   public didOpenTextDocument(params: lsp.DidOpenTextDocumentParams): void {
     this._sendNotification('textDocument/didOpen', params);
   }
 
-  // Public: Send a `textDocument/didChange` notification.
-  //
-  // * `params` The {DidChangeTextDocumentParams} containing the changed text document
-  // details including the version number and actual text changes.
+  /**
+   * Public: Send a `textDocument/didChange` notification.
+   *
+   * @param params The {DidChangeTextDocumentParams} containing the changed text document
+   *               details including the version number and actual text changes.
+   */
   public didChangeTextDocument(params: lsp.DidChangeTextDocumentParams): void {
     this._sendNotification('textDocument/didChange', params);
   }
 
-  // Public: Send a `textDocument/didClose` notification.
-  //
-  // * `params` The {DidCloseTextDocumentParams} containing the opened text document details.
+  /**
+   * Public: Send a `textDocument/didClose` notification.
+   *
+   * @param params The {DidCloseTextDocumentParams} containing the opened text document details.
+   */
   public didCloseTextDocument(params: lsp.DidCloseTextDocumentParams): void {
     this._sendNotification('textDocument/didClose', params);
   }
 
-  // Public: Send a `textDocument/willSave` notification.
-  //
-  // * `params` The {WillSaveTextDocumentParams} containing the to-be-saved text document
-  // details and the reason for the save.
+  /**
+   * Public: Send a `textDocument/willSave` notification.
+   *
+   * @param params The {WillSaveTextDocumentParams} containing the to-be-saved text document
+   * details and the reason for the save.
+   */
   public willSaveTextDocument(params: lsp.WillSaveTextDocumentParams): void {
     this._sendNotification('textDocument/willSave', params);
   }
 
-  // Public: Send a `textDocument/willSaveWaitUntil` notification.
-  //
-  // * `params` The {WillSaveTextDocumentParams} containing the to-be-saved text document
-  // details and the reason for the save.
-  // Returns a {Promise} containing an {Array} of {TextEdit}s to be applied to the text
-  // document before it is saved.
+  /**
+   * Public: Send a `textDocument/willSaveWaitUntil` notification.
+   *
+   * @param params The {WillSaveTextDocumentParams} containing the to-be-saved text document
+   * @returns A {Promise} containing an {Array} of {TextEdit}s to be applied to the text
+   * document before it is saved.
+   */
   public willSaveWaitUntilTextDocument(params: lsp.WillSaveTextDocumentParams): Promise<lsp.TextEdit[] | null> {
     return this._sendRequest('textDocument/willSaveWaitUntil', params);
   }
 
-  // Public: Send a `textDocument/didSave` notification.
-  //
-  // * `params` The {DidSaveTextDocumentParams} containing the saved text document details.
+  /**
+   * Public: Send a `textDocument/didSave` notification.
+   *
+   * @param params The {DidSaveTextDocumentParams} containing the saved text document details.
+   */
   public didSaveTextDocument(params: lsp.DidSaveTextDocumentParams): void {
     this._sendNotification('textDocument/didSave', params);
   }
 
-  // Public: Send a `workspace/didChangeWatchedFiles` notification.
-  //
-  // * `params` The {DidChangeWatchedFilesParams} containing the array of {FileEvent}s that
-  // have been observed upon the watched files.
+  /**
+   * Public: Send a `workspace/didChangeWatchedFiles` notification.
+   *
+   * @param params The {DidChangeWatchedFilesParams} containing the array of {FileEvent}s that
+   *               have been observed upon the watched files.
+   */
   public didChangeWatchedFiles(params: lsp.DidChangeWatchedFilesParams): void {
     this._sendNotification('workspace/didChangeWatchedFiles', params);
   }
 
-  // Public: Register a callback for the `textDocument/publishDiagnostics` message.
-  //
-  // * `callback` The function to be called when the `textDocument/publishDiagnostics` message is
-  //              received a {PublishDiagnosticsParams} containing new {Diagnostic} messages for a given uri.
+  /**
+   * Public: Register a callback for the `textDocument/publishDiagnostics` message.
+   *
+   * @param callback The function to be called when the `textDocument/publishDiagnostics` message is
+   *                 received a {PublishDiagnosticsParams} containing new {Diagnostic} messages for a given uri.
+   */
   public onPublishDiagnostics(callback: (params: lsp.PublishDiagnosticsParams) => void): void {
     this._onNotification({ method: 'textDocument/publishDiagnostics' }, callback);
   }
 
-  // Public: Send a `textDocument/completion` request.
-  //
-  // * `params`            The {TextDocumentPositionParams} or {CompletionParams} for which
-  //                       {CompletionItem}s are desired.
-  // * `cancellationToken` The {CancellationToken} that is used to cancel this request if
-  //                       necessary.
-  // Returns a {Promise} containing either a {CompletionList} or an {Array} of {CompletionItem}s.
+  /**
+   * Public: Send a `textDocument/completion` request.
+   *
+   * @param params            The {TextDocumentPositionParams} or {CompletionParams} for which
+   *                          {CompletionItem}s are desired.
+   * @param cancellationToken The {CancellationToken} that is used to cancel this request if
+   * @returns A {Promise} containing either a {CompletionList} or an {Array} of {CompletionItem}s.
+   */
   public completion(
     params: lsp.TextDocumentPositionParams | CompletionParams,
     cancellationToken?: jsonrpc.CancellationToken): Promise<lsp.CompletionItem[] | lsp.CompletionList | null> {
@@ -246,65 +286,76 @@ export class LanguageClientConnection extends EventEmitter {
     return this._sendRequest('textDocument/completion', params, cancellationToken);
   }
 
-  // Public: Send a `completionItem/resolve` request.
-  //
-  // * `params` The {CompletionItem} for which a fully resolved {CompletionItem} is desired.
-  // Returns a {Promise} containing a fully resolved {CompletionItem}.
+  /**
+   * Public: Send a `completionItem/resolve` request.
+   *
+   * @param params The {CompletionItem} for which a fully resolved {CompletionItem} is desired.
+   * @returns A {Promise} containing a fully resolved {CompletionItem}.
+   */
   public completionItemResolve(params: lsp.CompletionItem): Promise<lsp.CompletionItem | null> {
     return this._sendRequest('completionItem/resolve', params);
   }
 
-  // Public: Send a `textDocument/hover` request.
-  //
-  // * `params` The {TextDocumentPositionParams} for which a {Hover} is desired.
-  // Returns a {Promise} containing a {Hover}.
+  /**
+   * Public: Send a `textDocument/hover` request.
+   *
+   * @param params The {TextDocumentPositionParams} for which a {Hover} is desired.
+   * @returns A {Promise} containing a {Hover}.
+   */
   public hover(params: lsp.TextDocumentPositionParams): Promise<lsp.Hover | null> {
     return this._sendRequest('textDocument/hover', params);
   }
 
-  // Public: Send a `textDocument/signatureHelp` request.
-  //
-  // * `params` The {TextDocumentPositionParams} for which a {SignatureHelp} is desired.
-  // Returns a {Promise} containing a {SignatureHelp}.
+  /**
+   * Public: Send a `textDocument/signatureHelp` request.
+   *
+   * @param params The {TextDocumentPositionParams} for which a {SignatureHelp} is desired.
+   * @returns A {Promise} containing a {SignatureHelp}.
+   */
   public signatureHelp(params: lsp.TextDocumentPositionParams): Promise<lsp.SignatureHelp | null> {
     return this._sendRequest('textDocument/signatureHelp', params);
   }
 
-  // Public: Send a `textDocument/definition` request.
-  //
-  // * `params` The {TextDocumentPositionParams} of a symbol for which one or more {Location}s
-  // that define that symbol are required.
-  // Returns a {Promise} containing either a single {Location} or an {Array} of many {Location}s.
+  /**
+   * Public: Send a `textDocument/definition` request.
+   *
+   * @param params The {TextDocumentPositionParams} of a symbol for which one or more {Location}s
+   * @returns A {Promise} containing either a single {Location} or an {Array} of many {Location}s.
+   */
   public gotoDefinition(params: lsp.TextDocumentPositionParams): Promise<lsp.Location | lsp.Location[]> {
     return this._sendRequest('textDocument/definition', params);
   }
 
-  // Public: Send a `textDocument/references` request.
-  //
-  // * `params` The {TextDocumentPositionParams} of a symbol for which all referring {Location}s
-  // are desired.
-  // Returns a {Promise} containing an {Array} of {Location}s that reference this symbol.
+  /**
+   * Public: Send a `textDocument/references` request.
+   *
+   * @param params The {TextDocumentPositionParams} of a symbol for which all referring {Location}s
+   * @returns A {Promise} containing an {Array} of {Location}s that reference this symbol.
+   */
   public findReferences(params: lsp.ReferenceParams): Promise<lsp.Location[]> {
     return this._sendRequest('textDocument/references', params);
   }
 
-  // Public: Send a `textDocument/documentHighlight` request.
-  //
-  // * `params` The {TextDocumentPositionParams} of a symbol for which all highlights are desired.
-  // Returns a {Promise} containing an {Array} of {DocumentHighlight}s that can be used to
-  // highlight this symbol.
+  /**
+   * Public: Send a `textDocument/documentHighlight` request.
+   *
+   * @param params The {TextDocumentPositionParams} of a symbol for which all highlights are desired.
+   * @returns A {Promise} containing an {Array} of {DocumentHighlight}s that can be used to
+   *          highlight this symbol.
+   */
   public documentHighlight(params: lsp.TextDocumentPositionParams): Promise<lsp.DocumentHighlight[]> {
     return this._sendRequest('textDocument/documentHighlight', params);
   }
 
-  // Public: Send a `textDocument/documentSymbol` request.
-  //
-  // * `params`            The {DocumentSymbolParams} that identifies the document for which
-  //                       symbols are desired.
-  // * `cancellationToken` The {CancellationToken} that is used to cancel this request if
-  //                       necessary.
-  // Returns a {Promise} containing an {Array} of {SymbolInformation}s that can be used to
-  // navigate this document.
+  /**
+   * Public: Send a `textDocument/documentSymbol` request.
+   *
+   * @param params            The {DocumentSymbolParams} that identifies the document for which
+   *                       symbols are desired.
+   * @param cancellationToken The {CancellationToken} that is used to cancel this request if
+   * @returns A {Promise} containing an {Array} of {SymbolInformation}s that can be used to
+   *          navigate this document.
+   */
   public documentSymbol(
     params: lsp.DocumentSymbolParams,
     _cancellationToken?: jsonrpc.CancellationToken,
@@ -312,105 +363,121 @@ export class LanguageClientConnection extends EventEmitter {
     return this._sendRequest('textDocument/documentSymbol', params);
   }
 
-  // Public: Send a `workspace/symbol` request.
-  //
-  // * `params` The {WorkspaceSymbolParams} containing the query string to search the workspace for.
-  // Returns a {Promise} containing an {Array} of {SymbolInformation}s that identify where the query
-  // string occurs within the workspace.
+  /**
+   * Public: Send a `workspace/symbol` request.
+   *
+   * @param params The {WorkspaceSymbolParams} containing the query string to search the workspace for.
+   * @returns A {Promise} containing an {Array} of {SymbolInformation}s that identify where the query
+   *          string occurs within the workspace.
+   */
   public workspaceSymbol(params: lsp.WorkspaceSymbolParams): Promise<lsp.SymbolInformation[]> {
     return this._sendRequest('workspace/symbol', params);
   }
 
-  // Public: Send a `textDocument/codeAction` request.
-  //
-  // * `params` The {CodeActionParams} identifying the document, range and context for the code action.
-  // Returns a {Promise} containing an {Array} of {Commands}s that can be performed against the given
-  // documents range.
+  /**
+   * Public: Send a `textDocument/codeAction` request.
+   *
+   * @param params The {CodeActionParams} identifying the document, range and context for the code action.
+   * @returns A {Promise} containing an {Array} of {Commands}s that can be performed against the given
+   *          documents range.
+   */
   public codeAction(params: lsp.CodeActionParams): Promise<Array<lsp.Command | lsp.CodeAction>> {
     return this._sendRequest('textDocument/codeAction', params);
   }
 
-  // Public: Send a `textDocument/codeLens` request.
-  //
-  // * `params` The {CodeLensParams} identifying the document for which code lens commands are desired.
-  // Returns a {Promise} containing an {Array} of {CodeLens}s that associate commands and data with
-  // specified ranges within the document.
+  /**
+   * Public: Send a `textDocument/codeLens` request.
+   *
+   * @param params The {CodeLensParams} identifying the document for which code lens commands are desired.
+   * @returns A {Promise} containing an {Array} of {CodeLens}s that associate commands and data with
+   *          specified ranges within the document.
+   */
   public codeLens(params: lsp.CodeLensParams): Promise<lsp.CodeLens[]> {
     return this._sendRequest('textDocument/codeLens', params);
   }
 
-  // Public: Send a `codeLens/resolve` request.
-  //
-  // * `params` The {CodeLens} identifying the code lens to be resolved with full detail.
-  // Returns a {Promise} containing the {CodeLens} fully resolved.
+  /**
+   * Public: Send a `codeLens/resolve` request.
+   *
+   * @param params The {CodeLens} identifying the code lens to be resolved with full detail.
+   * @returns A {Promise} containing the {CodeLens} fully resolved.
+   */
   public codeLensResolve(params: lsp.CodeLens): Promise<lsp.CodeLens | null> {
     return this._sendRequest('codeLens/resolve', params);
   }
 
-  // Public: Send a `textDocument/documentLink` request.
-  //
-  // * `params` The {DocumentLinkParams} identifying the document for which links should be identified.
-  // Returns a {Promise} containing an {Array} of {DocumentLink}s relating uri's to specific ranges
-  // within the document.
+  /**
+   * Public: Send a `textDocument/documentLink` request.
+   *
+   * @param params The {DocumentLinkParams} identifying the document for which links should be identified.
+   * @returns A {Promise} containing an {Array} of {DocumentLink}s relating uri's to specific ranges
+   *          within the document.
+   */
   public documentLink(params: lsp.DocumentLinkParams): Promise<lsp.DocumentLink[]> {
     return this._sendRequest('textDocument/documentLink', params);
   }
 
-  // Public: Send a `documentLink/resolve` request.
-  //
-  // * `params` The {DocumentLink} identifying the document link to be resolved with full detail.
-  // Returns a {Promise} containing the {DocumentLink} fully resolved.
+  /**
+   * Public: Send a `documentLink/resolve` request.
+   *
+   * @param params The {DocumentLink} identifying the document link to be resolved with full detail.
+   * @returns A {Promise} containing the {DocumentLink} fully resolved.
+   */
   public documentLinkResolve(params: lsp.DocumentLink): Promise<lsp.DocumentLink> {
     return this._sendRequest('documentLink/resolve', params);
   }
 
-  // Public: Send a `textDocument/formatting` request.
-  //
-  // * `params` The {DocumentFormattingParams} identifying the document to be formatted as well as
-  // additional formatting preferences.
-  // Returns a {Promise} containing an {Array} of {TextEdit}s to be applied to the document to
-  // correctly reformat it.
+  /**
+   * Public: Send a `textDocument/formatting` request.
+   *
+   * @param params The {DocumentFormattingParams} identifying the document to be formatted as well as
+   * @returns A {Promise} containing an {Array} of {TextEdit}s to be applied to the document to
+   *          correctly reformat it.
+   */
   public documentFormatting(params: lsp.DocumentFormattingParams): Promise<lsp.TextEdit[]> {
     return this._sendRequest('textDocument/formatting', params);
   }
 
-  // Public: Send a `textDocument/rangeFormatting` request.
-  //
-  // * `params` The {DocumentRangeFormattingParams} identifying the document and range to be formatted
-  // as well as additional formatting preferences.
-  // Returns a {Promise} containing an {Array} of {TextEdit}s to be applied to the document to
-  // correctly reformat it.
+  /**
+   * Public: Send a `textDocument/rangeFormatting` request.
+   *
+   * @param params The {DocumentRangeFormattingParams} identifying the document and range to be formatted
+   * @returns A {Promise} containing an {Array} of {TextEdit}s to be applied to the document to
+   *          correctly reformat it.
+   */
   public documentRangeFormatting(params: lsp.DocumentRangeFormattingParams): Promise<lsp.TextEdit[]> {
     return this._sendRequest('textDocument/rangeFormatting', params);
   }
 
-  // Public: Send a `textDocument/onTypeFormatting` request.
-  //
-  // * `params` The {DocumentOnTypeFormattingParams} identifying the document to be formatted,
-  // the character that was typed and at what position as well as additional formatting preferences.
-  // Returns a {Promise} containing an {Array} of {TextEdit}s to be applied to the document to
-  // correctly reformat it.
+  /**
+   * Public: Send a `textDocument/onTypeFormatting` request.
+   *
+   * @param params The {DocumentOnTypeFormattingParams} identifying the document to be formatted,
+   * @returns A {Promise} containing an {Array} of {TextEdit}s to be applied to the document to
+   *          correctly reformat it.
+   */
   public documentOnTypeFormatting(params: lsp.DocumentOnTypeFormattingParams): Promise<lsp.TextEdit[]> {
     return this._sendRequest('textDocument/onTypeFormatting', params);
   }
 
-  // Public: Send a `textDocument/rename` request.
-  //
-  // * `params` The {RenameParams} identifying the document containing the symbol to be renamed,
-  // as well as the position and new name.
-  // Returns a {Promise} containing an {WorkspaceEdit} that contains a list of {TextEdit}s either
-  // on the changes property (keyed by uri) or the documentChanges property containing
-  // an {Array} of {TextDocumentEdit}s (preferred).
+  /**
+   * Public: Send a `textDocument/rename` request.
+   *
+   * @param params The {RenameParams} identifying the document containing the symbol to be renamed,
+   * @returns A {Promise} containing an {WorkspaceEdit} that contains a list of {TextEdit}s either
+   *          on the changes property (keyed by uri) or the documentChanges property containing
+   *          an {Array} of {TextDocumentEdit}s (preferred).
+   */
   public rename(params: lsp.RenameParams): Promise<lsp.WorkspaceEdit> {
     return this._sendRequest('textDocument/rename', params);
   }
 
-  // Public: Send a `workspace/executeCommand` request.
-  //
-  // * `params` The {ExecuteCommandParams} specifying the command and arguments
-  // the language server should execute (these commands are usually from {CodeLens} or {CodeAction}
-  // responses).
-  // Returns a {Promise} containing anything.
+  /**
+   * Public: Send a `workspace/executeCommand` request.
+   *
+   * @param params The {ExecuteCommandParams} specifying the command and arguments
+   * @returns A {Promise} containing anything.
+   */
   public executeCommand(params: lsp.ExecuteCommandParams): Promise<any> {
     return this._sendRequest('workspace/executeCommand', params);
   }

--- a/lib/languageclient.ts
+++ b/lib/languageclient.ts
@@ -73,30 +73,25 @@ export class LanguageClientConnection extends EventEmitter {
    * Public: Initialize the language server with necessary {InitializeParams}.
    *
    * @param params The {InitializeParams} containing processId, rootPath, options and
+   *   server capabilities.
    * @returns A {Promise} containing the {InitializeResult} with details of the server's
-   * capabilities.
+   *   capabilities.
    */
   public initialize(params: lsp.InitializeParams): Promise<lsp.InitializeResult> {
     return this._sendRequest('initialize', params);
   }
 
-  /**
-   * Public: Send an `initialized` notification to the language server.
-   */
+  /** Public: Send an `initialized` notification to the language server. */
   public initialized(): void {
     this._sendNotification('initialized', {});
   }
 
-  /**
-   * Public: Send a `shutdown` request to the language server.
-   */
+  /** Public: Send a `shutdown` request to the language server. */
   public shutdown(): Promise<void> {
     return this._sendRequest('shutdown');
   }
 
-  /**
-   * Public: Send an `exit` notification to the language server.
-   */
+  /** Public: Send an `exit` notification to the language server. */
   public exit(): void {
     this._sendNotification('exit');
   }
@@ -104,9 +99,9 @@ export class LanguageClientConnection extends EventEmitter {
   /**
    * Public: Register a callback for a custom message.
    *
-   * @param method   A string containing the name of the message to listen for.
+   * @param method A string containing the name of the message to listen for.
    * @param callback The function to be called when the message is received.
-   *                 The payload from the message is passed to the function.
+   *   The payload from the message is passed to the function.
    */
   public onCustom(method: string, callback: (obj: object) => void): void {
     this._onNotification({ method }, callback);
@@ -136,7 +131,7 @@ export class LanguageClientConnection extends EventEmitter {
    * Public: Register a callback for the `window/showMessage` message.
    *
    * @param callback The function to be called when the `window/showMessage` message is
-   *                 received with {ShowMessageParams} being passed.
+   *   received with {ShowMessageParams} being passed.
    */
   public onShowMessage(callback: (params: lsp.ShowMessageParams) => void): void {
     this._onNotification({ method: 'window/showMessage' }, callback);
@@ -146,6 +141,7 @@ export class LanguageClientConnection extends EventEmitter {
    * Public: Register a callback for the `window/showMessageRequest` message.
    *
    * @param callback The function to be called when the `window/showMessageRequest` message is
+   *   received with {ShowMessageRequestParam}' being passed.
    * @returns A {Promise} containing the {MessageActionItem}.
    */
   public onShowMessageRequest(callback: (params: lsp.ShowMessageRequestParams)
@@ -157,7 +153,7 @@ export class LanguageClientConnection extends EventEmitter {
    * Public: Register a callback for the `window/logMessage` message.
    *
    * @param callback The function to be called when the `window/logMessage` message is
-   *                 received with {LogMessageParams} being passed.
+   *   received with {LogMessageParams} being passed.
    */
   public onLogMessage(callback: (params: lsp.LogMessageParams) => void): void {
     this._onNotification({ method: 'window/logMessage' }, callback);
@@ -167,7 +163,7 @@ export class LanguageClientConnection extends EventEmitter {
    * Public: Register a callback for the `telemetry/event` message.
    *
    * @param callback The function to be called when the `telemetry/event` message is
-   *                 received with any parameters received being passed on.
+   *   received with any parameters received being passed on.
    */
   public onTelemetryEvent(callback: (...args: any[]) => void): void {
     this._onNotification({ method: 'telemetry/event' }, callback);
@@ -177,6 +173,7 @@ export class LanguageClientConnection extends EventEmitter {
    * Public: Register a callback for the `workspace/applyEdit` message.
    *
    * @param callback The function to be called when the `workspace/applyEdit` message is
+   *   received with {ApplyWorkspaceEditParams} being passed.
    * @returns A {Promise} containing the {ApplyWorkspaceEditResponse}.
    */
   public onApplyEdit(callback: (params: lsp.ApplyWorkspaceEditParams) =>
@@ -206,7 +203,7 @@ export class LanguageClientConnection extends EventEmitter {
    * Public: Send a `textDocument/didChange` notification.
    *
    * @param params The {DidChangeTextDocumentParams} containing the changed text document
-   *               details including the version number and actual text changes.
+   *   details including the version number and actual text changes.
    */
   public didChangeTextDocument(params: lsp.DidChangeTextDocumentParams): void {
     this._sendNotification('textDocument/didChange', params);
@@ -225,7 +222,7 @@ export class LanguageClientConnection extends EventEmitter {
    * Public: Send a `textDocument/willSave` notification.
    *
    * @param params The {WillSaveTextDocumentParams} containing the to-be-saved text document
-   * details and the reason for the save.
+   *   details and the reason for the save.
    */
   public willSaveTextDocument(params: lsp.WillSaveTextDocumentParams): void {
     this._sendNotification('textDocument/willSave', params);
@@ -235,8 +232,9 @@ export class LanguageClientConnection extends EventEmitter {
    * Public: Send a `textDocument/willSaveWaitUntil` notification.
    *
    * @param params The {WillSaveTextDocumentParams} containing the to-be-saved text document
+   *   details and the reason for the save.
    * @returns A {Promise} containing an {Array} of {TextEdit}s to be applied to the text
-   * document before it is saved.
+   *   document before it is saved.
    */
   public willSaveWaitUntilTextDocument(params: lsp.WillSaveTextDocumentParams): Promise<lsp.TextEdit[] | null> {
     return this._sendRequest('textDocument/willSaveWaitUntil', params);
@@ -255,7 +253,7 @@ export class LanguageClientConnection extends EventEmitter {
    * Public: Send a `workspace/didChangeWatchedFiles` notification.
    *
    * @param params The {DidChangeWatchedFilesParams} containing the array of {FileEvent}s that
-   *               have been observed upon the watched files.
+   *   have been observed upon the watched files.
    */
   public didChangeWatchedFiles(params: lsp.DidChangeWatchedFilesParams): void {
     this._sendNotification('workspace/didChangeWatchedFiles', params);
@@ -265,7 +263,7 @@ export class LanguageClientConnection extends EventEmitter {
    * Public: Register a callback for the `textDocument/publishDiagnostics` message.
    *
    * @param callback The function to be called when the `textDocument/publishDiagnostics` message is
-   *                 received a {PublishDiagnosticsParams} containing new {Diagnostic} messages for a given uri.
+   *   received a {PublishDiagnosticsParams} containing new {Diagnostic} messages for a given uri.
    */
   public onPublishDiagnostics(callback: (params: lsp.PublishDiagnosticsParams) => void): void {
     this._onNotification({ method: 'textDocument/publishDiagnostics' }, callback);
@@ -274,9 +272,9 @@ export class LanguageClientConnection extends EventEmitter {
   /**
    * Public: Send a `textDocument/completion` request.
    *
-   * @param params            The {TextDocumentPositionParams} or {CompletionParams} for which
-   *                          {CompletionItem}s are desired.
-   * @param cancellationToken The {CancellationToken} that is used to cancel this request if
+   * @param params The {TextDocumentPositionParams} or {CompletionParams} for which
+   *   {CompletionItem}s are desired.
+   * @param cancellationToken The {CancellationToken} that is used to cancel this request if necessary.
    * @returns A {Promise} containing either a {CompletionList} or an {Array} of {CompletionItem}s.
    */
   public completion(
@@ -320,6 +318,7 @@ export class LanguageClientConnection extends EventEmitter {
    * Public: Send a `textDocument/definition` request.
    *
    * @param params The {TextDocumentPositionParams} of a symbol for which one or more {Location}s
+   *   that define that symbol are required.
    * @returns A {Promise} containing either a single {Location} or an {Array} of many {Location}s.
    */
   public gotoDefinition(params: lsp.TextDocumentPositionParams): Promise<lsp.Location | lsp.Location[]> {
@@ -330,6 +329,7 @@ export class LanguageClientConnection extends EventEmitter {
    * Public: Send a `textDocument/references` request.
    *
    * @param params The {TextDocumentPositionParams} of a symbol for which all referring {Location}s
+   *   are desired.
    * @returns A {Promise} containing an {Array} of {Location}s that reference this symbol.
    */
   public findReferences(params: lsp.ReferenceParams): Promise<lsp.Location[]> {
@@ -341,7 +341,7 @@ export class LanguageClientConnection extends EventEmitter {
    *
    * @param params The {TextDocumentPositionParams} of a symbol for which all highlights are desired.
    * @returns A {Promise} containing an {Array} of {DocumentHighlight}s that can be used to
-   *          highlight this symbol.
+   *   highlight this symbol.
    */
   public documentHighlight(params: lsp.TextDocumentPositionParams): Promise<lsp.DocumentHighlight[]> {
     return this._sendRequest('textDocument/documentHighlight', params);
@@ -350,11 +350,12 @@ export class LanguageClientConnection extends EventEmitter {
   /**
    * Public: Send a `textDocument/documentSymbol` request.
    *
-   * @param params            The {DocumentSymbolParams} that identifies the document for which
-   *                       symbols are desired.
+   * @param params The {DocumentSymbolParams} that identifies the document for which
+   *   symbols are desired.
    * @param cancellationToken The {CancellationToken} that is used to cancel this request if
+   *   necessary.
    * @returns A {Promise} containing an {Array} of {SymbolInformation}s that can be used to
-   *          navigate this document.
+   *   navigate this document.
    */
   public documentSymbol(
     params: lsp.DocumentSymbolParams,
@@ -368,7 +369,7 @@ export class LanguageClientConnection extends EventEmitter {
    *
    * @param params The {WorkspaceSymbolParams} containing the query string to search the workspace for.
    * @returns A {Promise} containing an {Array} of {SymbolInformation}s that identify where the query
-   *          string occurs within the workspace.
+   *   string occurs within the workspace.
    */
   public workspaceSymbol(params: lsp.WorkspaceSymbolParams): Promise<lsp.SymbolInformation[]> {
     return this._sendRequest('workspace/symbol', params);
@@ -379,7 +380,7 @@ export class LanguageClientConnection extends EventEmitter {
    *
    * @param params The {CodeActionParams} identifying the document, range and context for the code action.
    * @returns A {Promise} containing an {Array} of {Commands}s that can be performed against the given
-   *          documents range.
+   *   documents range.
    */
   public codeAction(params: lsp.CodeActionParams): Promise<Array<lsp.Command | lsp.CodeAction>> {
     return this._sendRequest('textDocument/codeAction', params);
@@ -390,7 +391,7 @@ export class LanguageClientConnection extends EventEmitter {
    *
    * @param params The {CodeLensParams} identifying the document for which code lens commands are desired.
    * @returns A {Promise} containing an {Array} of {CodeLens}s that associate commands and data with
-   *          specified ranges within the document.
+   *   specified ranges within the document.
    */
   public codeLens(params: lsp.CodeLensParams): Promise<lsp.CodeLens[]> {
     return this._sendRequest('textDocument/codeLens', params);
@@ -411,7 +412,7 @@ export class LanguageClientConnection extends EventEmitter {
    *
    * @param params The {DocumentLinkParams} identifying the document for which links should be identified.
    * @returns A {Promise} containing an {Array} of {DocumentLink}s relating uri's to specific ranges
-   *          within the document.
+   *   within the document.
    */
   public documentLink(params: lsp.DocumentLinkParams): Promise<lsp.DocumentLink[]> {
     return this._sendRequest('textDocument/documentLink', params);
@@ -431,8 +432,9 @@ export class LanguageClientConnection extends EventEmitter {
    * Public: Send a `textDocument/formatting` request.
    *
    * @param params The {DocumentFormattingParams} identifying the document to be formatted as well as
+   *   additional formatting preferences.
    * @returns A {Promise} containing an {Array} of {TextEdit}s to be applied to the document to
-   *          correctly reformat it.
+   *   correctly reformat it.
    */
   public documentFormatting(params: lsp.DocumentFormattingParams): Promise<lsp.TextEdit[]> {
     return this._sendRequest('textDocument/formatting', params);
@@ -442,8 +444,9 @@ export class LanguageClientConnection extends EventEmitter {
    * Public: Send a `textDocument/rangeFormatting` request.
    *
    * @param params The {DocumentRangeFormattingParams} identifying the document and range to be formatted
+   *   as well as additional formatting preferences.
    * @returns A {Promise} containing an {Array} of {TextEdit}s to be applied to the document to
-   *          correctly reformat it.
+   *   correctly reformat it.
    */
   public documentRangeFormatting(params: lsp.DocumentRangeFormattingParams): Promise<lsp.TextEdit[]> {
     return this._sendRequest('textDocument/rangeFormatting', params);
@@ -453,8 +456,9 @@ export class LanguageClientConnection extends EventEmitter {
    * Public: Send a `textDocument/onTypeFormatting` request.
    *
    * @param params The {DocumentOnTypeFormattingParams} identifying the document to be formatted,
+   *   the character that was typed and at what position as well as additional formatting preferences.
    * @returns A {Promise} containing an {Array} of {TextEdit}s to be applied to the document to
-   *          correctly reformat it.
+   *   correctly reformat it.
    */
   public documentOnTypeFormatting(params: lsp.DocumentOnTypeFormattingParams): Promise<lsp.TextEdit[]> {
     return this._sendRequest('textDocument/onTypeFormatting', params);
@@ -464,9 +468,10 @@ export class LanguageClientConnection extends EventEmitter {
    * Public: Send a `textDocument/rename` request.
    *
    * @param params The {RenameParams} identifying the document containing the symbol to be renamed,
+   *   as well as the position and new name.
    * @returns A {Promise} containing an {WorkspaceEdit} that contains a list of {TextEdit}s either
-   *          on the changes property (keyed by uri) or the documentChanges property containing
-   *          an {Array} of {TextDocumentEdit}s (preferred).
+   *   on the changes property (keyed by uri) or the documentChanges property containing
+   *   an {Array} of {TextDocumentEdit}s (preferred).
    */
   public rename(params: lsp.RenameParams): Promise<lsp.WorkspaceEdit> {
     return this._sendRequest('textDocument/rename', params);
@@ -476,6 +481,8 @@ export class LanguageClientConnection extends EventEmitter {
    * Public: Send a `workspace/executeCommand` request.
    *
    * @param params The {ExecuteCommandParams} specifying the command and arguments
+   *   the language server should execute (these commands are usually from {CodeLens}
+   *   or {CodeAction} responses).
    * @returns A {Promise} containing anything.
    */
   public executeCommand(params: lsp.ExecuteCommandParams): Promise<any> {

--- a/lib/server-manager.ts
+++ b/lib/server-manager.ts
@@ -11,10 +11,12 @@ import {
 } from 'atom';
 import { ReportBusyWhile } from './utils';
 
-// Public: Defines the minimum surface area for an object that resembles a
-// ChildProcess.  This is used so that language packages with alternative
-// language server process hosting strategies can return something compatible
-// with AutoLanguageClient.startServerProcess.
+/**
+ * Public: Defines the minimum surface area for an object that resembles a
+ * ChildProcess.  This is used so that language packages with alternative
+ * language server process hosting strategies can return something compatible
+ * with AutoLanguageClient.startServerProcess.
+ */
 export interface LanguageServerProcess extends EventEmitter {
   stdin: stream.Writable;
   stdout: stream.Readable;
@@ -26,7 +28,7 @@ export interface LanguageServerProcess extends EventEmitter {
   on(event: 'exit', listener: (code: number, signal: string) => void): this;
 }
 
-// The necessary elements for a server that has started or is starting.
+/**  The necessary elements for a server that has started or is starting. */
 export interface ActiveServer {
   disposable: CompositeDisposable;
   projectPath: string;
@@ -40,8 +42,10 @@ interface RestartCounter {
   timerId: NodeJS.Timer;
 }
 
-// Manages the language server lifecycles and their associated objects necessary
-// for adapting them to Atom IDE.
+/**
+ * Manages the language server lifecycles and their associated objects necessary
+ * for adapting them to Atom IDE.
+ */
 export class ServerManager {
   private _activeServers: ActiveServer[] = [];
   private _startingServerPromises: Map<string, Promise<ActiveServer>> = new Map();

--- a/lib/server-manager.ts
+++ b/lib/server-manager.ts
@@ -28,7 +28,7 @@ export interface LanguageServerProcess extends EventEmitter {
   on(event: 'exit', listener: (code: number, signal: string) => void): this;
 }
 
-/**  The necessary elements for a server that has started or is starting. */
+/** The necessary elements for a server that has started or is starting. */
 export interface ActiveServer {
   disposable: CompositeDisposable;
   projectPath: string;

--- a/typings/atom-ide/index.d.ts
+++ b/typings/atom-ide/index.d.ts
@@ -362,9 +362,10 @@ declare module 'atom-ide' {
   /** Adds LSP specific properties to the Atom SuggestionBase type */
   interface SuggestionBase extends ac.SuggestionBase {
     /**
-     * A string that should be used when filtering and sorting a set of
-     * completion items when a prefix is present. When `falsy` the
-     * [displayText](#ac.SuggestionBase.displayText) is used.
+     * A string that is used when filtering and sorting a set of
+     * completion items with a prefix present. When `falsy` the
+     * [displayText](#ac.SuggestionBase.displayText) is used. When
+     * no prefix, the `sortText` property is used.
      */
     filterText?: string;
   }

--- a/typings/atom-ide/index.d.ts
+++ b/typings/atom-ide/index.d.ts
@@ -72,7 +72,9 @@ declare module 'atom-ide' {
   }
 
   export interface FindReferencesProvider {
-    // Return true if your provider supports finding references for the provided TextEditor.
+    /**
+     * Return true if your provider supports finding references for the provided TextEditor.
+     */
     isEditorSupported(editor: TextEditor): boolean | Promise<boolean>;
 
     // `findReferences` will only be called if `isEditorSupported` previously returned true
@@ -81,8 +83,14 @@ declare module 'atom-ide' {
   }
 
   export interface Reference {
-    uri: IdeUri; // URI of the file path
-    name: string | null; // name of calling method/function/symbol
+    /**
+     * URI of the file path
+     */
+    uri: IdeUri;
+    /**
+     * Name of calling method/function/symbol
+     */
+    name: string | null;
     range: Range;
   }
 
@@ -122,13 +130,17 @@ declare module 'atom-ide' {
     datatip(
       editor: TextEditor,
       bufferPosition: Point,
-      // The mouse event that triggered the datatip.
-      // This is null for manually toggled datatips.
+      /**
+       * The mouse event that triggered the datatip.
+       * This is null for manually toggled datatips.
+       */
       mouseEvent: MouseEvent | null,
     ): Promise<Datatip>;
     validForScope(scopeName: string): boolean;
-    // A unique name for the provider to be used for analytics.
-    // It is recommended that it be the name of the provider's package.
+    /**
+     * A unique name for the provider to be used for analytics.
+     * It is recommended that it be the name of the provider's package.
+     */
     providerName: string;
     priority: number;
     grammarScopes: string[];
@@ -165,7 +177,9 @@ declare module 'atom-ide' {
   export interface TextEdit {
     oldRange: Range;
     newText: string;
-    // If included, this will be used to verify that the edit still applies cleanly.
+    /**
+     *  If included, this will be used to verify that the edit still applies cleanly.
+     */
     oldText?: string;
   }
 
@@ -202,43 +216,62 @@ declare module 'atom-ide' {
   }
 
   export interface BusySignalOptions {
-    // Can say that a busy signal will only appear when a given file is open.
-    // Default = null, meaning the busy signal applies to all files.
+    /**
+     * Can say that a busy signal will only appear when a given file is open.
+     * Default = null, meaning the busy signal applies to all files.
+     */
     onlyForFile?: IdeUri;
-    // Is user waiting for computer to finish a task? (traditional busy spinner)
-    // or is the computer waiting for user to finish a task? (action required)
-    // Default = spinner.
+    /**
+     * Is user waiting for computer to finish a task? (traditional busy spinner)
+     * or is the computer waiting for user to finish a task? (action required)
+     * @defaultValue `'computer'`
+     */
     waitingFor?: 'computer' | 'user';
-    // Debounce it? default = true for busy-signal, and false for action-required.
+    /**
+     * Debounce it? default = true for busy-signal, and false for action-required.
+     */
     debounce?: boolean;
-    // If onClick is set, then the tooltip will be clickable. Default = null.
+    /**
+     * If onClick is set, then the tooltip will be clickable.
+     * @defaultValue `null`
+     */
     onDidClick?: () => void;
   }
 
   export interface BusySignalService {
-    // Activates the busy signal with the given title and returns the promise
-    // from the provided callback.
-    // The busy signal automatically deactivates when the returned promise
-    // either resolves or rejects.
+    /**
+     * Activates the busy signal with the given title and returns the promise
+     * from the provided callback.
+     * The busy signal automatically deactivates when the returned promise
+     * either resolves or rejects.
+     */
     reportBusyWhile<T>(
       title: string,
       f: () => Promise<T>,
       options?: BusySignalOptions,
     ): Promise<T>;
 
-    // Activates the busy signal. Set the title in the returned BusySignal
-    // object (you can update the title multiple times) and dispose it when done.
+    /**
+     * Activates the busy signal. Set the title in the returned BusySignal
+     * object (you can update the title multiple times) and dispose it when done.
+     */
     reportBusy(title: string, options?: BusySignalOptions): BusyMessage;
 
-    // This is a no-op. When someone consumes the busy service, they get back a
-    // reference to the single shared instance, so disposing of it would be wrong.
+    /**
+     * This is a no-op. When someone consumes the busy service, they get back a
+     * reference to the single shared instance, so disposing of it would be wrong.
+     */
     dispose(): void;
   }
 
   export interface BusyMessage {
-    // You can set/update the title.
+    /**
+     * You can set/update the title.
+     */
     setTitle(title: string): void;
-    // Dispose of the signal when done to make it go away.
+    /**
+     * Dispose of the signal when done to make it go away.
+     */
     dispose(): void;
   }
 
@@ -261,8 +294,10 @@ declare module 'atom-ide' {
     priority: number;
     grammarScopes: string[];
 
-    // A set of characters that will trigger signature help when typed.
-    // If a null/empty set is provided, only manual activation of the command works.
+    /**
+     * A set of characters that will trigger signature help when typed.
+     * If a null/empty set is provided, only manual activation of the command works.
+     */
     triggerCharacters?: Set<string>;
 
     getSignatureHelp(editor: TextEditor, point: Point): Promise<SignatureHelp | null>;

--- a/typings/atom-ide/index.d.ts
+++ b/typings/atom-ide/index.d.ts
@@ -4,8 +4,10 @@ declare module 'atom-ide' {
 
   export interface OutlineProvider {
     name: string;
-    // If there are multiple providers for a given grammar, the one with the highest priority will be
-    // used.
+    /**
+     * If there are multiple providers for a given grammar, the one with the highest priority will be
+     * used.
+     */
     priority: number;
     grammarScopes: string[];
     updateOnEdit?: boolean;
@@ -13,10 +15,12 @@ declare module 'atom-ide' {
   }
 
   export interface OutlineTree {
-    icon?: string; // from atom$Octicon | atom$OcticonsPrivate (types not allowed over rpc so we use string)
+    /** from atom$Octicon | atom$OcticonsPrivate (types not allowed over rpc so we use string) */
+    icon?: string;
 
-    // Must be one or the other. If both are present, tokenizedText is preferred.
+    /** Must have `plainText` or the `tokenizedText` property. If both are present, `tokenizedText` is preferred. */
     plainText?: string;
+    /** Must have `plainText` or the `tokenizedText` property. If both are present, `tokenizedText` is preferred. */
     tokenizedText?: TokenizedText;
     representativeName?: string;
 
@@ -72,24 +76,20 @@ declare module 'atom-ide' {
   }
 
   export interface FindReferencesProvider {
-    /**
-     * Return true if your provider supports finding references for the provided TextEditor.
-     */
+    /** Return true if your provider supports finding references for the provided TextEditor. */
     isEditorSupported(editor: TextEditor): boolean | Promise<boolean>;
 
-    // `findReferences` will only be called if `isEditorSupported` previously returned true
-    // for the given TextEditor.
+    /**
+     * `findReferences` will only be called if `isEditorSupported` previously returned true
+     * for the given TextEditor.
+     */
     findReferences(editor: TextEditor, position: Point): Promise<FindReferencesReturn | null>;
   }
 
   export interface Reference {
-    /**
-     * URI of the file path
-     */
+    /** URI of the file path */
     uri: IdeUri;
-    /**
-     * Name of calling method/function/symbol
-     */
+    /** Name of calling method / function / symbol */
     name: string | null;
     range: Range;
   }
@@ -177,9 +177,7 @@ declare module 'atom-ide' {
   export interface TextEdit {
     oldRange: Range;
     newText: string;
-    /**
-     *  If included, this will be used to verify that the edit still applies cleanly.
-     */
+    /** If included, this will be used to verify that the edit still applies cleanly. */
     oldText?: string;
   }
 
@@ -227,9 +225,7 @@ declare module 'atom-ide' {
      * @defaultValue `'computer'`
      */
     waitingFor?: 'computer' | 'user';
-    /**
-     * Debounce it? default = true for busy-signal, and false for action-required.
-     */
+    /** Debounce it? default = true for busy-signal, and false for action-required. */
     debounce?: boolean;
     /**
      * If onClick is set, then the tooltip will be clickable.
@@ -265,13 +261,9 @@ declare module 'atom-ide' {
   }
 
   export interface BusyMessage {
-    /**
-     * You can set/update the title.
-     */
+    /** You can set/update the title. */
     setTitle(title: string): void;
-    /**
-     * Dispose of the signal when done to make it go away.
-     */
+    /** Dispose of the signal when done to make it go away. */
     dispose(): void;
   }
 
@@ -367,14 +359,12 @@ declare module 'atom-ide' {
 
   // Autocomplete service
 
-  /**
-   * Adds LSP specific properties to the Atom SuggestionBase type
-   */
+  /** Adds LSP specific properties to the Atom SuggestionBase type */
   interface SuggestionBase extends ac.SuggestionBase {
     /**
-     * A string that should be used when filtering a set of
-     * completion items. When `falsy` the [displayText](#ac.SuggestionBase.displayText)
-     * is used.
+     * A string that should be used when filtering and sorting a set of
+     * completion items when a prefix is present. When `falsy` the
+     * [displayText](#ac.SuggestionBase.displayText) is used.
      */
     filterText?: string;
   }

--- a/typings/atom/index.d.ts
+++ b/typings/atom/index.d.ts
@@ -4,7 +4,9 @@ declare module 'atom' {
     getNonWordCharacters(position: Point): string;
   }
 
-  // Non-public Notification api
+  /**
+   * Non-public Notification api
+   */
   interface NotificationExt extends Notification {
     isDismissed?: () => boolean;
     getOptions?: () => NotificationOptions | null;

--- a/typings/atom/index.d.ts
+++ b/typings/atom/index.d.ts
@@ -4,9 +4,7 @@ declare module 'atom' {
     getNonWordCharacters(position: Point): string;
   }
 
-  /**
-   * Non-public Notification api
-   */
+  /** Non-public Notification api */
   interface NotificationExt extends Notification {
     isDismissed?: () => boolean;
     getOptions?: () => NotificationOptions | null;


### PR DESCRIPTION
The current comments are very informative, but were not being picked up by `ide-typescript`. This converts them to a more standardised format, which is recognised. 

Note it is not exactly a TSDoc match (which is quite difficult, considering TSDoc does not actually provide a spec yet...). However, it is clearly picked up and parsed by `ide-typescript`, so will suffice.

The only concern would be the `{reference}` syntax, which Atom likes to pick up as something (but not what it's meant to be) but `ide-typescript` ignores. It currently makes a lot of these comments very red.

I plan to merge anyway, short of any suggestions from @damieng or others about why the original syntax was used, because useful doc comments are more valuable than locally broken syntax highlighting IMO.