### PR TITLE
Fix completion deleting the triggerChar

### DIFF
--- a/lib/adapters/autocomplete-adapter.ts
+++ b/lib/adapters/autocomplete-adapter.ts
@@ -142,8 +142,8 @@ export default class AutocompleteAdapter {
     const cache = this._suggestionCache.get(server);
 
     const triggerColumn = (triggerChar !== '' && triggerOnly)
-      ? request.bufferPosition.column - triggerChar.length
-      : request.bufferPosition.column - request.prefix.length - triggerChar.length;
+      ? request.bufferPosition.column
+      : request.bufferPosition.column - request.prefix.length;
     const triggerPoint = new Point(request.bufferPosition.row, triggerColumn);
 
     // Do we have complete cached suggestions that are still valid for this request?


### PR DESCRIPTION
Fixes incorrect completion, e.g. `.with` -> `with_foo()` _(dot deletion)_.

Looking at the server messages they seem correct, so this does indeed seem like a client bug. Why was the `triggerChar.length` being removed? Was this a workaround for some language-server?

This fix is also available in my fork:
```json
"dependencies": {
  "atom-languageclient": "github:alexheretic/atom-languageclient#build",
}
```