### PR TITLE
Update CI node version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: node_js
-node_js: '8.9.3'
+node_js: '10.2.0'
 sudo: false
 os: osx
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,5 @@
 environment:
-  nodejs_version: "8"
+  nodejs_version: "10"
 
 platform:
   - x64


### PR DESCRIPTION
Now that stable Atom has reached Electron 3, updates the NodeJS version to 10 (specifically 10.2.0 on Travis to match Atom 1.39.1 version).