### PR TITLE
HACK: Support eclipe.jdt.ls's break with the LSP spec

### DIFF
--- a/lib/adapters/code-action-adapter.ts
+++ b/lib/adapters/code-action-adapter.ts
@@ -89,10 +89,20 @@ export default class CodeActionAdapter {
     connection: LanguageClientConnection,
   ): Promise<void> {
     if (Command.is(command)) {
-      await connection.executeCommand({
-        command: command.command,
-        arguments: command.arguments,
-      });
+      // eclipse.jdt.ls breaks with the spec and expects the client to handle the command
+      // https://github.com/eclipse/eclipse.jdt.ls/issues/376
+      if (command.command === 'java.apply.workspaceEdit') {
+        if (command.arguments) {
+          // Guaranteed only ever one element in the arguments array
+          const edit: WorkspaceEdit = command.arguments[0];
+          CodeActionAdapter.applyWorkspaceEdit(edit);
+        }
+      } else {
+        await connection.executeCommand({
+          command: command.command,
+          arguments: command.arguments,
+        });
+      }
     }
   }
 


### PR DESCRIPTION
This is a rather hacky hack to support eclipse.jdt.ls's custom `java.apply.workspaceEdit` command that they expect the _client_ to handle.

Originally I tried to implement a way for clients to specify which commands they wanted to handle as suggested in #183, but I ran into issues with being unable to actually follow through with the command. I can get the client to receive the command fine, but since all the logic is still in atom-languageclient, I can't hook into `applyWorkspaceEdit` or anything of the sort 😓. Maybe I'm missing something that would make this approach feasible?