### PR TITLE
Add shutdownServersGracefully() config function

### DIFF
--- a/lib/auto-languageclient.ts
+++ b/lib/auto-languageclient.ts
@@ -261,6 +261,7 @@ export default class AutoLanguageClient {
       (filepath) => this.filterChangeWatchedFiles(filepath),
       this.reportBusyWhile,
       this.getServerName(),
+      this.shutdownServersGracefully(),
     );
     this._serverManager.startListening();
     process.on('exit', () => this.exitCleanup.bind(this));
@@ -780,6 +781,11 @@ export default class AutoLanguageClient {
    * @returns `false` => message will not be sent to the language server
    */
   protected filterChangeWatchedFiles(_filePath: string): boolean {
+    return true;
+  }
+
+  /** @return false => servers will be killed without awaiting shutdown response. */
+  protected shutdownServersGracefully(): boolean {
     return true;
   }
 

--- a/lib/server-manager.ts
+++ b/lib/server-manager.ts
@@ -63,6 +63,7 @@ export class ServerManager {
     private _changeWatchedFileFilter: (filePath: string) => boolean,
     private _reportBusyWhile: ReportBusyWhile,
     private _languageServerName: string,
+    private _stopServersGracefully: boolean,
   ) {
     this.updateNormalizedProjectPaths();
   }
@@ -222,7 +223,7 @@ export class ServerManager {
         this._activeServers.splice(this._activeServers.indexOf(server), 1);
         this._stoppingServers.push(server);
         server.disposable.dispose();
-        if (server.connection.isConnected) {
+        if (this._stopServersGracefully && server.connection.isConnected) {
           await server.connection.shutdown();
         }
 


### PR DESCRIPTION
This change allows language clients to override the default server stopping behaviour allowing faster kills, ie killing the server process without waiting for the shutdown response.

Client's can override the `shutdownServersGracefully()` method.
```js
class Foo extends AutoLanguageClient {
  ...
  // Kill servers faster
  shutdownServersGracefully() { return false }
}
```

The default behaviour is unchanged. I'll use this in ide-rust as rls can be stuck building for long periods of time before it will shutdown, yet builds are safe to kill in this way.


This feature is also available in my fork:
```json
"dependencies": {
  "atom-languageclient": "github:alexheretic/atom-languageclient#build",
}
```