### PR TITLE
Add support for rename refactors

### DIFF
--- a/lib/adapters/rename-adapter.ts
+++ b/lib/adapters/rename-adapter.ts
@@ -1,0 +1,75 @@
+import * as atomIde from 'atom-ide';
+import Convert from '../convert';
+import {
+  Point,
+  TextEditor,
+} from 'atom';
+import {
+  LanguageClientConnection,
+  RenameParams,
+  ServerCapabilities,
+  TextDocumentEdit,
+  TextEdit,
+} from '../languageclient';
+
+export default class RenameAdapter {
+  public static canAdapt(serverCapabilities: ServerCapabilities): boolean {
+    return serverCapabilities.renameProvider === true;
+  }
+
+  public static async getRename(
+    connection: LanguageClientConnection,
+    editor: TextEditor,
+    point: Point,
+    newName: string,
+  ): Promise<Map<atomIde.IdeUri, atomIde.TextEdit[]> | null> {
+    const edit = await connection.rename(
+      RenameAdapter.createRenameParams(editor, point, newName),
+    );
+    if (edit === null) {
+      return null;
+    }
+
+    if (edit.documentChanges) {
+      return RenameAdapter.convertDocumentChanges(edit.documentChanges);
+    } else if (edit.changes) {
+      return RenameAdapter.convertChanges(edit.changes);
+    } else {
+      return null;
+    }
+  }
+
+  public static createRenameParams(editor: TextEditor, point: Point, newName: string): RenameParams {
+    return {
+      textDocument: Convert.editorToTextDocumentIdentifier(editor),
+      position: Convert.pointToPosition(point),
+      newName,
+    };
+  }
+
+  public static convertChanges(
+    changes: { [uri: string]: TextEdit[] },
+  ): Map<atomIde.IdeUri, atomIde.TextEdit[]> {
+    const result = new Map();
+    Object.keys(changes).forEach((uri) => {
+      result.set(
+        Convert.uriToPath(uri),
+        Convert.convertLsTextEdits(changes[uri]),
+      );
+    });
+    return result;
+  }
+
+  public static convertDocumentChanges(
+    documentChanges: TextDocumentEdit[],
+  ): Map<atomIde.IdeUri, atomIde.TextEdit[]> {
+    const result = new Map();
+    documentChanges.forEach((documentEdit) => {
+      result.set(
+        Convert.uriToPath(documentEdit.textDocument.uri),
+        Convert.convertLsTextEdits(documentEdit.edits),
+      );
+    });
+    return result;
+  }
+}

--- a/lib/auto-languageclient.ts
+++ b/lib/auto-languageclient.ts
@@ -18,6 +18,7 @@ import LinterPushV2Adapter from './adapters/linter-push-v2-adapter';
 import LoggingConsoleAdapter from './adapters/logging-console-adapter';
 import NotificationsAdapter from './adapters/notifications-adapter';
 import OutlineViewAdapter from './adapters/outline-view-adapter';
+import RenameAdapter from './adapters/rename-adapter';
 import SignatureHelpAdapter from './adapters/signature-help-adapter';
 import * as Utils from './utils';
 import { Socket } from 'net';
@@ -753,6 +754,28 @@ export default class AutoLanguageClient {
       editor,
       range,
       diagnostics,
+    );
+  }
+
+  public provideRefactor(): atomIde.RefactorProvider {
+    return {
+      grammarScopes: this.getGrammarScopes(),
+      priority: 1,
+      rename: this.getRename.bind(this),
+    };
+  }
+
+  protected async getRename(editor: TextEditor, position: Point, newName: string) {
+    const server = await this._serverManager.getServer(editor);
+    if (server == null || !RenameAdapter.canAdapt(server.capabilities)) {
+      return null;
+    }
+
+    return RenameAdapter.getRename(
+      server.connection,
+      editor,
+      position,
+      newName,
     );
   }
 

--- a/typings/atom-ide/index.d.ts
+++ b/typings/atom-ide/index.d.ts
@@ -213,6 +213,12 @@ declare module 'atom-ide' {
     ): Promise<CodeAction[] | null>;
   }
 
+  export interface RefactorProvider {
+    grammarScopes: string[];
+    priority: number;
+    rename?(editor: TextEditor, position: Point, newName: string): Promise<Map<IdeUri, TextEdit[]> | null>;
+  }
+
   export interface BusySignalOptions {
     /**
      * Can say that a busy signal will only appear when a given file is open.


### PR DESCRIPTION
This pull request implements rename refactoring support via `textDocument/rename`, resolving #13. It is compatible with the protocol expected by the most recent release of `atom-ide-ui`, which is `0.13.0`. Here’s a demonstration using the `ide-haskell-hie` backend:

![](https://user-images.githubusercontent.com/759911/60529105-81ae1e00-9cbb-11e9-9901-4fc03cf7f32e.gif)

(It’s not the fastest backend in the world, but it gets the job done eventually.)

Awkwardly, this implementation *doesn’t* work with the latest version of `atom-ide-ui` in [the archived source code](https://github.com/facebookarchive/atom-ide-ui), since it was changed just after the final release to use a slightly different protocol. I don’t think that’s a big deal, though, since it’s always possible to bump the service version if those changes ever make it into something released.