### PR TITLE
Implement completion additionalTextEdits

### DIFF
--- a/lib/adapters/autocomplete-adapter.ts
+++ b/lib/adapters/autocomplete-adapter.ts
@@ -379,6 +379,8 @@ export default class AutocompleteAdapter {
       onDidConvertCompletionItem(item, suggestion as ac.AnySuggestion, request);
     }
 
+    suggestion.completionItem = item;
+
     return suggestion;
   }
 

--- a/lib/convert.ts
+++ b/lib/convert.ts
@@ -225,7 +225,7 @@ export default class Convert {
    * @param textEdits The language server protocol {TextEdit} objects to convert.
    * @returns An {Array} of Atom {TextEdit} objects.
    */
-  public static convertLsTextEdits(textEdits: ls.TextEdit[] | null): TextEdit[] {
+  public static convertLsTextEdits(textEdits?: ls.TextEdit[] | null): TextEdit[] {
     return (textEdits || []).map(Convert.convertLsTextEdit);
   }
 

--- a/typings/atom-ide/index.d.ts
+++ b/typings/atom-ide/index.d.ts
@@ -1,6 +1,7 @@
 declare module 'atom-ide' {
   import { Disposable, Grammar, Point, Range, TextEditor } from 'atom';
   import * as ac from 'atom/autocomplete-plus';
+  import { CompletionItem } from 'lib/languageclient';
 
   export interface OutlineProvider {
     name: string;
@@ -381,6 +382,9 @@ declare module 'atom-ide' {
      * was gathered from.
      */
     customReplacmentPrefix?: string;
+
+    /** Original completion item, if available */
+    completionItem?: CompletionItem;
   }
 
   export type TextSuggestion = SuggestionBase & ac.TextSuggestion;


### PR DESCRIPTION
This pr adds support for a completion item `additionalTextEdits`, see [spec](https://microsoft.github.io/language-server-protocol/specification#textDocument_completion).

This feature is also available in my fork:
```json
"dependencies": {
  "atom-languageclient": "github:alexheretic/atom-languageclient#build",
}